### PR TITLE
docs: scrub brain paper references and fix agent terminology

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -71,11 +71,8 @@ it's a composition of an embodiment with a **loadout of agents**. Every
 robot has exactly one **PILOT** (running a Vision-Language-Action model
 with physical authority over the actuators) and zero or more
 **SPECIALISTs** (running language models for delegated reasoning — map
-queries, calculations, lookups). Each agent is authored with a persona,
-goals, and success criteria, and runs against a pinned model checkpoint;
-its behavior is conditioned at runtime by materialized artifacts
-produced from that prose. The fuller picture is described in the Lovell
-AI robot-brain paper.
+queries, calculations, lookups). Each agent runs against a pinned model
+checkpoint.
 
 Odyssey's spec models this hierarchy directly. A `robot:` block
 declares an embodiment and an inline loadout of agents:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -2,11 +2,12 @@
 
 An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
 
-You describe a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+You describe a mission in YAML — specifying a robot, an agent, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
 
 ## Key Concepts
 
 - **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
+- **Agents** — The AI models attached to a robot (e.g. a VLA policy). Each agent has a role (PILOT or SPECIALIST) and a pinned model checkpoint
 - **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
 - **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
 

--- a/src/odyssey/spec/agents.py
+++ b/src/odyssey/spec/agents.py
@@ -1,11 +1,10 @@
 """Agent definitions on a robot.
 
 In the Lovell architecture, a robot is an embodiment plus a loadout of
-agents (see the robot-brain paper). Each agent has an id, a role
-(PILOT or SPECIALIST), and an underlying model checkpoint. The brain
-paper describes the full agent shape — persona, goals, success
-criteria, materialized artifacts — that v0.0.x ``AgentSpec`` does not
-yet model.
+agents. Each agent has an id, a role (PILOT or SPECIALIST), and an
+underlying model checkpoint. Future versions will extend ``AgentSpec``
+with additional fields (persona, goals, success criteria, materialized
+artifacts).
 
 What v0.0.x ships: enough of the agent shape that training tasks can
 reference an agent and the framework can look up that agent's starting

--- a/src/odyssey/spec/mission.py
+++ b/src/odyssey/spec/mission.py
@@ -56,9 +56,8 @@ class RobotSpec(BaseModel):
     today is the PILOT (running a Vision-Language-Action model with
     physical authority over the actuators).
 
-    See the Lovell robot-brain paper for the fuller agent shape that
-    v0.0.x's ``AgentSpec`` does not yet model (persona, goals, success
-    criteria, materialized artifacts).
+    Future versions will extend ``AgentSpec`` with additional fields
+    (persona, goals, success criteria, materialized artifacts).
     """
 
     embodiment: str | None = None


### PR DESCRIPTION
## Summary

Second round of review feedback on PR #1 from @femtechie.

### Changes

- **Scrub all remaining "robot-brain paper" references** — Removed from `docs/concepts.md` (line 78), `src/odyssey/spec/agents.py` (docstring), and `src/odyssey/spec/mission.py` (docstring). The document is not published, so references to it should not appear in the codebase. Replaced with forward-looking language ("Future versions will extend AgentSpec with additional fields").
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3313860292

- **Fix "a model" → "an agent" regression in `docs/overview.md`** — Line 5 still said "specifying a robot, a model, a dataset" after PR #12 only fixed `README.md`. Now consistent across both files.
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3313875371

- **Add "Agents" as a key concept in `docs/overview.md`** — Added to the Key Concepts list with a description: "The AI models attached to a robot (e.g. a VLA policy). Each agent has a role (PILOT or SPECIALIST) and a pinned model checkpoint."
  - Addresses: https://github.com/lovellai-dev/odyssey/pull/1#discussion_r3313877945

### Verification

- Full codebase search confirms zero remaining "brain paper" / "robot-brain" references
- Full codebase search confirms zero remaining "a robot, a model" phrasing in docs or docstrings
- Python imports verified: `agents.py` and `mission.py` load without errors after docstring edits
- No behavioral changes — only docstrings and markdown

## Test plan

- [x] Verify `python -c "from odyssey.spec.agents import AgentSpec"` works
- [x] Verify `python -c "from odyssey.spec.mission import RobotSpec"` works
- [x] Grep for "brain paper" returns no results

🤖 Generated with [Claude Code](https://claude.com/claude-code)