### PR TITLE
fix(mission): add data_root_dir to OpenVLA quickstart

### DIFF
--- a/examples/quickstart-openvla/mission.yaml
+++ b/examples/quickstart-openvla/mission.yaml
@@ -47,7 +47,8 @@ tasks:
       batch_size: 2
       learning_rate: 5.0e-5
       epochs: 1
-      dataset_name: bridge_orig  # OXE name required by OpenVLA's finetune.py
+      dataset_name: bridge_orig      # OXE name required by OpenVLA's finetune.py
+      data_root_dir: /path/to/dataset  # parent dir containing bridge_orig/1.0.0/
 
   - name: eval-on-robosuite-lift
     kind: evaluation


### PR DESCRIPTION
## Summary

Add `data_root_dir` to the OpenVLA quickstart mission config.

## Problem

Without `data_root_dir`, the OpenVLA runner falls back to `task.dataset.ref` (`lerobot/bridge_v2`) — an HF reference, not a local path. TFDS then fails with:

```
DatasetNotFoundError: Dataset bridge_orig not found.
```

## Fix

Add `data_root_dir: /path/to/dataset` as a placeholder. Users must set this to the parent directory containing `bridge_orig/1.0.0/`.

## Context

Discovered during end-to-end `odyssey run` testing on GCP VM. Part of #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)