### PR TITLE
[TRAINING]fix(runners): torchrun support for OpenVLA + GCP compatibility

### DIFF
--- a/src/odyssey/runners/openvla.py
+++ b/src/odyssey/runners/openvla.py
@@ -162,7 +162,16 @@ def build_openvla_argv(
     # the dedicated branch above only fires when it's missing from
     # config, so when the operator sets it the override loop here is
     # what propagates their value.
-    handled = {"vla_path", "data_root_dir", "dataset_name"}
+    # Keys consumed by Odyssey's mission spec but not accepted by the
+    # upstream finetune.py draccus config.
+    handled = {
+        "vla_path",
+        "data_root_dir",
+        "dataset_name",
+        "method",
+        "lora_alpha",
+        "epochs",
+    }
     for key, value in _flatten_config(config):
         if key in handled:
             continue
@@ -284,6 +293,7 @@ class OpenVLARunner(Runner):
 
         process_spec = TrainingProcessSpec(
             script_path=script_path,
+            use_torchrun=True,
             argv_extra=build_openvla_argv(
                 task=spec.model_copy(update={"config": config}),
                 agent_model_base=agent_model_base,

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -59,6 +59,8 @@ class TrainingProcessSpec:
     line_parser: LineParser | None = None
     cwd: str | None = None
     sigterm_grace_seconds: float = 30.0
+    use_torchrun: bool = False
+    torchrun_nproc: int = 1
 
     def __post_init__(self) -> None:
         if (self.entry_module is None) == (self.script_path is None):
@@ -78,12 +80,21 @@ async def run_training_subprocess(
     responsible for building ``argv_extra``, picking the entry, and
     post-processing the resulting output directory.
     """
+    if spec.use_torchrun:
+        launcher = [
+            "torchrun",
+            "--standalone",
+            f"--nproc_per_node={spec.torchrun_nproc}",
+        ]
+    else:
+        launcher = ["python"]
+
     if spec.entry_module is not None:
-        cmd = ["python", "-m", spec.entry_module, *spec.argv_extra]
+        cmd = [*launcher, "-m", spec.entry_module, *spec.argv_extra]
     else:
         # script_path is guaranteed by __post_init__
         assert spec.script_path is not None
-        cmd = ["python", spec.script_path, *spec.argv_extra]
+        cmd = [*launcher, spec.script_path, *spec.argv_extra]
     env = {**os.environ, **spec.env}
 
     logger.info(


### PR DESCRIPTION
## Summary

- Add `use_torchrun` / `torchrun_nproc` fields to `TrainingProcessSpec` so runners can launch via `torchrun` instead of `python`
- Enable `use_torchrun=True` for the OpenVLA runner (required for DDP initialization)
- Filter Odyssey-only config keys (`method`, `lora_alpha`, `epochs`) from CLI args passed to upstream `finetune.py`
- Add `dataset_name: bridge_orig` to quickstart mission (OpenVLA requires a valid OXE dataset name)

## Context

Discovered during end-to-end testing on a GCP VM (NVIDIA L4, 24GB). Full details in #5.

### Key findings:
- OpenVLA's `finetune.py` requires `torchrun` (not `python`) for DDP initialization
- On GCP single-GPU VMs, `export NCCL_NET=Socket` is required to bypass Google's custom NCCL plugin (`gIB`)
- OpenVLA expects RLDS/TFDS format datasets, not LeRobot/HuggingFace format
- The `--dataset_name` must be a valid OXE name (e.g. `bridge_orig`), not the Odyssey task name

### Verified pipeline (on GCP L4):
- ✅ Model download from HuggingFace (`openvla/openvla-7b`, ~15GB)
- ✅ Model loading + LoRA setup (27M/7.5B trainable params)
- ✅ DDP initialization (with `NCCL_NET=Socket`)
- ✅ RLDS dataset discovery and reading
- ⏳ End-to-end training (blocked on full dataset download, in progress)

## Scope & limitations

This PR targets **single-node execution only**. The launcher uses `torchrun --standalone`, which assumes all GPUs are on one machine.

| Scenario | Status |
|----------|--------|
| Single GPU | ✅ Works (current default: `nproc_per_node=1`) |
| Multi-GPU, single node | ⚠️ Requires exposing `torchrun_nproc` to mission config (field exists on `TrainingProcessSpec` but is not yet configurable from YAML — currently hardcoded to 1) |
| Multi-node (multiple machines) | ❌ Not supported. Would require replacing `--standalone` with `--nnodes`, `--node_rank`, `--master_addr`, `--master_port`, and an orchestration layer to launch processes across machines |

### Future work for multi-node support

To support multi-node training, `TrainingProcessSpec` and `run_training_subprocess` would need to:
1. Drop `--standalone` and accept `nnodes`, `node_rank`, `master_addr`, `master_port` as configurable fields
2. Add an orchestration layer (e.g. integration with SLURM, Kubernetes, or a custom launcher) to start the same command on each node
3. Expose these parameters through the mission YAML config

This is out of scope for this PR and tracked as a future feature.

## Test plan

- [ ] Full Bridge V2 dataset download completes (~124GB)
- [ ] Manual `torchrun` test runs training steps successfully
- [ ] `odyssey run examples/quickstart-openvla/mission.yaml` completes end-to-end
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5