### PR TITLE
[TRAINING]fix(runners): increase subprocess buffer + add dataset_name

### DIFF
--- a/examples/quickstart-openvla/mission.yaml
+++ b/examples/quickstart-openvla/mission.yaml
@@ -47,6 +47,7 @@ tasks:
       batch_size: 2
       learning_rate: 5.0e-5
       epochs: 1
+      dataset_name: bridge_orig  # OXE name required by OpenVLA's finetune.py
 
   - name: eval-on-robosuite-lift
     kind: evaluation

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -113,6 +113,10 @@ async def run_training_subprocess(
         cwd=spec.cwd,
         # New process group so SIGTERM targets only this child tree.
         preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        # tqdm progress bars use \r without \n, which can accumulate
+        # into a single "line" that exceeds asyncio's default 64 KB
+        # buffer.  10 MB is enough for long training runs.
+        limit=10 * 1024 * 1024,
     )
 
     stdout_task = asyncio.create_task(


### PR DESCRIPTION
## Summary

- Increase asyncio subprocess stdout buffer to 10 MB to handle tqdm `\r` output without `LimitOverrunError`
- Add `dataset_name: bridge_orig` to OpenVLA quickstart mission config

These commits were pending locally on `fix/torchrun-openvla` but couldn't be pushed due to branch protection rules.

## Context

Part of the work in #5 and PR #6. Discovered during end-to-end testing on GCP VM (NVIDIA L4).

## Test plan

- [ ] `odyssey run examples/quickstart-openvla/mission.yaml` no longer crashes with `LimitOverrunError`
- [ ] Dataset name is correctly passed as `bridge_orig` to OpenVLA's `finetune.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)