### PR TITLE
[ONBOARDING]docs: improve README install section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     name: DCO sign-off
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The DCO is checked by CI on every pull request. We do not require a CLA.
 ## Development setup
 
 ```bash
-git clone https://github.com/femtechie/lovell-odyssey.git
+git clone https://github.com/lovellai-dev/odyssey.git
 cd lovell-odyssey
 python -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ one agent — will become possible when the agent cap lifts.
 ## Install
 
 ```bash
-git clone https://github.com/femtechie/lovell-odyssey.git
-cd lovell-odyssey
+git clone https://github.com/lovellai-dev/odyssey.git
+cd odyssey
 pip install -e .
 ```
 

--- a/README.md
+++ b/README.md
@@ -162,17 +162,10 @@ run `validate`, `list`, `status`, and `run --use-mock-runner` against any
 mission spec without a GPU. `.[all]` adds everything needed for real training
 and evaluation runs.
 
-You can also install extras individually if you only need part of the stack:
-
-```bash
-pip install -e ".[huggingface]"   # HF model + dataset providers
-pip install -e ".[openvla]"       # OpenVLA training runner deps
-pip install -e ".[robosuite]"     # Robosuite evaluation runner deps
-```
-
 ## 60-second smoke test (no GPU, no network)
 
 ```bash
+# Validate the mission spec
 $ odyssey validate examples/quickstart-openvla/mission.yaml
 OK  examples/quickstart-openvla/mission.yaml
   spec version : 0.1
@@ -180,6 +173,7 @@ OK  examples/quickstart-openvla/mission.yaml
   robot        : embodiment=franka_panda
   tasks        : 1 training, 1 evaluation
 
+# Run the full mission with a CPU mock (no GPU needed)
 $ odyssey run examples/quickstart-openvla/mission.yaml --use-mock-runner
 {"ts": "...", "event": "mission.created", ...}
 {"ts": "...", "event": "mission.queued", ...}
@@ -190,9 +184,11 @@ $ odyssey run examples/quickstart-openvla/mission.yaml --use-mock-runner
 COMPLETED  c1756bad855e45cc9a95b5b0566c948b
   overall_grade : 1.000
 
+# List all missions from the local DB
 $ odyssey list
 c1756bad855e  COMPLETED   openvla-bridge-lift   2026-05-17T23:18:34+00:00  grade=1.000
 
+# Show details for a specific mission (prefix match)
 $ odyssey status c1756bad
 COMPLETED  c1756bad855e45cc9a95b5b0566c948b
   name         : openvla-bridge-lift

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
 ## What it is
 
-You describe a mission in YAML — a robot, a model, a dataset to train on, an
+You describe a mission in YAML — a robot, an agent, a dataset to train on, an
 evaluation benchmark to score against — and `odyssey run` walks it through the
 full lifecycle: load → validate → execute training tasks → execute the
 evaluation task → persist results. Local-mode by default; the hosted Lovell

--- a/README.md
+++ b/README.md
@@ -149,6 +149,12 @@ one agent — will become possible when the agent cap lifts.
 
 ## Install
 
+**Linux only** — install build dependencies before proceeding (needed by `.[all]`):
+
+```bash
+sudo apt update && sudo apt install build-essential python3-dev -y
+```
+
 ```bash
 git clone https://github.com/lovellai-dev/odyssey.git
 cd odyssey

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
 ## What it is
 
-You describe a mission in YAML — a robot, an agent, a dataset to train on, an
+You describe a mission in YAML — a robot, a model, a dataset to train on, an
 evaluation benchmark to score against — and `odyssey run` walks it through the
 full lifecycle: load → validate → execute training tasks → execute the
 evaluation task → persist results. Local-mode by default; the hosted Lovell

--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ one agent — will become possible when the agent cap lifts.
 ```bash
 git clone https://github.com/lovellai-dev/odyssey.git
 cd odyssey
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -e .              # CLI, validate, mock runs (lightweight)
 pip install -e ".[all]"       # real training + evaluation (torch, robosuite…)
 pip install -e ".[all,dev]"   # + pytest, ruff, mypy

