### PR TITLE
[ONBOARDING]docs: add training mission section + fix CONTRIBUTING clone URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The DCO is checked by CI on every pull request. We do not require a CLA.
 ## Development setup
 
 ```bash
-git clone https://github.com/femtechie/lovell-odyssey.git
+git clone https://github.com/lovellai-dev/odyssey.git
 cd lovell-odyssey
 python -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -112,20 +112,40 @@ src/odyssey/
   utils/        ~/.odyssey/ path management
 ```
 
-## Real run (OpenVLA + Robosuite)
+## Launching a training mission
 
-This works only after the extras are installed AND the upstream
-[openvla](https://github.com/openvla/openvla) repo is cloned somewhere
-findable (`$OPENVLA_REPO_PATH` or `/srv/openvla`):
+### Prerequisites
+
+1. Install the training extras:
+   ```bash
+   pip install -e ".[huggingface,openvla,robosuite]"
+   ```
+2. Clone the upstream OpenVLA repo and install its dependencies (needed for
+   `draccus` and the fine-tuning script):
+   ```bash
+   git clone https://github.com/openvla/openvla.git /srv/openvla
+   pip install -e /srv/openvla
+   export OPENVLA_REPO_PATH=/srv/openvla
+   ```
+3. Download the Bridge V2 dataset in RLDS format (~124 GB):
+   ```bash
+   wget -r -nH --cut-dirs=4 --reject="index.html*" \
+     https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
+   mv bridge_dataset bridge_orig
+   ```
+   Set `--data_root_dir` to the parent directory containing `bridge_orig/`.
+
+### Run
 
 ```bash
-pip install -e ".[huggingface,openvla,robosuite]"
-git clone https://github.com/openvla/openvla.git /srv/openvla
-
 odyssey run examples/quickstart-openvla/mission.yaml
 ```
 
-Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
+Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA LoRA fine-tune.
+
+> [!NOTE]
+> **GCP users:** single-GPU VMs require `export NCCL_NET=Socket` before
+> running, to bypass Google's NCCL plugin. See [issue #5](https://github.com/lovellai-dev/odyssey/issues/5) for details.
 
 > [!NOTE]
 > **Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,40 @@
+# Lovell Odyssey Overview
+
+An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
+
+You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+
+## Key Concepts
+
+- **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
+- **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
+- **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
+
+## Codebase Structure (`src/odyssey/`)
+
+| Module | Purpose |
+|---|---|
+| `spec/` | Pydantic schemas for `mission.yaml` validation |
+| `engine/` | MissionEngine — lifecycle orchestration & runtime records |
+| `runners/` | Runner ABC + registry, CPU mock, OpenVLA training, Robosuite eval |
+| `providers/` | Provider ABCs + local & HuggingFace implementations |
+| `persistence/` | Storage layer — InMemory + SQLite backends |
+| `telemetry/` | Event vocabulary + stdout publisher |
+| `cli/` | Click-based CLI (`odyssey validate/run/list/status/init`) |
+| `materializer/` | Handles materializing assets |
+| `utils/` | `~/.odyssey/` path management |
+
+## Tech Stack
+
+- **Python 3.10+**, Apache 2.0 licensed
+- Core deps: pydantic, click, pyyaml, aiosqlite
+- Optional extras: `torch` + `transformers` + `peft` (OpenVLA training), `robosuite` + `mujoco` (evaluation), `huggingface-hub` + `datasets`
+- Tooling: hatchling build, ruff linter, mypy strict, pytest
+
+## CLI
+
+`odyssey init`, `validate`, `run`, `list`, `status` — with `--use-mock-runner` for GPU-free testing on a laptop.
+
+## Focus
+
+The project is oriented toward **VLA (Vision-Language-Action) model** fine-tuning and robotic sim evaluation, with OpenVLA as the first supported model and Robosuite as the first eval environment.


### PR DESCRIPTION
## Summary

- Rename "Real run (OpenVLA + Robosuite)" to "Launching a training mission" with clear prerequisites
- Add GCP-specific note about `NCCL_NET=Socket` for single-GPU VMs
- Fix clone URL in CONTRIBUTING.md (`femtechie/lovell-odyssey` → `lovellai-dev/odyssey`)

Part of PR #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)