### PR TITLE
[TRAINING] feat(runners): stream subprocess output + buffer fix + dataset_name

### DIFF
--- a/examples/quickstart-openvla/mission.yaml
+++ b/examples/quickstart-openvla/mission.yaml
@@ -47,6 +47,7 @@ tasks:
       batch_size: 2
       learning_rate: 5.0e-5
       epochs: 1
+      dataset_name: bridge_orig  # OXE name required by OpenVLA's finetune.py
 
   - name: eval-on-robosuite-lift
     kind: evaluation

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -113,6 +113,10 @@ async def run_training_subprocess(
         cwd=spec.cwd,
         # New process group so SIGTERM targets only this child tree.
         preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        # tqdm progress bars use \r without \n, which can accumulate
+        # into a single "line" that exceeds asyncio's default 64 KB
+        # buffer.  10 MB is enough for long training runs.
+        limit=10 * 1024 * 1024,
     )
 
     stdout_task = asyncio.create_task(

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -20,6 +20,7 @@ import logging
 import os
 import re
 import signal
+import sys
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -178,9 +179,10 @@ async def _stream_stdout(
         return
     last_step_emitted = -1
     last_checkpoint_emitted = -1
+    buf = ""
     while True:
         try:
-            raw = await proc.stdout.readline()
+            raw = await proc.stdout.read(8192)
         except Exception:
             logger.exception(
                 "Error reading subprocess stdout for task %s", ctx.task.id
@@ -188,52 +190,59 @@ async def _stream_stdout(
             break
         if not raw:
             break
-        line = raw.decode("utf-8", errors="replace").rstrip()
-        if not line:
-            continue
-        logger.info("[%s] %s", ctx.task.id, line)
+        # Write raw bytes directly to terminal for real-time tqdm output
+        sys.stdout.buffer.write(raw)
+        sys.stdout.buffer.flush()
+        # Also parse lines for structured events
+        buf += raw.decode("utf-8", errors="replace")
+        while "\n" in buf:
+            line, buf = buf.split("\n", 1)
+            line = line.rstrip("\r")
+            if not line:
+                continue
+            logger.info("[%s] %s", ctx.task.id, line)
 
-        parsed: dict[str, Any] | None = None
-        if line_parser is not None:
+            parsed: dict[str, Any] | None = None
+            if line_parser is not None:
+                try:
+                    parsed = line_parser(line)
+                except Exception:
+                    logger.exception(
+                        "line_parser raised for task %s — using fallback", ctx.task.id
+                    )
+
+            if parsed is None:
+                m = _GENERIC_STEP_RE.search(line)
+                if m:
+                    step = int(m.group(1))
+                    if step != last_step_emitted:
+                        last_step_emitted = step
+                        parsed = {
+                            "stage": "executing",
+                            "step": "training_step",
+                            "step_index": step,
+                        }
+                elif _CHECKPOINT_RE.search(line):
+                    m2 = _CHECKPOINT_RE.search(line)
+                    assert m2 is not None  # we just matched
+                    step = int(m2.group(2))
+                    if step != last_checkpoint_emitted:
+                        last_checkpoint_emitted = step
+                        parsed = {
+                            "stage": "checkpoint_saving",
+                            "step": "checkpoint_save",
+                            "step_index": step,
+                        }
+
+            if parsed is None:
+                continue
+
             try:
-                parsed = line_parser(line)
+                await ctx.emit_progress(**parsed)
             except Exception:
                 logger.exception(
-                    "line_parser raised for task %s — using fallback", ctx.task.id
+                    "emit_progress failed for task %s — continuing", ctx.task.id
                 )
-
-        if parsed is None:
-            m = _GENERIC_STEP_RE.search(line)
-            if m:
-                step = int(m.group(1))
-                if step != last_step_emitted:
-                    last_step_emitted = step
-                    parsed = {
-                        "stage": "executing",
-                        "step": "training_step",
-                        "step_index": step,
-                    }
-            elif _CHECKPOINT_RE.search(line):
-                m2 = _CHECKPOINT_RE.search(line)
-                assert m2 is not None  # we just matched
-                step = int(m2.group(2))
-                if step != last_checkpoint_emitted:
-                    last_checkpoint_emitted = step
-                    parsed = {
-                        "stage": "checkpoint_saving",
-                        "step": "checkpoint_save",
-                        "step_index": step,
-                    }
-
-        if parsed is None:
-            continue
-
-        try:
-            await ctx.emit_progress(**parsed)
-        except Exception:
-            logger.exception(
-                "emit_progress failed for task %s — continuing", ctx.task.id
-            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Stream subprocess stdout/stderr directly to the terminal in real-time (tqdm bars, model loading, training output all visible now)
- Switch from `readline()` to `read(8192)` chunks to handle tqdm `\r` output without blocking
- Increase asyncio buffer to 10 MB as safety net
- Add `dataset_name: bridge_orig` to OpenVLA quickstart mission config

Replaces PR #9 (`fix/subprocess-buffer`).

## Problem

Users running `odyssey run` saw `dataset_loading` and then silence — no training output visible. Root causes:
1. Subprocess stdout went only to `logger.info()`, not shown in CLI
2. `readline()` blocks on tqdm `\r` output (no `\n` terminator)

## Fix

Write raw bytes from subprocess directly to `sys.stdout.buffer` for real-time output, while still parsing `\n`-terminated lines for structured progress events.

## Context

Part of #5. Discovered during end-to-end testing on GCP VM (NVIDIA L4).

## Test plan

- [ ] `odyssey run examples/quickstart-openvla/mission.yaml` shows live training output
- [ ] tqdm progress bars render correctly
- [ ] Structured events (`training_step`, `checkpoint_save`) still emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)