--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 <h1 align="center">Lovell Odyssey</h1>
 
-[![CI](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
-[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
-[![Status: Pre-Alpha](https://img.shields.io/badge/status-pre--alpha-orange.svg)]()
+<p align="center">
+  <a href="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml"><img src="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License: Apache 2.0"></a>
+  <img src="https://img.shields.io/badge/status-pre--alpha-orange.svg" alt="Status: Pre-Alpha">
+</p>
 
 Open-source framework for defining, running, and benchmarking robot training missions.
-
-> [!WARNING]
-> **Pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is
-> targeted at `v0.1.0-alpha`. API, CLI, schemas, and wire protocols are
-> subject to change without notice.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@
 
 Open-source framework for defining, running, and benchmarking robot training missions.
 
-> **Status: pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is
-> targeted at `v0.1.0-alpha`. The API, CLI, schemas, and wire protocols are
-> still subject to change without notice.
+> [!WARNING]
+> **Pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is
+> targeted at `v0.1.0-alpha`. API, CLI, schemas, and wire protocols are
+> subject to change without notice.
 
 ## Install
 
-**Linux only** — install build dependencies before proceeding (needed by `.[all]`):
-
-```bash
-sudo apt update && sudo apt install build-essential python3-dev -y
-```
+> [!IMPORTANT]
+> **Linux only** — install build dependencies before proceeding (needed by `.[all]`):
+> ```bash
+> sudo apt update && sudo apt install build-essential python3-dev -y
+> ```
 
 ```bash
 git clone https://github.com/lovellai-dev/odyssey.git
@@ -129,11 +130,12 @@ odyssey run examples/quickstart-openvla/mission.yaml
 
 Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
 
-**Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
-the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
-adapter. Real eval numbers require supplying a `policy_factory` to
-`RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
-The built-in adapter is a v0.2.x line item.
+> [!NOTE]
+> **Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
+> the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
+> adapter. Real eval numbers require supplying a `policy_factory` to
+> `RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
+> The built-in adapter is a v0.2.x line item.
 
 ## Status snapshot (v0.0.x)
 

--- a/README.md
+++ b/README.md
@@ -112,20 +112,40 @@ src/odyssey/
   utils/        ~/.odyssey/ path management
 ```
 
-## Real run (OpenVLA + Robosuite)
+## Launching a training mission
 
-This works only after the extras are installed AND the upstream
-[openvla](https://github.com/openvla/openvla) repo is cloned somewhere
-findable (`$OPENVLA_REPO_PATH` or `/srv/openvla`):
+### Prerequisites
+
+1. Install the training extras:
+   ```bash
+   pip install -e ".[huggingface,openvla,robosuite]"
+   ```
+2. Clone the upstream OpenVLA repo and install its dependencies (needed for
+   `draccus` and the fine-tuning script):
+   ```bash
+   git clone https://github.com/openvla/openvla.git /srv/openvla
+   pip install -e /srv/openvla
+   export OPENVLA_REPO_PATH=/srv/openvla
+   ```
+3. Download the Bridge V2 dataset in RLDS format (~124 GB):
+   ```bash
+   wget -r -nH --cut-dirs=4 --reject="index.html*" \
+     https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
+   mv bridge_dataset bridge_orig
+   ```
+   Set `--data_root_dir` to the parent directory containing `bridge_orig/`.
+
+### Run
 
 ```bash
-pip install -e ".[huggingface,openvla,robosuite]"
-git clone https://github.com/openvla/openvla.git /srv/openvla
-
 odyssey run examples/quickstart-openvla/mission.yaml
 ```
 
-Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
+Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA LoRA fine-tune.
+
+> [!NOTE]
+> **GCP users:** single-GPU VMs require `export NCCL_NET=Socket` before
+> running, to bypass Google's NCCL plugin. See [issue #5](https://github.com/lovellai-dev/odyssey/issues/5) for details.
 
 > [!NOTE]
 > **Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with

--- a/README.md
+++ b/README.md
@@ -152,18 +152,22 @@ one agent — will become possible when the agent cap lifts.
 ```bash
 git clone https://github.com/lovellai-dev/odyssey.git
 cd odyssey
-pip install -e .
+pip install -e .              # CLI, validate, mock runs (lightweight)
+pip install -e ".[all]"       # real training + evaluation (torch, robosuite…)
+pip install -e ".[all,dev]"   # + pytest, ruff, mypy
 ```
 
 The base install pulls in pydantic, click, pyyaml, and aiosqlite — enough to
 run `validate`, `list`, `status`, and `run --use-mock-runner` against any
-mission spec. Real training and evaluation runners need their own extras:
+mission spec without a GPU. `.[all]` adds everything needed for real training
+and evaluation runs.
+
+You can also install extras individually if you only need part of the stack:
 
 ```bash
 pip install -e ".[huggingface]"   # HF model + dataset providers
 pip install -e ".[openvla]"       # OpenVLA training runner deps
 pip install -e ".[robosuite]"     # Robosuite evaluation runner deps
-pip install -e ".[dev]"           # pytest, ruff, mypy
 ```
 
 ## 60-second smoke test (no GPU, no network)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Lovell Odyssey</h1>
+<h1 align="center">Odyssey</h1>
 
 <p align="center">
   <a href="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml"><img src="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
@@ -7,7 +7,7 @@
   <img src="https://img.shields.io/badge/status-pre--alpha-orange.svg" alt="Status: Pre-Alpha">
 </p>
 
-Open-source framework for defining, running, and benchmarking robot training missions.
+<p align="center">Open-source framework for defining, running, and benchmarking robot training missions.</p>
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
 ## What it is
 
-You describe a mission in YAML — a robot, a model, a dataset to train on, an
+You train an agent by describing a mission in YAML — a robot, a model, a dataset to train on, an
 evaluation benchmark to score against — and `odyssey run` walks it through the
 full lifecycle: load → validate → execute training tasks → execute the
 evaluation task → persist results. Local-mode by default; the hosted Lovell

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Lovell Odyssey
+<h1 align="center">Lovell Odyssey</h1>
 
 [![CI](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
@@ -9,148 +9,7 @@ Open-source framework for defining, running, and benchmarking robot training mis
 
 > **Status: pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is
 > targeted at `v0.1.0-alpha`. The API, CLI, schemas, and wire protocols are
-> still subject to change without notice. See `docs/` for the design refs.
-
-## What it is
-
-You describe a mission in YAML — a robot, a model, a dataset to train on, an
-evaluation benchmark to score against — and `odyssey run` walks it through the
-full lifecycle: load → validate → execute training tasks → execute the
-evaluation task → persist results. Local-mode by default; the hosted Lovell
-services (leaderboard, learning graph, hosted runners) are optional layers
-that land in later releases.
-
-## Concepts
-
-### Missions
-
-A **mission** is the unit of work in Odyssey: a single, reproducible recipe
-that fine-tunes a model on a dataset and benchmarks the result. You describe
-one in a `mission.yaml`; the framework loads it, drives it through a
-lifecycle (`DRAFT → QUEUED → ACTIVE → COMPLETED | FAILED | CANCELLED`),
-persists every status transition to `~/.odyssey/missions.db`, and emits one
-JSON event per state change to stdout.
-
-Every mission has four required pieces:
-
-1. **An objective** — prose stating what you're trying to achieve.
-2. **Acceptance criteria** — prose stating how success is judged.
-3. **A robot** — the embodiment plus a loadout of agents (see below).
-4. **A list of tasks** — *at least one training task, exactly one
-   evaluation task, and the evaluation task must be the last entry.*
-   Each training task updates one agent on the robot; the evaluation
-   task runs the robot after every training task has completed.
-
-Training tasks chain implicitly through the agent: when multiple
-training tasks target the same `agent_id`, each one starts from the
-previous one's checkpoint. No explicit `from_task` reference is needed,
-because the model lives on the agent and tasks update it. When every
-task reaches `COMPLETED`, the mission's `overall_grade` is set to the
-average of the evaluation scores.
-
-Shape of a minimal mission:
-
-```yaml
-odysseyVersion: "0.1"
-kind: Mission
-metadata:
-  name: my-mission
-objective: |
-  Fine-tune OpenVLA so it can pick up a cube in Robosuite Lift.
-acceptance_criteria: |
-  At least one successful lift across 10 evaluation episodes.
-robot:
-  embodiment: franka_panda
-  agents:
-    - id: pilot
-      role: PILOT
-      model: { source: huggingface, base: openvla/openvla-7b }
-tasks:
-  - name: finetune
-    kind: training
-    training_type: demonstration
-    agent_id: pilot              # updates the pilot agent's model
-    config: { method: peft_lora, lora_rank: 8, epochs: 1 }
-  - name: bench
-    kind: evaluation
-    evaluation_type: robosuite
-    benchmark_name: Lift
-    num_episodes: 10
-    # no model / agent_id — the eval runs the robot
-```
-
-`objective` and `acceptance_criteria` are required prose fields. They aren't
-parsed by anything today, but in later releases the Mission Materializer
-will extract structured artifacts from them (evaluation predicates,
-deadlines, instruction prefixes injected into VLA prompts). Write them like
-you mean it — future-you will reread them in leaderboard submissions and
-graph queries.
-
-### Robots and agents
-
-In the Lovell AI architecture, a **robot** is more than an embodiment —
-it's a composition of an embodiment with a **loadout of agents**. Every
-robot has exactly one **PILOT** (running a Vision-Language-Action model
-with physical authority over the actuators) and zero or more
-**SPECIALISTs** (running language models for delegated reasoning — map
-queries, calculations, lookups). Each agent is authored with a persona,
-goals, and success criteria, and runs against a pinned model checkpoint;
-its behavior is conditioned at runtime by materialized artifacts
-produced from that prose. The fuller picture is described in the Lovell
-AI robot-brain paper.
-
-Odyssey's spec models this hierarchy directly. A `robot:` block
-declares an embodiment and an inline loadout of agents:
-
-```yaml
-robot:
-  embodiment: franka_panda
-  agents:
-    - id: pilot
-      role: PILOT
-      model: { source: huggingface, base: openvla/openvla-7b }
-```
-
-Each agent owns its model — the `model:` field lives on the agent, not
-on a task. Training tasks reference an agent by id (`agent_id: pilot`),
-and the framework looks up the model from the agent. When several
-training tasks target the same agent, each one starts from the previous
-one's checkpoint. The evaluation task takes no model reference at all:
-it runs the robot — that is, it composes the current checkpoints of
-every agent in the loadout.
-
-**Today, Odyssey fine-tunes the underlying model for one of the
-robot's agents at a time.** v0.0.x enforces exactly one agent on the
-robot (the implicit PILOT), and the eval composes a single policy from
-that single agent. Multi-agent loadouts (PILOT + one or more
-SPECIALISTs) and the multi-agent execution that goes with them ship
-when the multi-agent runtime lands. What v0.0.x does *not* model from
-the brain paper — agent persona / goals / success criteria,
-materialized artifacts that condition runtime behavior, the
-deterministic safety stack, conduct-rule enforcement, the deployment
-contract — is on the roadmap. Where each of those ultimately lives
-(in `src/odyssey/` versus in a hosted Lovell service) is a strategic
-decision still being worked out.
-
-### Robot specs in v0.0.x
-
-The `robot:` block names a robot's embodiment in one of three forms.
-The spec validator enforces that exactly one embodiment form is set
-and that `agents` contains exactly one agent.
-
-| Form | Example | What it does today |
-|---|---|---|
-| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
-| `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
-| `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
-
-Two missions with the same model and benchmark but different
-embodiments produce genuinely different eval runs (Robosuite simulates
-the named robot, not its per-env default). The embodiment is what
-categorizes leaderboard submissions when the leaderboard backend ships
-— a Franka Panda result and a Sawyer result are different categories.
-Multi-agent comparison — same loadout, different model checkpoint in
-one agent — will become possible when the agent cap lifts.
+> still subject to change without notice.
 
 ## Install
 
@@ -175,7 +34,7 @@ run `validate`, `list`, `status`, and `run --use-mock-runner` against any
 mission spec without a GPU. `.[all]` adds everything needed for real training
 and evaluation runs.
 
-## 60-second smoke test (no GPU, no network)
+## Quick start (no GPU, no network)
 
 ```bash
 # Validate the mission spec
@@ -215,26 +74,17 @@ COMPLETED  c1756bad855e45cc9a95b5b0566c948b
 laptop without a GPU. State is persisted to `~/.odyssey/missions.db`;
 artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
-## Real run (OpenVLA + Robosuite)
+## What it is
 
-This works only after the extras are installed AND the upstream
-[openvla](https://github.com/openvla/openvla) repo is cloned somewhere
-findable (`$OPENVLA_REPO_PATH` or `/srv/openvla`):
+You describe a mission in YAML — a robot, a model, a dataset to train on, an
+evaluation benchmark to score against — and `odyssey run` walks it through the
+full lifecycle: load → validate → execute training tasks → execute the
+evaluation task → persist results. Local-mode by default; the hosted Lovell
+services (leaderboard, learning graph, hosted runners) are optional layers
+that land in later releases.
 
-```bash
-pip install -e ".[huggingface,openvla,robosuite]"
-git clone https://github.com/openvla/openvla.git /srv/openvla
-
-odyssey run examples/quickstart-openvla/mission.yaml
-```
-
-Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
-
-**Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
-the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
-adapter. Real eval numbers require supplying a `policy_factory` to
-`RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
-The built-in adapter is a v0.2.x line item.
+Odyssey organizes work around **missions**, **robots**, and **agents**.
+See [docs/concepts.md](docs/concepts.md) for the full architecture.
 
 ## CLI reference
 
@@ -263,6 +113,27 @@ src/odyssey/
   cli/          Click-based `odyssey` command + subcommands
   utils/        ~/.odyssey/ path management
 ```
+
+## Real run (OpenVLA + Robosuite)
+
+This works only after the extras are installed AND the upstream
+[openvla](https://github.com/openvla/openvla) repo is cloned somewhere
+findable (`$OPENVLA_REPO_PATH` or `/srv/openvla`):
+
+```bash
+pip install -e ".[huggingface,openvla,robosuite]"
+git clone https://github.com/openvla/openvla.git /srv/openvla
+
+odyssey run examples/quickstart-openvla/mission.yaml
+```
+
+Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
+
+**Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
+the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
+adapter. Real eval numbers require supplying a `policy_factory` to
+`RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
+The built-in adapter is a v0.2.x line item.
 
 ## Status snapshot (v0.0.x)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Lovell Odyssey
 
+[![CI](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-green.svg)](LICENSE)
+[![Status: Pre-Alpha](https://img.shields.io/badge/status-pre--alpha-orange.svg)]()
+
 Open-source framework for defining, running, and benchmarking robot training missions.
 
 > **Status: pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,131 @@
+# Concepts
+
+## Missions
+
+A **mission** is the unit of work in Odyssey: a single, reproducible recipe
+that fine-tunes a model on a dataset and benchmarks the result. You describe
+one in a `mission.yaml`; the framework loads it, drives it through a
+lifecycle (`DRAFT → QUEUED → ACTIVE → COMPLETED | FAILED | CANCELLED`),
+persists every status transition to `~/.odyssey/missions.db`, and emits one
+JSON event per state change to stdout.
+
+Every mission has four required pieces:
+
+1. **An objective** — prose stating what you're trying to achieve.
+2. **Acceptance criteria** — prose stating how success is judged.
+3. **A robot** — the embodiment plus a loadout of agents (see below).
+4. **A list of tasks** — *at least one training task, exactly one
+   evaluation task, and the evaluation task must be the last entry.*
+   Each training task updates one agent on the robot; the evaluation
+   task runs the robot after every training task has completed.
+
+Training tasks chain implicitly through the agent: when multiple
+training tasks target the same `agent_id`, each one starts from the
+previous one's checkpoint. No explicit `from_task` reference is needed,
+because the model lives on the agent and tasks update it. When every
+task reaches `COMPLETED`, the mission's `overall_grade` is set to the
+average of the evaluation scores.
+
+Shape of a minimal mission:
+
+```yaml
+odysseyVersion: "0.1"
+kind: Mission
+metadata:
+  name: my-mission
+objective: |
+  Fine-tune OpenVLA so it can pick up a cube in Robosuite Lift.
+acceptance_criteria: |
+  At least one successful lift across 10 evaluation episodes.
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model: { source: huggingface, base: openvla/openvla-7b }
+tasks:
+  - name: finetune
+    kind: training
+    training_type: demonstration
+    agent_id: pilot              # updates the pilot agent's model
+    config: { method: peft_lora, lora_rank: 8, epochs: 1 }
+  - name: bench
+    kind: evaluation
+    evaluation_type: robosuite
+    benchmark_name: Lift
+    num_episodes: 10
+    # no model / agent_id — the eval runs the robot
+```
+
+`objective` and `acceptance_criteria` are required prose fields. They aren't
+parsed by anything today, but in later releases the Mission Materializer
+will extract structured artifacts from them (evaluation predicates,
+deadlines, instruction prefixes injected into VLA prompts). Write them like
+you mean it — future-you will reread them in leaderboard submissions and
+graph queries.
+
+## Robots and agents
+
+In the Lovell AI architecture, a **robot** is more than an embodiment —
+it's a composition of an embodiment with a **loadout of agents**. Every
+robot has exactly one **PILOT** (running a Vision-Language-Action model
+with physical authority over the actuators) and zero or more
+**SPECIALISTs** (running language models for delegated reasoning — map
+queries, calculations, lookups). Each agent is authored with a persona,
+goals, and success criteria, and runs against a pinned model checkpoint;
+its behavior is conditioned at runtime by materialized artifacts
+produced from that prose. The fuller picture is described in the Lovell
+AI robot-brain paper.
+
+Odyssey's spec models this hierarchy directly. A `robot:` block
+declares an embodiment and an inline loadout of agents:
+
+```yaml
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model: { source: huggingface, base: openvla/openvla-7b }
+```
+
+Each agent owns its model — the `model:` field lives on the agent, not
+on a task. Training tasks reference an agent by id (`agent_id: pilot`),
+and the framework looks up the model from the agent. When several
+training tasks target the same agent, each one starts from the previous
+one's checkpoint. The evaluation task takes no model reference at all:
+it runs the robot — that is, it composes the current checkpoints of
+every agent in the loadout.
+
+**Today, Odyssey fine-tunes the underlying model for one of the
+robot's agents at a time.** v0.0.x enforces exactly one agent on the
+robot (the implicit PILOT), and the eval composes a single policy from
+that single agent. Multi-agent loadouts (PILOT + one or more
+SPECIALISTs) and the multi-agent execution that goes with them ship
+when the multi-agent runtime lands. What v0.0.x does *not* model from
+the brain paper — agent persona / goals / success criteria,
+materialized artifacts that condition runtime behavior, the
+deterministic safety stack, conduct-rule enforcement, the deployment
+contract — is on the roadmap. Where each of those ultimately lives
+(in `src/odyssey/` versus in a hosted Lovell service) is a strategic
+decision still being worked out.
+
+## Robot specs in v0.0.x
+
+The `robot:` block names a robot's embodiment in one of three forms.
+The spec validator enforces that exactly one embodiment form is set
+and that `agents` contains exactly one agent.
+
+| Form | Example | What it does today |
+|---|---|---|
+| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
+| `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
+| `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
+
+Two missions with the same model and benchmark but different
+embodiments produce genuinely different eval runs (Robosuite simulates
+the named robot, not its per-env default). The embodiment is what
+categorizes leaderboard submissions when the leaderboard backend ships
+— a Franka Panda result and a Sawyer result are different categories.
+Multi-agent comparison — same loadout, different model checkpoint in
+one agent — will become possible when the agent cap lifts.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -71,11 +71,8 @@ it's a composition of an embodiment with a **loadout of agents**. Every
 robot has exactly one **PILOT** (running a Vision-Language-Action model
 with physical authority over the actuators) and zero or more
 **SPECIALISTs** (running language models for delegated reasoning — map
-queries, calculations, lookups). Each agent is authored with a persona,
-goals, and success criteria, and runs against a pinned model checkpoint;
-its behavior is conditioned at runtime by materialized artifacts
-produced from that prose. The fuller picture is described in the Lovell
-AI robot-brain paper.
+queries, calculations, lookups). Each agent runs against a pinned model
+checkpoint.
 
 Odyssey's spec models this hierarchy directly. A `robot:` block
 declares an embodiment and an inline loadout of agents:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -102,13 +102,7 @@ robot's agents at a time.** v0.0.x enforces exactly one agent on the
 robot (the implicit PILOT), and the eval composes a single policy from
 that single agent. Multi-agent loadouts (PILOT + one or more
 SPECIALISTs) and the multi-agent execution that goes with them ship
-when the multi-agent runtime lands. What v0.0.x does *not* model from
-the brain paper — agent persona / goals / success criteria,
-materialized artifacts that condition runtime behavior, the
-deterministic safety stack, conduct-rule enforcement, the deployment
-contract — is on the roadmap. Where each of those ultimately lives
-(in `src/odyssey/` versus in a hosted Lovell service) is a strategic
-decision still being worked out.
+when the multi-agent runtime lands.
 
 ## Robot specs in v0.0.x
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,12 +2,11 @@
 
 An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
 
-You describe a mission in YAML — specifying a robot, an agent, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
 
 ## Key Concepts
 
 - **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
-- **Agents** — The AI models attached to a robot (e.g. a VLA policy). Each agent has a role (PILOT or SPECIALIST) and a pinned model checkpoint
 - **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
 - **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,4 +1,4 @@
-# Lovell Odyssey Overview
+# Odyssey Overview
 
 An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
 
@@ -8,6 +8,8 @@ You describe a mission in YAML — specifying a robot, a model, a dataset, and a
 
 - **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
 - **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
+- **Models** — The neural network being trained (e.g. OpenVLA). A mission specifies which model to fine-tune and how
+- **Agents** — The autonomous entity resulting from training a mission. It becomes part of the robot as a PILOT or SPECIALIST
 - **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
 
 ## Codebase Structure (`src/odyssey/`)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,7 +2,7 @@
 
 An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
 
-You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+You train an agent by describing a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
 
 ## Key Concepts
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,4 +37,4 @@ You describe a mission in YAML — specifying a robot, a model, a dataset, and a
 
 ## Focus
 
-The project is oriented toward **VLA (Vision-Language-Action) model** fine-tuning and robotic sim evaluation, with OpenVLA as the first supported model and Robosuite as the first eval environment.
+The pre-alpha version supports **VLA (Vision-Language-Action) model** fine-tuning only, with OpenVLA as the first supported model and Robosuite as the first eval environment. Future releases will add multi-agent training and VLM support.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,11 +2,12 @@
 
 An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
 
-You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+You describe a mission in YAML — specifying a robot, an agent, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
 
 ## Key Concepts
 
 - **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
+- **Agents** — The AI models attached to a robot (e.g. a VLA policy). Each agent has a role (PILOT or SPECIALIST) and a pinned model checkpoint
 - **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
 - **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,40 @@
+# Lovell Odyssey Overview
+
+An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
+
+You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+
+## Key Concepts
+
+- **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
+- **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
+- **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
+
+## Codebase Structure (`src/odyssey/`)
+
+| Module | Purpose |
+|---|---|
+| `spec/` | Pydantic schemas for `mission.yaml` validation |
+| `engine/` | MissionEngine — lifecycle orchestration & runtime records |
+| `runners/` | Runner ABC + registry, CPU mock, OpenVLA training, Robosuite eval |
+| `providers/` | Provider ABCs + local & HuggingFace implementations |
+| `persistence/` | Storage layer — InMemory + SQLite backends |
+| `telemetry/` | Event vocabulary + stdout publisher |
+| `cli/` | Click-based CLI (`odyssey validate/run/list/status/init`) |
+| `materializer/` | Handles materializing assets |
+| `utils/` | `~/.odyssey/` path management |
+
+## Tech Stack
+
+- **Python 3.10+**, Apache 2.0 licensed
+- Core deps: pydantic, click, pyyaml, aiosqlite
+- Optional extras: `torch` + `transformers` + `peft` (OpenVLA training), `robosuite` + `mujoco` (evaluation), `huggingface-hub` + `datasets`
+- Tooling: hatchling build, ruff linter, mypy strict, pytest
+
+## CLI
+
+`odyssey init`, `validate`, `run`, `list`, `status` — with `--use-mock-runner` for GPU-free testing on a laptop.
+
+## Focus
+
+The project is oriented toward **VLA (Vision-Language-Action) model** fine-tuning and robotic sim evaluation, with OpenVLA as the first supported model and Robosuite as the first eval environment.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ openvla = [
     "peft>=0.8",
     "torch>=2.1",
 ]
+all = [
+    "lovell-odyssey[huggingface,openvla,robosuite]",
+]
 
 [project.scripts]
 odyssey = "odyssey.cli.main:cli"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
-"""Lovell Odyssey — open-source framework for robot training missions."""
+"""Odyssey — open-source framework for robot training missions."""
 
 __version__ = "0.0.1"

--- a/src/odyssey/cli/main.py
+++ b/src/odyssey/cli/main.py
@@ -20,7 +20,7 @@ from odyssey.cli.commands.validate import validate
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(__version__, prog_name="odyssey")
 def cli() -> None:
-    """Lovell Odyssey — robot training mission framework."""
+    """Odyssey — robot training mission framework."""
 
 
 cli.add_command(init)

--- a/src/odyssey/spec/agents.py
+++ b/src/odyssey/spec/agents.py
@@ -1,11 +1,10 @@
 """Agent definitions on a robot.
 
 In the Lovell architecture, a robot is an embodiment plus a loadout of
-agents (see the robot-brain paper). Each agent has an id, a role
-(PILOT or SPECIALIST), and an underlying model checkpoint. The brain
-paper describes the full agent shape — persona, goals, success
-criteria, materialized artifacts — that v0.0.x ``AgentSpec`` does not
-yet model.
+agents. Each agent has an id, a role (PILOT or SPECIALIST), and an
+underlying model checkpoint. Future versions will extend ``AgentSpec``
+with additional fields (persona, goals, success criteria, materialized
+artifacts).
 
 What v0.0.x ships: enough of the agent shape that training tasks can
 reference an agent and the framework can look up that agent's starting

--- a/src/odyssey/spec/mission.py
+++ b/src/odyssey/spec/mission.py
@@ -56,9 +56,8 @@ class RobotSpec(BaseModel):
     today is the PILOT (running a Vision-Language-Action model with
     physical authority over the actuators).
 
-    See the Lovell robot-brain paper for the fuller agent shape that
-    v0.0.x's ``AgentSpec`` does not yet model (persona, goals, success
-    criteria, materialized artifacts).
+    Future versions will extend ``AgentSpec`` with additional fields
+    (persona, goals, success criteria, materialized artifacts).
     """
 
     embodiment: str | None = None


### PR DESCRIPTION
## Summary

- Add `[all]` extra to `pyproject.toml` that bundles `huggingface`, `openvla`, and `robosuite` for a single-command install of the full training + evaluation stack.
- Restructure the README Install section into three clear tiers: base (lightweight CLI), `.[all]` (real runs), and `.[all,dev]` (contributor tooling).
- Update git clone URL and directory name to point at `lovellai-dev/odyssey`.
- Keep individual extras documented as a secondary note for users who only need part of the stack.

## Test plan

- [x] `pip install -e .` installs successfully
- [x] `pip install -e ".[all]"` resolves and installs all runner/provider deps
- [x] `pip install -e ".[dev]"` installs dev tooling
- [x] `odyssey --help` works after base install
- [x] Smoke test section (`odyssey validate`, `odyssey run --use-mock-runner`) — in progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)