### PR TITLE
docs: address PR #1 review feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
 ## What it is
 
-You describe a mission in YAML — a robot, a model, a dataset to train on, an
+You describe a mission in YAML — a robot, an agent, a dataset to train on, an
 evaluation benchmark to score against — and `odyssey run` walks it through the
 full lifecycle: load → validate → execute training tasks → execute the
 evaluation task → persist results. Local-mode by default; the hosted Lovell

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -102,13 +102,7 @@ robot's agents at a time.** v0.0.x enforces exactly one agent on the
 robot (the implicit PILOT), and the eval composes a single policy from
 that single agent. Multi-agent loadouts (PILOT + one or more
 SPECIALISTs) and the multi-agent execution that goes with them ship
-when the multi-agent runtime lands. What v0.0.x does *not* model from
-the brain paper — agent persona / goals / success criteria,
-materialized artifacts that condition runtime behavior, the
-deterministic safety stack, conduct-rule enforcement, the deployment
-contract — is on the roadmap. Where each of those ultimately lives
-(in `src/odyssey/` versus in a hosted Lovell service) is a strategic
-decision still being worked out.
+when the multi-agent runtime lands.
 
 ## Robot specs in v0.0.x
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -37,4 +37,4 @@ You describe a mission in YAML — specifying a robot, a model, a dataset, and a
 
 ## Focus
 
-The project is oriented toward **VLA (Vision-Language-Action) model** fine-tuning and robotic sim evaluation, with OpenVLA as the first supported model and Robosuite as the first eval environment.
+The pre-alpha version supports **VLA (Vision-Language-Action) model** fine-tuning only, with OpenVLA as the first supported model and Robosuite as the first eval environment. Future releases will add multi-agent training and VLM support.


### PR DESCRIPTION
## Summary


<img width="500" height="321" alt="tron" src="https://github.com/user-attachments/assets/485cb61c-c7ba-483a-a325-5a72a83074aa" />



Addresses the review comments from @femtechie on PR #1.

### Changes

- **Remove "brain paper" reference** (`docs/concepts.md` lines 105-111) — Removed the paragraph referencing the internal "brain paper" and detailed roadmap items (agent persona, safety stack, conduct-rule enforcement, deployment contract). The preceding paragraph about single-agent limitations and future multi-agent support is preserved.
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3310653176

- **Clarify VLA-only scope in pre-alpha** (`docs/overview.md` line 40) — Updated the Focus section to explicitly state that the pre-alpha supports VLA fine-tuning only, and that multi-agent training and VLM support are planned for future releases.
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3310662463

- **Fix terminology: "a model" → "an agent"** (`README.md` line 77) — The "What it is" section now correctly describes a mission as containing "a robot, an agent, a dataset" instead of "a robot, a model, a dataset", which better reflects the mission spec structure.
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3310667835

### Not addressed (no action needed)

- Comment on `docs/concepts.md` line 2 ("The reorganization makes sense. Nice!") — positive feedback, no change required.

## Test plan

- [ ] Verify no broken links in README.md or docs/
- [ ] Confirm removed text does not appear elsewhere in the docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)