### PR TITLE
[TRAINING]fix(mission): add dataset_name to OpenVLA quickstart mission

### DIFF
--- a/examples/quickstart-openvla/mission.yaml
+++ b/examples/quickstart-openvla/mission.yaml
@@ -47,6 +47,7 @@ tasks:
       batch_size: 2
       learning_rate: 5.0e-5
       epochs: 1
+      dataset_name: bridge_orig  # OXE name required by OpenVLA's finetune.py
 
   - name: eval-on-robosuite-lift
     kind: evaluation


### PR DESCRIPTION

> [!IMPORTANT]  
> This PR is NOT to develop nor to main , it is to another fix branch
> RULES were activated while I was working on that branch .

Merging this branch will allow me to work in the fix.
Thanks 



## Summary

Adds `dataset_name: bridge_orig` to the OpenVLA quickstart mission config.

## Problem

The OpenVLA runner (`openvla.py:153`) builds the `--dataset_name` CLI arg like this:

```python
argv += ["--dataset_name", str(config.get("dataset_name", task.name))]
```

When `dataset_name` is not in the mission config, it falls back to `task.name` which is `finetune-openvla`. This is **not a valid OXE dataset name** and causes:

```
KeyError: 'finetune-openvla'
```

OpenVLA's `finetune.py` requires the dataset name to match a key in the Open X-Embodiment (OXE) config registry (`prismatic/vla/datasets/rlds/oxe/configs.py`).

## Fix

Add `dataset_name: bridge_orig` explicitly to the mission.yaml config. `bridge_orig` is the OXE name for Bridge V2 in RLDS/TFDS format.

## Important: dataset format

OpenVLA expects the dataset in **RLDS/TFDS format**, not LeRobot/HuggingFace format. The mission.yaml still references `lerobot/bridge_v2` as the dataset source, but the actual data must be downloaded separately in RLDS format:

```bash
wget -r -nH --cut-dirs=4 --reject="index.html*" \
  https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
mv bridge_dataset bridge_orig
```

Then `--data_root_dir` must point to the parent directory containing `bridge_orig/`. The full dataset is ~124 GB.

This format mismatch is a known limitation tracked in #5.

## Context

Discovered during end-to-end testing on GCP VM (NVIDIA L4). Part of the work in PR #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)