### PR TITLE
feat: Add GR00T quickstart mission, training runner, and Isaac Lab eval runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
     name: DCO sign-off
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The DCO is checked by CI on every pull request. We do not require a CLA.
 ## Development setup
 
 ```bash
-git clone https://github.com/femtechie/lovell-odyssey.git
+git clone https://github.com/lovellai-dev/odyssey.git
 cd lovell-odyssey
 python -m venv .venv
 source .venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -1,174 +1,41 @@
-# Lovell Odyssey
+<h1 align="center">Odyssey</h1>
 
-Open-source framework for defining, running, and benchmarking robot training missions.
+<p align="center">
+  <a href="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml"><img src="https://github.com/lovellai-dev/odyssey/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue.svg" alt="Python 3.10+"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-green.svg" alt="License: Apache 2.0"></a>
+  <img src="https://img.shields.io/badge/status-pre--alpha-orange.svg" alt="Status: Pre-Alpha">
+</p>
 
-> **Status: pre-alpha (v0.0.x).** Not yet on PyPI. The first public alpha is
-> targeted at `v0.1.0-alpha`. The API, CLI, schemas, and wire protocols are
-> still subject to change without notice. See `docs/` for the design refs.
-
-## What it is
-
-You describe a mission in YAML — a robot, a model, a dataset to train on, an
-evaluation benchmark to score against — and `odyssey run` walks it through the
-full lifecycle: load → validate → execute training tasks → execute the
-evaluation task → persist results. Local-mode by default; the hosted Lovell
-services (leaderboard, learning graph, hosted runners) are optional layers
-that land in later releases.
-
-## Concepts
-
-### Missions
-
-A **mission** is the unit of work in Odyssey: a single, reproducible recipe
-that fine-tunes a model on a dataset and benchmarks the result. You describe
-one in a `mission.yaml`; the framework loads it, drives it through a
-lifecycle (`DRAFT → QUEUED → ACTIVE → COMPLETED | FAILED | CANCELLED`),
-persists every status transition to `~/.odyssey/missions.db`, and emits one
-JSON event per state change to stdout.
-
-Every mission has four required pieces:
-
-1. **An objective** — prose stating what you're trying to achieve.
-2. **Acceptance criteria** — prose stating how success is judged.
-3. **A robot** — the embodiment plus a loadout of agents (see below).
-4. **A list of tasks** — *at least one training task, exactly one
-   evaluation task, and the evaluation task must be the last entry.*
-   Each training task updates one agent on the robot; the evaluation
-   task runs the robot after every training task has completed.
-
-Training tasks chain implicitly through the agent: when multiple
-training tasks target the same `agent_id`, each one starts from the
-previous one's checkpoint. No explicit `from_task` reference is needed,
-because the model lives on the agent and tasks update it. When every
-task reaches `COMPLETED`, the mission's `overall_grade` is set to the
-average of the evaluation scores.
-
-Shape of a minimal mission:
-
-```yaml
-odysseyVersion: "0.1"
-kind: Mission
-metadata:
-  name: my-mission
-objective: |
-  Fine-tune OpenVLA so it can pick up a cube in Robosuite Lift.
-acceptance_criteria: |
-  At least one successful lift across 10 evaluation episodes.
-robot:
-  embodiment: franka_panda
-  agents:
-    - id: pilot
-      role: PILOT
-      model: { source: huggingface, base: openvla/openvla-7b }
-tasks:
-  - name: finetune
-    kind: training
-    training_type: demonstration
-    agent_id: pilot              # updates the pilot agent's model
-    config: { method: peft_lora, lora_rank: 8, epochs: 1 }
-  - name: bench
-    kind: evaluation
-    evaluation_type: robosuite
-    benchmark_name: Lift
-    num_episodes: 10
-    # no model / agent_id — the eval runs the robot
-```
-
-`objective` and `acceptance_criteria` are required prose fields. They aren't
-parsed by anything today, but in later releases the Mission Materializer
-will extract structured artifacts from them (evaluation predicates,
-deadlines, instruction prefixes injected into VLA prompts). Write them like
-you mean it — future-you will reread them in leaderboard submissions and
-graph queries.
-
-### Robots and agents
-
-In the Lovell AI architecture, a **robot** is more than an embodiment —
-it's a composition of an embodiment with a **loadout of agents**. Every
-robot has exactly one **PILOT** (running a Vision-Language-Action model
-with physical authority over the actuators) and zero or more
-**SPECIALISTs** (running language models for delegated reasoning — map
-queries, calculations, lookups). Each agent is authored with a persona,
-goals, and success criteria, and runs against a pinned model checkpoint;
-its behavior is conditioned at runtime by materialized artifacts
-produced from that prose. The fuller picture is described in the Lovell
-AI robot-brain paper.
-
-Odyssey's spec models this hierarchy directly. A `robot:` block
-declares an embodiment and an inline loadout of agents:
-
-```yaml
-robot:
-  embodiment: franka_panda
-  agents:
-    - id: pilot
-      role: PILOT
-      model: { source: huggingface, base: openvla/openvla-7b }
-```
-
-Each agent owns its model — the `model:` field lives on the agent, not
-on a task. Training tasks reference an agent by id (`agent_id: pilot`),
-and the framework looks up the model from the agent. When several
-training tasks target the same agent, each one starts from the previous
-one's checkpoint. The evaluation task takes no model reference at all:
-it runs the robot — that is, it composes the current checkpoints of
-every agent in the loadout.
-
-**Today, Odyssey fine-tunes the underlying model for one of the
-robot's agents at a time.** v0.0.x enforces exactly one agent on the
-robot (the implicit PILOT), and the eval composes a single policy from
-that single agent. Multi-agent loadouts (PILOT + one or more
-SPECIALISTs) and the multi-agent execution that goes with them ship
-when the multi-agent runtime lands. What v0.0.x does *not* model from
-the brain paper — agent persona / goals / success criteria,
-materialized artifacts that condition runtime behavior, the
-deterministic safety stack, conduct-rule enforcement, the deployment
-contract — is on the roadmap. Where each of those ultimately lives
-(in `src/odyssey/` versus in a hosted Lovell service) is a strategic
-decision still being worked out.
-
-### Robot specs in v0.0.x
-
-The `robot:` block names a robot's embodiment in one of three forms.
-The spec validator enforces that exactly one embodiment form is set
-and that `agents` contains exactly one agent.
-
-| Form | Example | What it does today |
-|---|---|---|
-| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
-| `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
-| `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
-
-Two missions with the same model and benchmark but different
-embodiments produce genuinely different eval runs (Robosuite simulates
-the named robot, not its per-env default). The embodiment is what
-categorizes leaderboard submissions when the leaderboard backend ships
-— a Franka Panda result and a Sawyer result are different categories.
-Multi-agent comparison — same loadout, different model checkpoint in
-one agent — will become possible when the agent cap lifts.
+<p align="center">Open-source framework for defining, running, and benchmarking robot training missions.</p>
 
 ## Install
 
+> [!IMPORTANT]
+> **Linux only** — install build dependencies before proceeding (needed by `.[all]`):
+> ```bash
+> sudo apt update && sudo apt install build-essential python3-dev -y
+> ```
+
 ```bash
-git clone https://github.com/femtechie/lovell-odyssey.git
-cd lovell-odyssey
-pip install -e .
+git clone https://github.com/lovellai-dev/odyssey.git
+cd odyssey
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .              # CLI, validate, mock runs (lightweight)
+pip install -e ".[all]"       # real training + evaluation (torch, robosuite…)
+pip install -e ".[all,dev]"   # + pytest, ruff, mypy
 ```
 
 The base install pulls in pydantic, click, pyyaml, and aiosqlite — enough to
 run `validate`, `list`, `status`, and `run --use-mock-runner` against any
-mission spec. Real training and evaluation runners need their own extras:
+mission spec without a GPU. `.[all]` adds everything needed for real training
+and evaluation runs.
+
+## Quick start (no GPU, no network)
 
 ```bash
-pip install -e ".[huggingface]"   # HF model + dataset providers
-pip install -e ".[openvla]"       # OpenVLA training runner deps
-pip install -e ".[robosuite]"     # Robosuite evaluation runner deps
-pip install -e ".[dev]"           # pytest, ruff, mypy
-```
-
-## 60-second smoke test (no GPU, no network)
-
-```bash
+# Validate the mission spec
 $ odyssey validate examples/quickstart-openvla/mission.yaml
 OK  examples/quickstart-openvla/mission.yaml
   spec version : 0.1
@@ -176,6 +43,7 @@ OK  examples/quickstart-openvla/mission.yaml
   robot        : embodiment=franka_panda
   tasks        : 1 training, 1 evaluation
 
+# Run the full mission with a CPU mock (no GPU needed)
 $ odyssey run examples/quickstart-openvla/mission.yaml --use-mock-runner
 {"ts": "...", "event": "mission.created", ...}
 {"ts": "...", "event": "mission.queued", ...}
@@ -186,9 +54,11 @@ $ odyssey run examples/quickstart-openvla/mission.yaml --use-mock-runner
 COMPLETED  c1756bad855e45cc9a95b5b0566c948b
   overall_grade : 1.000
 
+# List all missions from the local DB
 $ odyssey list
 c1756bad855e  COMPLETED   openvla-bridge-lift   2026-05-17T23:18:34+00:00  grade=1.000
 
+# Show details for a specific mission (prefix match)
 $ odyssey status c1756bad
 COMPLETED  c1756bad855e45cc9a95b5b0566c948b
   name         : openvla-bridge-lift
@@ -202,26 +72,17 @@ COMPLETED  c1756bad855e45cc9a95b5b0566c948b
 laptop without a GPU. State is persisted to `~/.odyssey/missions.db`;
 artifacts under `~/.odyssey/runs/<mission-id>/<task-id>/`.
 
-## Real run (OpenVLA + Robosuite)
+## What it is
 
-This works only after the extras are installed AND the upstream
-[openvla](https://github.com/openvla/openvla) repo is cloned somewhere
-findable (`$OPENVLA_REPO_PATH` or `/srv/openvla`):
+You train an agent by describing a mission in YAML — a robot, a model, a dataset to train on, an
+evaluation benchmark to score against — and `odyssey run` walks it through the
+full lifecycle: load → validate → execute training tasks → execute the
+evaluation task → persist results. Local-mode by default; the hosted Lovell
+services (leaderboard, learning graph, hosted runners) are optional layers
+that land in later releases.
 
-```bash
-pip install -e ".[huggingface,openvla,robosuite]"
-git clone https://github.com/openvla/openvla.git /srv/openvla
-
-odyssey run examples/quickstart-openvla/mission.yaml
-```
-
-Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA fine-tune.
-
-**Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
-the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
-adapter. Real eval numbers require supplying a `policy_factory` to
-`RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
-The built-in adapter is a v0.2.x line item.
+Odyssey organizes work around **missions**, **robots**, and **agents**.
+See [docs/concepts.md](docs/concepts.md) for the full architecture.
 
 ## CLI reference
 
@@ -250,6 +111,48 @@ src/odyssey/
   cli/          Click-based `odyssey` command + subcommands
   utils/        ~/.odyssey/ path management
 ```
+
+## Launching a training mission
+
+### Prerequisites
+
+1. Install the training extras:
+   ```bash
+   pip install -e ".[huggingface,openvla,robosuite]"
+   ```
+2. Clone the upstream OpenVLA repo and install its dependencies (needed for
+   `draccus` and the fine-tuning script):
+   ```bash
+   git clone https://github.com/openvla/openvla.git /srv/openvla
+   pip install -e /srv/openvla
+   export OPENVLA_REPO_PATH=/srv/openvla
+   ```
+3. Download the Bridge V2 dataset in RLDS format (~124 GB):
+   ```bash
+   wget -r -nH --cut-dirs=4 --reject="index.html*" \
+     https://rail.eecs.berkeley.edu/datasets/bridge_release/data/tfds/bridge_dataset/
+   mv bridge_dataset bridge_orig
+   ```
+   Set `--data_root_dir` to the parent directory containing `bridge_orig/`.
+
+### Run
+
+```bash
+odyssey run examples/quickstart-openvla/mission.yaml
+```
+
+Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA LoRA fine-tune.
+
+> [!NOTE]
+> **GCP users:** single-GPU VMs require `export NCCL_NET=Socket` before
+> running, to bypass Google's NCCL plugin. See [issue #5](https://github.com/lovellai-dev/odyssey/issues/5) for details.
+
+> [!NOTE]
+> **Known gap for v0.1.0-alpha:** the Robosuite evaluation runner ships with
+> the lifecycle plumbing wired but no built-in OpenVLA→robosuite-action
+> adapter. Real eval numbers require supplying a `policy_factory` to
+> `RobosuiteRunner` — see the docstring in `src/odyssey/runners/robosuite.py`.
+> The built-in adapter is a v0.2.x line item.
 
 ## Status snapshot (v0.0.x)
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ src/odyssey/
   spec/         Pydantic schemas for mission.yaml
   engine/       MissionEngine + lifecycle + runtime records
   runners/      Runner ABC, registry, CPU mock, subprocess infra,
-                OpenVLA training, Robosuite evaluation
+                OpenVLA + GR00T training, Robosuite evaluation
   providers/    Provider ABCs + registry, local/ + huggingface/
   persistence/  Persistence ABC + InMemory + SQLite
   telemetry/    Event vocabulary + stdout publisher
@@ -164,7 +164,9 @@ Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA LoRA fine-tune.
 | Provider ABCs + Local + HF | ✓ | OXE, Lovell-mode |
 | CPU mock runner | ✓ | — |
 | OpenVLA training runner | skeleton + tests | end-to-end smoke with real OpenVLA |
+| GR00T training runner | skeleton + tests, task-level `runner: gr00t` routing | end-to-end smoke with real Isaac-GR00T |
 | Robosuite eval runner | skeleton + tests | built-in OpenVLA→action adapter |
+| Isaac Lab eval runner | spec enum only (`evaluation_type: isaac_lab`) | runner implementation |
 | `odyssey init / run / list / status / validate` | ✓ | `logs`, `publish` |
 | Leaderboard publish, Learning Graph, Anonymizer, Auth | — | post-v0.1.0-alpha |
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Hardware: 24 GB GPU (RTX 4090-class or better) for the OpenVLA LoRA fine-tune.
 | OpenVLA training runner | skeleton + tests | end-to-end smoke with real OpenVLA |
 | GR00T training runner | skeleton + tests, task-level `runner: gr00t` routing | end-to-end smoke with real Isaac-GR00T |
 | Robosuite eval runner | skeleton + tests | built-in OpenVLA→action adapter |
-| Isaac Lab eval runner | spec enum only (`evaluation_type: isaac_lab`) | runner implementation |
+| Isaac Lab eval runner | skeleton + tests, subprocess launch + `ODYSSEY_*` stdout protocol | blessed eval script (GR00T/VLA recipe), real-Isaac smoke |
 | `odyssey init / run / list / status / validate` | ✓ | `logs`, `publish` |
 | Leaderboard publish, Learning Graph, Anonymizer, Auth | — | post-v0.1.0-alpha |
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,122 @@
+# Concepts
+
+## Missions
+
+A **mission** is the unit of work in Odyssey: a single, reproducible recipe
+that fine-tunes a model on a dataset and benchmarks the result. You describe
+one in a `mission.yaml`; the framework loads it, drives it through a
+lifecycle (`DRAFT → QUEUED → ACTIVE → COMPLETED | FAILED | CANCELLED`),
+persists every status transition to `~/.odyssey/missions.db`, and emits one
+JSON event per state change to stdout.
+
+Every mission has four required pieces:
+
+1. **An objective** — prose stating what you're trying to achieve.
+2. **Acceptance criteria** — prose stating how success is judged.
+3. **A robot** — the embodiment plus a loadout of agents (see below).
+4. **A list of tasks** — *at least one training task, exactly one
+   evaluation task, and the evaluation task must be the last entry.*
+   Each training task updates one agent on the robot; the evaluation
+   task runs the robot after every training task has completed.
+
+Training tasks chain implicitly through the agent: when multiple
+training tasks target the same `agent_id`, each one starts from the
+previous one's checkpoint. No explicit `from_task` reference is needed,
+because the model lives on the agent and tasks update it. When every
+task reaches `COMPLETED`, the mission's `overall_grade` is set to the
+average of the evaluation scores.
+
+Shape of a minimal mission:
+
+```yaml
+odysseyVersion: "0.1"
+kind: Mission
+metadata:
+  name: my-mission
+objective: |
+  Fine-tune OpenVLA so it can pick up a cube in Robosuite Lift.
+acceptance_criteria: |
+  At least one successful lift across 10 evaluation episodes.
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model: { source: huggingface, base: openvla/openvla-7b }
+tasks:
+  - name: finetune
+    kind: training
+    training_type: demonstration
+    agent_id: pilot              # updates the pilot agent's model
+    config: { method: peft_lora, lora_rank: 8, epochs: 1 }
+  - name: bench
+    kind: evaluation
+    evaluation_type: robosuite
+    benchmark_name: Lift
+    num_episodes: 10
+    # no model / agent_id — the eval runs the robot
+```
+
+`objective` and `acceptance_criteria` are required prose fields. They aren't
+parsed by anything today, but in later releases the Mission Materializer
+will extract structured artifacts from them (evaluation predicates,
+deadlines, instruction prefixes injected into VLA prompts). Write them like
+you mean it — future-you will reread them in leaderboard submissions and
+graph queries.
+
+## Robots and agents
+
+In the Lovell AI architecture, a **robot** is more than an embodiment —
+it's a composition of an embodiment with a **loadout of agents**. Every
+robot has exactly one **PILOT** (running a Vision-Language-Action model
+with physical authority over the actuators) and zero or more
+**SPECIALISTs** (running language models for delegated reasoning — map
+queries, calculations, lookups). Each agent runs against a pinned model
+checkpoint.
+
+Odyssey's spec models this hierarchy directly. A `robot:` block
+declares an embodiment and an inline loadout of agents:
+
+```yaml
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model: { source: huggingface, base: openvla/openvla-7b }
+```
+
+Each agent owns its model — the `model:` field lives on the agent, not
+on a task. Training tasks reference an agent by id (`agent_id: pilot`),
+and the framework looks up the model from the agent. When several
+training tasks target the same agent, each one starts from the previous
+one's checkpoint. The evaluation task takes no model reference at all:
+it runs the robot — that is, it composes the current checkpoints of
+every agent in the loadout.
+
+**Today, Odyssey fine-tunes the underlying model for one of the
+robot's agents at a time.** v0.0.x enforces exactly one agent on the
+robot (the implicit PILOT), and the eval composes a single policy from
+that single agent. Multi-agent loadouts (PILOT + one or more
+SPECIALISTs) and the multi-agent execution that goes with them ship
+when the multi-agent runtime lands.
+
+## Robot specs in v0.0.x
+
+The `robot:` block names a robot's embodiment in one of three forms.
+The spec validator enforces that exactly one embodiment form is set
+and that `agents` contains exactly one agent.
+
+| Form | Example | What it does today |
+|---|---|---|
+| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
+| `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
+| `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
+
+Two missions with the same model and benchmark but different
+embodiments produce genuinely different eval runs (Robosuite simulates
+the named robot, not its per-env default). The embodiment is what
+categorizes leaderboard submissions when the leaderboard backend ships
+— a Franka Panda result and a Sawyer result are different categories.
+Multi-agent comparison — same loadout, different model checkpoint in
+one agent — will become possible when the agent cap lifts.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,42 @@
+# Odyssey Overview
+
+An **open-source framework for defining, running, and benchmarking robot training missions**. Built by Lovell AI, currently in pre-alpha (v0.0.1).
+
+You train an agent by describing a mission in YAML — specifying a robot, a model, a dataset, and an evaluation benchmark — and `odyssey run` orchestrates the full lifecycle: load → validate → train → evaluate → persist results.
+
+## Key Concepts
+
+- **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
+- **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
+- **Models** — The neural network being trained (e.g. OpenVLA). A mission specifies which model to fine-tune and how
+- **Agents** — The autonomous entity resulting from training a mission. It becomes part of the robot as a PILOT or SPECIALIST
+- **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
+
+## Codebase Structure (`src/odyssey/`)
+
+| Module | Purpose |
+|---|---|
+| `spec/` | Pydantic schemas for `mission.yaml` validation |
+| `engine/` | MissionEngine — lifecycle orchestration & runtime records |
+| `runners/` | Runner ABC + registry, CPU mock, OpenVLA training, Robosuite eval |
+| `providers/` | Provider ABCs + local & HuggingFace implementations |
+| `persistence/` | Storage layer — InMemory + SQLite backends |
+| `telemetry/` | Event vocabulary + stdout publisher |
+| `cli/` | Click-based CLI (`odyssey validate/run/list/status/init`) |
+| `materializer/` | Handles materializing assets |
+| `utils/` | `~/.odyssey/` path management |
+
+## Tech Stack
+
+- **Python 3.10+**, Apache 2.0 licensed
+- Core deps: pydantic, click, pyyaml, aiosqlite
+- Optional extras: `torch` + `transformers` + `peft` (OpenVLA training), `robosuite` + `mujoco` (evaluation), `huggingface-hub` + `datasets`
+- Tooling: hatchling build, ruff linter, mypy strict, pytest
+
+## CLI
+
+`odyssey init`, `validate`, `run`, `list`, `status` — with `--use-mock-runner` for GPU-free testing on a laptop.
+
+## Focus
+
+The pre-alpha version supports **VLA (Vision-Language-Action) model** fine-tuning only, with OpenVLA as the first supported model and Robosuite as the first eval environment. Future releases will add multi-agent training and VLM support.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,7 +9,8 @@ You train an agent by describing a mission in YAML — specifying a robot, a mod
 - **Missions** — YAML specs that define what to train, how to evaluate, and on which robot
 - **Runners** — Pluggable backends that execute tasks (CPU mock for testing, OpenVLA for real training, Robosuite for evaluation)
 - **Models** — The neural network being trained (e.g. OpenVLA). A mission specifies which model to fine-tune and how
-- **Agents** — The autonomous entity resulting from training a mission. It becomes part of the robot as a PILOT or SPECIALIST
+- **Agents** — The autonomous entities that define the models to use and provide instructions for models to follow.
+- **Robots** — The embodiment of the physical robot and a collection of agents purposely collaborating to operate the robot.
 - **Providers** — Abstractions for data/model sources (local filesystem, HuggingFace)
 
 ## Codebase Structure (`src/odyssey/`)

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,16 +3,56 @@
 | Directory | What it does | Hardware |
 |---|---|---|
 | `quickstart-openvla/` | OpenVLA 7B LoRA fine-tune on Bridge V2 + Robosuite Lift eval. | 24 GB GPU |
+| `quickstart-gr00t/` | GR00T N1.7 3B fine-tune on the Isaac-GR00T demo set + Isaac Lab eval. | 24 GB+ GPU for training; eval mock-only until the Isaac Lab runner lands |
 
 More quickstarts (Octo, Pi0.5) arrive in later releases. See the
 publication plan for the cadence.
 
-## Validating an example
+## Validating and mock-running an example
 
 Once `lovell-odyssey` is installed:
 
 ```bash
 odyssey validate examples/quickstart-openvla/mission.yaml
+odyssey validate examples/quickstart-gr00t/mission.yaml
 ```
 
-`odyssey run` is not implemented yet in v0.0.x.
+Every example also runs end-to-end with the CPU mock (no GPU, no
+network):
+
+```bash
+odyssey run examples/quickstart-gr00t/mission.yaml --use-mock-runner
+```
+
+For a real OpenVLA training run, see the prerequisites in the top-level
+README (OpenVLA repo clone, Bridge V2 download, 24 GB GPU).
+
+## GR00T quickstart status
+
+`quickstart-gr00t/` ships with a real training runner skeleton
+(`src/odyssey/runners/gr00t.py`): `validate` and `--use-mock-runner`
+work everywhere, and real training runs work once the
+[Isaac-GR00T repo](https://github.com/NVIDIA/Isaac-GR00T) is installed
+(`pip install -e` of the checkout, plus `$ISAAC_GR00T_REPO_PATH`
+pointing at it for the demo data). The Isaac Lab *evaluation* runner is
+still a v0.2.x line item — the eval task is spec-pinned but mock-only.
+
+The moving parts:
+
+* **Model** — `nvidia/GR00T-N1.7-3B` from HuggingFace (the base
+  checkpoint; zero-shot on pretrain embodiments, fine-tunable for new
+  tasks). NVIDIA's license applies to the weights.
+* **Data** — the LeRobot-v2-flavor demo set shipped inside Isaac-GR00T
+  (`demo_data/cube_to_bowl_5`), resolved against
+  `$ISAAC_GR00T_REPO_PATH`. GR00T's format adds a `meta/modality.json`
+  on top of LeRobot v2.
+* **Runner routing** — OpenVLA and GR00T are both wildcard training
+  runners, so the mission selects GR00T explicitly with
+  `config: {runner: gr00t}` on the training task.
+* **Training config** — remaining keys mirror the
+  `gr00t/experiment/launch_finetune.py` flags (`embodiment_tag`,
+  `global_batch_size`, `max_steps`); the runner maps them 1:1 onto the
+  upstream CLI with underscores translated to dashes.
+* **Eval** — Isaac Lab task `Isaac-Lift-Cube-Franka-v0`,
+  `evaluation_type: isaac_lab` (already a first-class enum in the
+  mission spec).

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,8 +24,8 @@ network):
 odyssey run examples/quickstart-gr00t/mission.yaml --use-mock-runner
 ```
 
-For a real OpenVLA training run, see the prerequisites in the top-level
-README (OpenVLA repo clone, Bridge V2 download, 24 GB GPU).
+For a real GR00T fine-tuning run, see the prerequisites in the top-level
+README (Isaac-GR00T repo clone, a LeRobot-format dataset, and a CUDA GPU).
 
 ## GR00T quickstart status
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,13 +29,16 @@ README (OpenVLA repo clone, Bridge V2 download, 24 GB GPU).
 
 ## GR00T quickstart status
 
-`quickstart-gr00t/` ships with a real training runner skeleton
-(`src/odyssey/runners/gr00t.py`): `validate` and `--use-mock-runner`
-work everywhere, and real training runs work once the
-[Isaac-GR00T repo](https://github.com/NVIDIA/Isaac-GR00T) is installed
-(`pip install -e` of the checkout, plus `$ISAAC_GR00T_REPO_PATH`
-pointing at it for the demo data). The Isaac Lab *evaluation* runner is
-still a v0.2.x line item — the eval task is spec-pinned but mock-only.
+`quickstart-gr00t/` ships with real runner skeletons on both sides:
+`validate` and `--use-mock-runner` work everywhere; real training runs
+work once the [Isaac-GR00T repo](https://github.com/NVIDIA/Isaac-GR00T)
+is installed (`pip install -e` of the checkout, plus
+`$ISAAC_GR00T_REPO_PATH` pointing at it for the demo data); and real
+evaluation runs work once you have Isaac Lab installed
+(`$ISAACLAB_PATH`) and supply an eval script speaking the `ODYSSEY_*`
+stdout protocol via `config: {eval_script: ...}` — see
+`src/odyssey/runners/isaac_lab.py` for the contract. The built-in
+GR00T-policy eval script is the remaining v0.2.x piece.
 
 The moving parts:
 
@@ -54,5 +57,7 @@ The moving parts:
   `global_batch_size`, `max_steps`); the runner maps them 1:1 onto the
   upstream CLI with underscores translated to dashes.
 * **Eval** — Isaac Lab task `Isaac-Lift-Cube-Franka-v0`,
-  `evaluation_type: isaac_lab` (already a first-class enum in the
-  mission spec).
+  `evaluation_type: isaac_lab`. The runner launches your eval script
+  under `isaaclab.sh -p`, passes
+  `--task/--num_episodes/--checkpoint/--headless`, and scores the
+  `ODYSSEY_EPISODE` / `ODYSSEY_RESULT` lines the script prints.

--- a/examples/quickstart-gr00t/mission.yaml
+++ b/examples/quickstart-gr00t/mission.yaml
@@ -62,6 +62,11 @@ tasks:
     evaluation_type: isaac_lab
     benchmark_name: Isaac-Lift-Cube-Franka-v0
     num_episodes: 10
+    # For a real run: set $ISAACLAB_PATH and point eval_script at a
+    # script speaking the ODYSSEY_* stdout protocol (see
+    # src/odyssey/runners/isaac_lab.py). Mock-run needs neither.
+    # config:
+    #   eval_script: /path/to/gr00t_isaaclab_eval.py
 
 leaderboard:
   publish: false   # Backend not live yet.

--- a/examples/quickstart-gr00t/mission.yaml
+++ b/examples/quickstart-gr00t/mission.yaml
@@ -1,0 +1,70 @@
+# GR00T quickstart mission.
+#
+# Fine-tunes NVIDIA Isaac GR00T N1.7 (3B) on the LeRobot-format demo
+# set that ships inside the Isaac-GR00T repo, then evaluates the
+# resulting policy in the Isaac Lab cube-lift environment.
+#
+# Status (v0.1.x): `odyssey validate` and `odyssey run --use-mock-runner`
+# work today. The GR00T training runner and the Isaac Lab evaluation
+# runner are v0.2.x line items — this mission pins the spec-level
+# contract they will execute. See examples/README.md.
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: gr00t-cube-to-bowl
+  description: GR00T N1.7 fine-tune on the Isaac-GR00T demo set, evaluated in Isaac Lab.
+  tags: [quickstart, gr00t, nvidia, isaac-lab]
+
+objective: |
+  Demonstrate that the GR00T N1.7 3B foundation model fine-tuned on a
+  small LeRobot-format demonstration set can pick up a cube and place
+  it in a bowl, evaluated in the Isaac Lab lift environment.
+
+acceptance_criteria: |
+  At least one successful lift across 10 evaluation episodes.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: nvidia/GR00T-N1.7-3B
+
+tasks:
+  - name: finetune-gr00t
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    dataset:
+      source: local
+      # Ships inside the Isaac-GR00T repo (no separate download);
+      # resolved against $ISAAC_GR00T_REPO_PATH by the runner.
+      ref: demo_data/cube_to_bowl_5
+      # GR00T trains on a flavor of LeRobot v2 with an additional
+      # meta/modality.json describing state/action/video keys.
+      format: lerobot
+    config:
+      # OpenVLA and GR00T both serve wildcard training tasks — this key
+      # routes the task to the GR00T runner explicitly.
+      runner: gr00t
+      # Remaining keys mirror gr00t/experiment/launch_finetune.py flags
+      # (underscores become dashes on the CLI).
+      embodiment_tag: new_embodiment
+      global_batch_size: 32
+      max_steps: 1000
+
+  - name: eval-in-isaac-lab
+    kind: evaluation
+    evaluation_type: isaac_lab
+    benchmark_name: Isaac-Lift-Cube-Franka-v0
+    num_episodes: 10
+
+leaderboard:
+  publish: false   # Backend not live yet.
+
+graph:
+  contribute: false   # Backend not live yet.

--- a/examples/quickstart-gr00t/mission.yaml
+++ b/examples/quickstart-gr00t/mission.yaml
@@ -54,6 +54,7 @@ tasks:
       # Remaining keys mirror gr00t/experiment/launch_finetune.py flags
       # (underscores become dashes on the CLI).
       embodiment_tag: new_embodiment
+      modality_config_path: examples/SO100/so100_config.py
       global_batch_size: 32
       max_steps: 1000
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ all = [
 odyssey = "odyssey.cli.main:cli"
 
 [project.urls]
-Homepage = "https://github.com/femtechie/lovell-odyssey"
-Repository = "https://github.com/femtechie/lovell-odyssey"
-Issues = "https://github.com/femtechie/lovell-odyssey/issues"
+Homepage = "https://github.com/lovellai-dev/odyssey"
+Repository = "https://github.com/lovellai-dev/odyssey"
+Issues = "https://github.com/lovellai-dev/odyssey/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/odyssey"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,9 @@ openvla = [
     "peft>=0.8",
     "torch>=2.1",
 ]
+all = [
+    "lovell-odyssey[huggingface,openvla,robosuite]",
+]
 
 [project.scripts]
 odyssey = "odyssey.cli.main:cli"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
-"""Lovell Odyssey — open-source framework for robot training missions."""
+"""Odyssey — open-source framework for robot training missions."""
 
 __version__ = "0.0.1"

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -28,6 +28,7 @@ from odyssey.providers.huggingface import HFDatasetProvider, HFModelProvider
 from odyssey.providers.local import LocalDatasetProvider, LocalRobotProvider
 from odyssey.runners import (
     CPUMockRunner,
+    GR00TRunner,
     OpenVLARunner,
     RunnerRegistry,
 )
@@ -38,14 +39,16 @@ from odyssey.telemetry import StdoutEventPublisher
 from odyssey.utils.paths import default_db_path, runs_dir
 
 
-def _build_runners(use_mock: bool) -> RunnerRegistry:
+def _build_runners() -> RunnerRegistry:
     registry = RunnerRegistry()
-    if use_mock:
-        registry.register(CPUMockRunner())
-        return registry
     # Real runners first; CPU mock as a last-resort fallback so unfamiliar
     # task types still produce *something* instead of "no runner registered."
+    # OpenVLA and GR00T are both wildcard training runners — registration
+    # order makes OpenVLA the default; GR00T is selected per-task via
+    # ``config: {runner: gr00t}``. --use-mock-runner forces the mock
+    # through the engine's force_runner, not by thinning this registry.
     registry.register(OpenVLARunner())
+    registry.register(GR00TRunner())
     registry.register(RobosuiteRunner())
     registry.register(CPUMockRunner())
     return registry
@@ -100,7 +103,7 @@ def run(
     work_dir = working_dir or runs_dir()
 
     persistence = SqlitePersistence(str(db_path))
-    runners = _build_runners(use_mock=use_mock_runner)
+    runners = _build_runners()
     providers = _build_providers()
     publisher = StdoutEventPublisher()
     engine = MissionEngine(
@@ -109,6 +112,7 @@ def run(
         event_publisher=publisher,
         working_dir=work_dir,
         providers=providers,
+        force_runner="cpu_mock" if use_mock_runner else None,
     )
 
     final = asyncio.run(_run_mission(engine, spec))

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -32,6 +32,7 @@ from odyssey.runners import (
     OpenVLARunner,
     RunnerRegistry,
 )
+from odyssey.runners.isaac_lab import IsaacLabRunner
 from odyssey.runners.robosuite import RobosuiteRunner
 from odyssey.spec.loader import LoadError, load_mission
 from odyssey.spec.mission import Mission
@@ -50,6 +51,7 @@ def _build_runners() -> RunnerRegistry:
     registry.register(OpenVLARunner())
     registry.register(GR00TRunner())
     registry.register(RobosuiteRunner())
+    registry.register(IsaacLabRunner())
     registry.register(CPUMockRunner())
     return registry
 

--- a/src/odyssey/cli/main.py
+++ b/src/odyssey/cli/main.py
@@ -20,7 +20,7 @@ from odyssey.cli.commands.validate import validate
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(__version__, prog_name="odyssey")
 def cli() -> None:
-    """Lovell Odyssey — robot training mission framework."""
+    """Odyssey — robot training mission framework."""
 
 
 cli.add_command(init)

--- a/src/odyssey/engine/mission_engine.py
+++ b/src/odyssey/engine/mission_engine.py
@@ -46,7 +46,7 @@ from odyssey.providers.registry import ProviderRegistry
 from odyssey.runners.base import TaskContext
 from odyssey.runners.registry import RunnerRegistry
 from odyssey.spec.mission import Mission
-from odyssey.spec.tasks import EvaluationTask, TrainingTask
+from odyssey.spec.tasks import EvaluationTask, TaskSpec, TrainingTask
 from odyssey.telemetry.events import MissionEventType, TaskEventType
 from odyssey.telemetry.publishers.base import EventPublisher
 
@@ -80,6 +80,20 @@ def _task_payload(mission: MissionRun, task: TaskRun) -> dict[str, Any]:
     }
 
 
+def _runner_override(spec: TaskSpec) -> str | None:
+    """Task-level runner selection: ``config: {runner: <name>}``.
+
+    Lets a mission disambiguate when several runners serve the same
+    (kind, type) routing key — e.g. OpenVLA and GR00T are both wildcard
+    training runners, and the model family isn't visible to the
+    registry. Non-string or empty values are ignored.
+    """
+    value = spec.config.get("runner")
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
 class MissionEngine:
     def __init__(
         self,
@@ -89,10 +103,15 @@ class MissionEngine:
         event_publisher: EventPublisher,
         working_dir: Path | None = None,
         providers: ProviderRegistry | None = None,
+        force_runner: str | None = None,
     ):
         self._persistence = persistence
         self._runners = runners
         self._publisher = event_publisher
+        # When set, every task dispatches to this runner regardless of
+        # task-level ``config: {runner: ...}`` overrides. The CLI sets
+        # it to "cpu_mock" for --use-mock-runner.
+        self._force_runner = force_runner
         # Per-mission working dirs live under here. Lazy-init to a tempdir
         # on first use if the caller didn't supply one — keeps tests cheap.
         self._working_dir = working_dir
@@ -252,7 +271,10 @@ class MissionEngine:
         )
 
         try:
-            runner = self._runners.select(task.spec)
+            runner = self._runners.select(
+                task.spec,
+                override=self._force_runner or _runner_override(task.spec),
+            )
         except NoRunnerForTaskError as e:
             await self._finalize_task(
                 mission,

--- a/src/odyssey/providers/huggingface/models.py
+++ b/src/odyssey/providers/huggingface/models.py
@@ -58,8 +58,17 @@ class HFModelProvider(ModelProvider):
         api = self._get_api()
         # model_info accepts revision=None and returns the latest commit
         # sha, which we then pin into the resolved record.
-        info = api.model_info(repo_id=ref.base, revision=ref.revision)
-        sha = getattr(info, "sha", None) or ref.revision
+        try:
+            info = api.model_info(repo_id=ref.base, revision=ref.revision)
+            sha = getattr(info, "sha", None) or ref.revision
+        except Exception:
+            # Hub unreachable (HF_HUB_OFFLINE / air-gapped) or a gated repo with
+            # no token: fall back to a cached revision and let the downstream
+            # loader resolve weights from the local HF cache. ``HEAD`` is a
+            # non-cached alias for the default branch, so map it to ``main`` so
+            # the cache lookup (refs/main) succeeds. Keeps training runnable
+            # offline once the base model is cached.
+            sha = ref.revision if (ref.revision and ref.revision != "HEAD") else "main"
         if not sha:
             raise RuntimeError(
                 f"HF model_info returned no sha for {ref.base!r}"
@@ -73,12 +82,27 @@ class HFModelProvider(ModelProvider):
         )
 
     async def fetch(self, resolved: ResolvedModel, dest: Path) -> Path:
+        import os
+
         try:
             from huggingface_hub import snapshot_download
         except ImportError as e:
             raise RuntimeError(
                 "HuggingFace fetch requires the 'huggingface' extra."
             ) from e
+
+        # Offline / air-gapped: resolve straight from the local HF cache. We
+        # avoid ``local_dir`` here because it triggers a network ``repo_info``
+        # call (which raises under HF_HUB_OFFLINE) plus a multi-GB copy; instead
+        # we hand the cached snapshot path to the downstream loader.
+        if os.getenv("HF_HUB_OFFLINE", "").lower() in ("1", "true", "yes"):
+            return Path(
+                snapshot_download(
+                    repo_id=resolved.identifier,
+                    revision=resolved.revision,
+                    local_files_only=True,
+                )
+            )
 
         dest.mkdir(parents=True, exist_ok=True)
         local_path = snapshot_download(

--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -2,6 +2,7 @@
 
 from odyssey.runners.base import WILDCARD_TYPE, Runner, TaskContext
 from odyssey.runners.cpu_mock import CPUMockRunner
+from odyssey.runners.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
 from odyssey.runners.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
 from odyssey.runners.registry import RunnerRegistry
 from odyssey.runners.subprocess import (
@@ -13,13 +14,16 @@ from odyssey.runners.subprocess import (
 __all__ = [
     "WILDCARD_TYPE",
     "CPUMockRunner",
+    "GR00TRunner",
     "LineParser",
     "OpenVLARunner",
     "Runner",
     "RunnerRegistry",
     "TaskContext",
     "TrainingProcessSpec",
+    "build_gr00t_argv",
     "build_openvla_argv",
+    "parse_gr00t_line",
     "parse_openvla_line",
     "run_training_subprocess",
 ]

--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -3,6 +3,7 @@
 from odyssey.runners.base import WILDCARD_TYPE, Runner, TaskContext
 from odyssey.runners.cpu_mock import CPUMockRunner
 from odyssey.runners.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
+from odyssey.runners.isaac_lab import IsaacLabRunner
 from odyssey.runners.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
 from odyssey.runners.registry import RunnerRegistry
 from odyssey.runners.subprocess import (
@@ -15,6 +16,7 @@ __all__ = [
     "WILDCARD_TYPE",
     "CPUMockRunner",
     "GR00TRunner",
+    "IsaacLabRunner",
     "LineParser",
     "OpenVLARunner",
     "Runner",

--- a/src/odyssey/runners/base.py
+++ b/src/odyssey/runners/base.py
@@ -14,14 +14,20 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from odyssey.engine.records import MissionRun, TaskRun
 from odyssey.providers.registry import ProviderRegistry
 from odyssey.spec.agents import AgentSpec
 from odyssey.spec.tasks import TaskKind
 from odyssey.telemetry.events import TaskEventType
 from odyssey.telemetry.publishers.base import EventPublisher
+
+if TYPE_CHECKING:
+    # Annotation-only: importing engine.records at runtime initializes
+    # the engine package, whose mission_engine imports this module right
+    # back — a cycle that bites when a runner module is the entry
+    # import. Guarded by tests/unit/test_imports.py.
+    from odyssey.engine.records import MissionRun, TaskRun
 
 # Sentinel meaning "this runner accepts any training_type / evaluation_type
 # value." Used by CPUMockRunner so a single registration covers every task

--- a/src/odyssey/runners/gr00t.py
+++ b/src/odyssey/runners/gr00t.py
@@ -171,9 +171,16 @@ def build_gr00t_argv(
     # Pass through remaining config keys as kebab-case flags. ``runner``
     # is the registry-override key, not an upstream flag.
     handled = {"base_model_path", "dataset_path", "runner"}
+    repo_path = os.getenv("ISAAC_GR00T_REPO_PATH", _DEFAULT_REPO_PATH)
     for key, value in _flatten_config(config):
         if key in handled:
             continue
+        # A relative ``modality_config_path`` resolves against the Isaac-GR00T
+        # checkout (same convention as the dataset ref). The NEW_EMBODIMENT tag
+        # *requires* a modality config file, so this lets a mission point at a
+        # repo-relative config (e.g. examples/SO100/so100_config.py) portably.
+        if key == "modality_config_path" and isinstance(value, str) and not os.path.isabs(value):
+            value = os.path.join(repo_path, value)
         argv += [f"--{key.replace('_', '-')}", str(value)]
     return argv
 

--- a/src/odyssey/runners/gr00t.py
+++ b/src/odyssey/runners/gr00t.py
@@ -1,0 +1,293 @@
+"""GR00T training runner.
+
+Fine-tunes an NVIDIA Isaac GR00T checkpoint (N1.7 family) by invoking
+the upstream ``gr00t.experiment.launch_finetune`` entry point as a
+subprocess — the Isaac-GR00T package must be installed in the
+environment (``pip install -e`` of https://github.com/NVIDIA/Isaac-GR00T).
+
+Mission ``config:`` keys map 1:1 onto the upstream CLI flags with
+underscores translated to dashes (``embodiment_tag`` →
+``--embodiment-tag``), the same passthrough pattern the OpenVLA runner
+uses for draccus flags.
+
+Routing: GR00T registers as a wildcard training runner *behind* OpenVLA,
+so it is selected explicitly via the task-level ``config: {runner: gr00t}``
+override (see ``examples/quickstart-gr00t/mission.yaml``). The eventual
+model-family-aware dispatch is a Lovell-platform concern; the explicit
+override is the OSS-local mechanism.
+
+Licensing note: GR00T checkpoints are distributed under NVIDIA's terms.
+This runner contains no NVIDIA code — it shells out to the user's own
+Isaac-GR00T checkout — but users must accept the upstream license to
+download the weights.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import (
+    WILDCARD_TYPE,
+    Runner,
+    TaskContext,
+)
+
+# Shared with the OpenVLA runner; extract to a common module when a
+# third runner needs them.
+from odyssey.runners.openvla import _flatten_config, _resolve_and_fetch_hf_model
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    output_path,
+    run_training_subprocess,
+)
+from odyssey.spec.refs import DatasetSource, HFModelRef
+from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
+
+logger = logging.getLogger(__name__)
+
+
+_ENTRY_MODULE = "gr00t.experiment.launch_finetune"
+_DEFAULT_REPO_PATH = "/srv/isaac-gr00t"
+
+# GR00T's finetune drives a HuggingFace Trainer, so stdout carries the
+# Trainer's dict-style log lines and tqdm progress bars:
+#   "{'loss': 0.693, 'grad_norm': 1.2, 'learning_rate': 1e-05, 'epoch': 0.25}"
+#   " 10%|█         | 100/1000 [00:42<06:18,  2.38it/s]"
+#   "Saving model checkpoint to ./checkpoint-500"
+_GR00T_LOSS_RE = re.compile(r"'loss':\s*([\d.eE+-]+)")
+_GR00T_EPOCH_RE = re.compile(r"'epoch':\s*([\d.]+)")
+_GR00T_TQDM_RE = re.compile(r"\b(\d+)/(\d+)\s*\[")
+_GR00T_SAVE_RE = re.compile(
+    r"(?i)(saving model checkpoint|model weights saved|saving.*(checkpoint|model))"
+)
+_GR00T_DATASET_RE = re.compile(
+    r"(?i)\b(loading|generating|building)\b.*\b(dataset|episodes|lerobot)\b"
+)
+_GR00T_LOAD_RE = re.compile(
+    r"(?i)\bloading\b.*\b(checkpoint|shards|weights|model|processor|tokenizer)\b"
+)
+
+
+def parse_gr00t_line(line: str) -> dict[str, Any] | None:
+    """Extract a progress-event dict from a GR00T finetune stdout line.
+
+    Public for tests and for users embedding GR00T stdout parsing in a
+    custom runner.
+    """
+    loss_match = _GR00T_LOSS_RE.search(line)
+    if loss_match:
+        payload: dict[str, Any] = {
+            "stage": "executing",
+            "step": "training_step",
+            "step_label": f"loss={loss_match.group(1)}",
+        }
+        epoch_match = _GR00T_EPOCH_RE.search(line)
+        if epoch_match:
+            payload["step_label"] += f" epoch={epoch_match.group(1)}"
+        return payload
+    tqdm_match = _GR00T_TQDM_RE.search(line)
+    if tqdm_match:
+        return {
+            "stage": "executing",
+            "step": "training_step",
+            "step_index": int(tqdm_match.group(1)),
+            "step_total": int(tqdm_match.group(2)),
+        }
+    if _GR00T_SAVE_RE.search(line):
+        return {"stage": "checkpoint_saving"}
+    if _GR00T_DATASET_RE.search(line):
+        return {"stage": "dataset_loading"}
+    if _GR00T_LOAD_RE.search(line):
+        return {"stage": "model_loading", "step": "load_artifacts"}
+    return None
+
+
+def _path_env_for_hf_id(hf_id: str) -> str | None:
+    """Convention: ``nvidia/GR00T-N1.7-3B`` → ``NVIDIA_GR00T_N1_7_3B_PATH``.
+
+    Same scheme as the OpenVLA runner, extended with ``.`` → ``_`` so
+    dotted GR00T version ids form valid env-var names.
+    """
+    slug = hf_id.replace("/", "_").replace("-", "_").replace(".", "_").upper()
+    return os.getenv(f"{slug}_PATH")
+
+
+def _resolve_dataset_path(task: TrainingTask) -> str | None:
+    """Resolve the task's dataset ref to a path/id for ``--dataset-path``.
+
+    Relative ``local`` refs resolve against ``$ISAAC_GR00T_REPO_PATH`` —
+    the quickstart points at the demo data shipped inside the
+    Isaac-GR00T checkout. Everything else (absolute paths, HF ids)
+    passes through for the upstream loader to interpret.
+    """
+    if task.dataset is None:
+        return None
+    ref = task.dataset.ref
+    if task.dataset.source == DatasetSource.LOCAL and not os.path.isabs(ref):
+        repo_path = os.getenv("ISAAC_GR00T_REPO_PATH", _DEFAULT_REPO_PATH)
+        return os.path.join(repo_path, ref)
+    return ref
+
+
+def build_gr00t_argv(
+    *,
+    task: TrainingTask,
+    agent_model_base: str | None,
+    output_dir: Path,
+) -> list[str]:
+    """Build the GR00T ``launch_finetune`` CLI argv.
+
+    Resolution order for ``--base-model-path``:
+      1. ``task.config["base_model_path"]`` (operator override, also
+         where the runner injects a starting checkpoint or fetched HF dir)
+      2. ``<HF_ID>_PATH`` env var derived from the agent's HF base id
+      3. ``agent_model_base`` itself (an HF hub id; first call triggers
+         a download by the upstream loader)
+    """
+    config = task.config or {}
+    base_model_path = (
+        config.get("base_model_path")
+        or (_path_env_for_hf_id(agent_model_base) if agent_model_base else None)
+        or agent_model_base
+    )
+    if not base_model_path:
+        raise RuntimeError(
+            "GR00T runner: cannot resolve base_model_path. The agent's "
+            "model must be a HuggingFace ref, or the runner must pre-fill "
+            "task.config['base_model_path'] from a starting checkpoint."
+        )
+
+    dataset_path = config.get("dataset_path") or _resolve_dataset_path(task)
+
+    argv: list[str] = ["--base-model-path", str(base_model_path)]
+    if dataset_path:
+        argv += ["--dataset-path", str(dataset_path)]
+    argv += ["--output-dir", str(output_dir)]
+
+    # Pass through remaining config keys as kebab-case flags. ``runner``
+    # is the registry-override key, not an upstream flag.
+    handled = {"base_model_path", "dataset_path", "runner"}
+    for key, value in _flatten_config(config):
+        if key in handled:
+            continue
+        argv += [f"--{key.replace('_', '-')}", str(value)]
+    return argv
+
+
+def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
+    """Locate the trained checkpoint under ``--output-dir``.
+
+    The Trainer saves the final model at the output root (``config.json``
+    plus weights); intermediate saves land in ``checkpoint-<step>/``
+    subdirs. Prefer the root; fall back to the newest checkpoint dir.
+    The fetched HF base model lives in ``base_model/`` and is never a
+    candidate.
+    """
+    if not output_dir.is_dir():
+        return None
+    marker_files = ("config.json", "model.safetensors")
+    if any((output_dir / fname).is_file() for fname in marker_files):
+        return output_dir
+    candidates = [
+        entry
+        for entry in output_dir.iterdir()
+        if entry.is_dir()
+        and entry.name.startswith("checkpoint-")
+        and any((entry / fname).is_file() for fname in marker_files)
+    ]
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return candidates[0]
+
+
+class GR00TRunner(Runner):
+    """Fine-tune a GR00T model. Subprocess-based — actual training
+    happens in the upstream ``launch_finetune`` entry point."""
+
+    @property
+    def name(self) -> str:
+        return "gr00t"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING}
+
+    @property
+    def supported_types(self) -> set[str]:
+        # Registered behind OpenVLA's wildcard; reached via the
+        # task-level ``config: {runner: gr00t}`` override.
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, TrainingTask):
+            raise TypeError(
+                f"GR00TRunner expects TrainingTask, got {type(spec).__name__}"
+            )
+        if context.agent is None:
+            raise RuntimeError(
+                "GR00TRunner: TaskContext.agent is None — training tasks "
+                "must be invoked through the engine, which resolves the "
+                "agent from spec.robot.agents[task.agent_id]."
+            )
+
+        output_dir = output_path(context)
+
+        # Decide what base_model_path the subprocess starts from — same
+        # ladder as the OpenVLA runner: prior checkpoint, then provider
+        # fetch of the agent's HF ref, then env-var / HF-id fallback
+        # inside build_gr00t_argv.
+        config = dict(spec.config)
+        agent_model_base: str | None = None
+        if context.starting_checkpoint is not None:
+            config.setdefault("base_model_path", context.starting_checkpoint)
+        elif (
+            context.providers is not None
+            and isinstance(context.agent.model, HFModelRef)
+        ):
+            resolved_path = await _resolve_and_fetch_hf_model(
+                context, context.agent.model, output_dir / "base_model"
+            )
+            config.setdefault("base_model_path", str(resolved_path))
+
+        if isinstance(context.agent.model, HFModelRef):
+            agent_model_base = context.agent.model.base
+
+        process_spec = TrainingProcessSpec(
+            entry_module=_ENTRY_MODULE,
+            argv_extra=build_gr00t_argv(
+                task=spec.model_copy(update={"config": config}),
+                agent_model_base=agent_model_base,
+                output_dir=output_dir,
+            ),
+            line_parser=parse_gr00t_line,
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("GR00T task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"gr00t launch_finetune exited with code {rc}")
+
+        checkpoint = _resolve_output_checkpoint(output_dir)
+        if checkpoint is None:
+            raise RuntimeError(
+                f"gr00t launch_finetune finished but no checkpoint found "
+                f"under {output_dir!r}"
+            )
+        return {
+            "checkpoint_path": str(checkpoint),
+            "agent_id": context.agent.id,
+            "training_config": spec.config,
+            "training_type": (
+                spec.training_type.value
+                if isinstance(spec.training_type, TrainingType)
+                else spec.training_type
+            ),
+        }

--- a/src/odyssey/runners/isaac_lab.py
+++ b/src/odyssey/runners/isaac_lab.py
@@ -1,0 +1,281 @@
+"""Isaac Lab evaluation runner — subprocess contract.
+
+Unlike the in-process Robosuite runner, Isaac Lab evaluation must run
+as a subprocess: Isaac Lab scripts execute under Isaac Sim's bundled
+Python (``isaaclab.sh -p``) and boot the Omniverse kit app, neither of
+which can live inside Odyssey's process or dependency set.
+
+The runner therefore launches an *eval script* inside the user's Isaac
+Lab installation and consumes a small JSON-line protocol on stdout.
+The script itself is the pluggable piece — the slot where a blessed
+GR00T/VLA evaluation recipe lands (see the GR00T integration issue) —
+Odyssey owns the launch, the protocol, cancellation, and scoring.
+
+Launch contract::
+
+    ${ISAACLAB_PATH}/isaaclab.sh -p <eval_script> \\
+        --task <benchmark_name> --num_episodes <N> \\
+        --checkpoint <path> --headless [--<config-key> <value> ...]
+
+``eval_script`` comes from ``task.config["eval_script"]`` or
+``$ISAACLAB_EVAL_SCRIPT``. When ``$ISAACLAB_PATH`` is unset the script
+runs under plain ``python`` (an env where ``isaaclab`` is importable).
+
+Stdout protocol (other lines are ignored; Isaac Sim boot noise is
+expected)::
+
+    ODYSSEY_EPISODE {"index": 1, "total": 10, "success": true, "return": 1.5}
+    ODYSSEY_RESULT {"success_rate": 0.4, "performance_score": 0.7, "metrics": {}}
+
+``ODYSSEY_RESULT`` is optional — when absent, the summary is computed
+from the episode lines.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import Runner, TaskContext
+
+# Shared eval helpers; extract to a common module when a third
+# evaluation runner needs them.
+from odyssey.runners.robosuite import _grade, _resolve_eval_checkpoint
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    run_training_subprocess,
+)
+from odyssey.spec.tasks import EvaluationTask, EvaluationType, TaskKind
+
+logger = logging.getLogger(__name__)
+
+
+_EPISODE_PREFIX = "ODYSSEY_EPISODE "
+_RESULT_PREFIX = "ODYSSEY_RESULT "
+
+# Config keys consumed by the runner itself, never forwarded as flags.
+_HANDLED_CONFIG_KEYS = {"eval_script", "runner", "headless"}
+
+
+class EvalProtocolCollector:
+    """Parses the ODYSSEY_* stdout protocol while collecting results.
+
+    Doubles as the subprocess ``line_parser``: each parsed episode is
+    recorded *and* turned into a progress event. Malformed protocol
+    lines are logged and skipped — a single bad line never fails the
+    eval.
+    """
+
+    def __init__(self) -> None:
+        self.episodes: list[dict[str, Any]] = []
+        self.result: dict[str, Any] | None = None
+
+    def parse(self, line: str) -> dict[str, Any] | None:
+        stripped = line.strip()
+        if stripped.startswith(_EPISODE_PREFIX):
+            payload = self._load_json(stripped[len(_EPISODE_PREFIX):])
+            if payload is None:
+                return None
+            self.episodes.append(payload)
+            success = bool(payload.get("success"))
+            event: dict[str, Any] = {
+                "stage": "executing",
+                "step": "episode_complete",
+                "step_label": f"episode: {'PASS' if success else 'FAIL'}",
+            }
+            index = payload.get("index")
+            total = payload.get("total")
+            if isinstance(index, int):
+                event["step_index"] = index
+            if isinstance(total, int):
+                event["step_total"] = total
+            return event
+        if stripped.startswith(_RESULT_PREFIX):
+            payload = self._load_json(stripped[len(_RESULT_PREFIX):])
+            if payload is None:
+                return None
+            self.result = payload
+            return {"stage": "executing", "step": "result_received"}
+        return None
+
+    @staticmethod
+    def _load_json(raw: str) -> dict[str, Any] | None:
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Malformed ODYSSEY_* protocol line skipped: %r", raw)
+            return None
+        if not isinstance(payload, dict):
+            logger.warning("ODYSSEY_* payload is not an object: %r", raw)
+            return None
+        return payload
+
+
+def resolve_eval_script(config: dict[str, Any]) -> str:
+    """``task.config["eval_script"]`` or ``$ISAACLAB_EVAL_SCRIPT``."""
+    script = config.get("eval_script") or os.getenv("ISAACLAB_EVAL_SCRIPT")
+    if not script:
+        raise RuntimeError(
+            "Isaac Lab eval requires an eval script: set "
+            "task.config['eval_script'] (or $ISAACLAB_EVAL_SCRIPT) to a "
+            "script that runs the benchmark and prints the ODYSSEY_EPISODE "
+            "/ ODYSSEY_RESULT stdout protocol. See "
+            "src/odyssey/runners/isaac_lab.py for the contract."
+        )
+    return str(script)
+
+
+def resolve_launcher() -> list[str] | None:
+    """``[$ISAACLAB_PATH/isaaclab.sh, -p]`` when the env var is set.
+
+    None means plain ``python`` — fine for environments where
+    ``isaaclab`` is importable directly (and for tests).
+    """
+    isaaclab_path = os.getenv("ISAACLAB_PATH")
+    if not isaaclab_path:
+        return None
+    return [os.path.join(isaaclab_path, "isaaclab.sh"), "-p"]
+
+
+def build_isaac_lab_argv(
+    *,
+    task: EvaluationTask,
+    checkpoint: Path,
+) -> list[str]:
+    """Build the eval script's argv per the launch contract.
+
+    Isaac Lab scripts use argparse with snake_case flags, so config
+    keys pass through verbatim (``num_envs`` → ``--num_envs``), unlike
+    the kebab-case training runners.
+    """
+    config = task.config or {}
+    argv: list[str] = [
+        "--task", task.benchmark_name,
+        "--num_episodes", str(task.num_episodes),
+        "--checkpoint", str(checkpoint),
+    ]
+    if config.get("headless", True):
+        argv.append("--headless")
+    for key, value in config.items():
+        if key in _HANDLED_CONFIG_KEYS:
+            continue
+        argv += [f"--{key}", str(value)]
+    return argv
+
+
+def summarize(
+    *,
+    collector: EvalProtocolCollector,
+    spec: EvaluationTask,
+    checkpoint: Path,
+    eval_script: str,
+) -> dict[str, Any]:
+    """Build the result_summary from collected protocol output.
+
+    Same shape as the Robosuite runner (what lai-trainer's
+    ``update_evaluation_results`` expects). An explicit ODYSSEY_RESULT
+    wins; otherwise the summary is computed from the episode lines.
+    """
+    episodes = collector.episodes
+    successes = sum(1 for e in episodes if e.get("success"))
+    episode_returns = [float(e.get("return", 0.0)) for e in episodes]
+    attempted = len(episodes)
+
+    if collector.result is not None:
+        result = collector.result
+        success_rate = float(
+            result.get(
+                "success_rate", (successes / attempted) if attempted else 0.0
+            )
+        )
+        performance_score = float(result.get("performance_score", success_rate))
+        metrics = dict(result.get("metrics") or {})
+        num_episodes = int(result.get("num_episodes", attempted or spec.num_episodes))
+    elif attempted:
+        success_rate = successes / attempted
+        performance_score = sum(episode_returns) / attempted
+        metrics = {}
+        num_episodes = attempted
+    else:
+        raise RuntimeError(
+            "Isaac Lab eval script completed without emitting any "
+            "ODYSSEY_EPISODE or ODYSSEY_RESULT lines — it does not speak "
+            "the protocol. See src/odyssey/runners/isaac_lab.py."
+        )
+
+    metrics.setdefault("successes", successes)
+    metrics.setdefault(
+        "episode_returns", [round(r, 4) for r in episode_returns]
+    )
+    metrics.setdefault("benchmark", spec.benchmark_name)
+    metrics.setdefault("checkpoint_path", str(checkpoint))
+    metrics.setdefault("eval_script", eval_script)
+    return {
+        "num_episodes": num_episodes,
+        "success_rate": round(success_rate, 4),
+        "performance_score": round(performance_score, 4),
+        "letter_grade": _grade(success_rate),
+        "passed": success_rate >= 0.5,
+        "metrics": metrics,
+    }
+
+
+class IsaacLabRunner(Runner):
+    """Evaluation runner for ``evaluation_type: isaac_lab`` tasks."""
+
+    @property
+    def name(self) -> str:
+        return "isaac_lab"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.EVALUATION}
+
+    @property
+    def supported_types(self) -> set[str]:
+        return {EvaluationType.ISAAC_LAB.value}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, EvaluationTask):
+            raise TypeError(
+                f"IsaacLabRunner expects EvaluationTask, got {type(spec).__name__}"
+            )
+
+        checkpoint = _resolve_eval_checkpoint(context)
+        eval_script = resolve_eval_script(spec.config or {})
+        launcher = resolve_launcher()
+
+        await context.emit_progress(
+            "executing",
+            step="env_construct",
+            step_label=(
+                f"benchmark={spec.benchmark_name} "
+                f"launcher={'isaaclab.sh' if launcher else 'python'}"
+            ),
+        )
+
+        collector = EvalProtocolCollector()
+        process_spec = TrainingProcessSpec(
+            script_path=eval_script,
+            launcher=launcher,
+            argv_extra=build_isaac_lab_argv(task=spec, checkpoint=checkpoint),
+            line_parser=collector.parse,
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("Isaac Lab task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"Isaac Lab eval script exited with code {rc}")
+
+        return summarize(
+            collector=collector,
+            spec=spec,
+            checkpoint=checkpoint,
+            eval_script=eval_script,
+        )

--- a/src/odyssey/runners/registry.py
+++ b/src/odyssey/runners/registry.py
@@ -14,7 +14,6 @@ Selection order:
 
 from __future__ import annotations
 
-from odyssey.engine.errors import NoRunnerForTaskError
 from odyssey.runners.base import WILDCARD_TYPE, Runner
 from odyssey.spec.tasks import EvaluationTask, TaskKind, TaskSpec, TrainingTask
 
@@ -31,6 +30,12 @@ class RunnerRegistry:
                 self._by_key.setdefault((kind, type_value), []).append(runner)
 
     def select(self, task: TaskSpec, *, override: str | None = None) -> Runner:
+        # Imported at call time: the error belongs to the engine's
+        # exception hierarchy, but a module-level import would cycle
+        # (runners package init → registry → engine package init →
+        # mission_engine → runners). Guarded by tests/unit/test_imports.py.
+        from odyssey.engine.errors import NoRunnerForTaskError
+
         if override is not None:
             if override in self._by_name:
                 return self._by_name[override]

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -43,6 +43,8 @@ to ``ctx.emit_progress(**kwargs)``, or ``None`` to skip emitting.
 class TrainingProcessSpec:
     """How to launch a specific family's training subprocess.
 
+    Also used by subprocess-shaped evaluation runners (Isaac Lab).
+
     Exactly one of ``entry_module`` or ``script_path`` must be set:
       * ``entry_module`` invokes ``python -m <module>`` (suitable for
         packages like ``gr00t.experiment.launch_train`` or
@@ -59,12 +61,22 @@ class TrainingProcessSpec:
     line_parser: LineParser | None = None
     cwd: str | None = None
     sigterm_grace_seconds: float = 30.0
+    # Optional command prefix replacing the default ``python`` for
+    # ``script_path`` invocations — e.g. ["/path/isaaclab.sh", "-p"] so
+    # the script runs under Isaac Sim's bundled interpreter. Not valid
+    # with ``entry_module`` (the ``-m`` form assumes a python launcher).
+    launcher: list[str] | None = None
 
     def __post_init__(self) -> None:
         if (self.entry_module is None) == (self.script_path is None):
             raise ValueError(
                 "TrainingProcessSpec requires exactly one of "
                 "entry_module or script_path"
+            )
+        if self.launcher is not None and self.entry_module is not None:
+            raise ValueError(
+                "TrainingProcessSpec.launcher only applies to script_path "
+                "invocations"
             )
 
 
@@ -83,7 +95,8 @@ async def run_training_subprocess(
     else:
         # script_path is guaranteed by __post_init__
         assert spec.script_path is not None
-        cmd = ["python", spec.script_path, *spec.argv_extra]
+        prefix = spec.launcher if spec.launcher is not None else ["python"]
+        cmd = [*prefix, spec.script_path, *spec.argv_extra]
     env = {**os.environ, **spec.env}
 
     logger.info(

--- a/src/odyssey/spec/agents.py
+++ b/src/odyssey/spec/agents.py
@@ -1,11 +1,10 @@
 """Agent definitions on a robot.
 
 In the Lovell architecture, a robot is an embodiment plus a loadout of
-agents (see the robot-brain paper). Each agent has an id, a role
-(PILOT or SPECIALIST), and an underlying model checkpoint. The brain
-paper describes the full agent shape — persona, goals, success
-criteria, materialized artifacts — that v0.0.x ``AgentSpec`` does not
-yet model.
+agents. Each agent has an id, a role (PILOT or SPECIALIST), and an
+underlying model checkpoint. Future versions will extend ``AgentSpec``
+with additional fields (persona, goals, success criteria, materialized
+artifacts).
 
 What v0.0.x ships: enough of the agent shape that training tasks can
 reference an agent and the framework can look up that agent's starting

--- a/src/odyssey/spec/mission.py
+++ b/src/odyssey/spec/mission.py
@@ -56,9 +56,8 @@ class RobotSpec(BaseModel):
     today is the PILOT (running a Vision-Language-Action model with
     physical authority over the actuators).
 
-    See the Lovell robot-brain paper for the fuller agent shape that
-    v0.0.x's ``AgentSpec`` does not yet model (persona, goals, success
-    criteria, materialized artifacts).
+    Future versions will extend ``AgentSpec`` with additional fields
+    (persona, goals, success criteria, materialized artifacts).
     """
 
     embodiment: str | None = None

--- a/tests/conformance/test_gr00t_upstream.py
+++ b/tests/conformance/test_gr00t_upstream.py
@@ -1,0 +1,119 @@
+"""Conformance tests against a real Isaac-GR00T checkout.
+
+The GR00T runner's CLI surface was derived from NVIDIA's docs; these
+tests pin it against the actual upstream source so drift shows up as a
+red test instead of a failed training run on a rented GPU.
+
+Env-gated: set ``ISAAC_GR00T_REPO_PATH`` to an Isaac-GR00T checkout to
+enable (skipped otherwise, so CI without the checkout stays green).
+The upstream config is inspected via ``ast`` — no ``gr00t`` install or
+GPU is needed.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+from odyssey.runners.gr00t import _ENTRY_MODULE, build_gr00t_argv
+from odyssey.spec import TrainingTask
+from odyssey.spec.loader import load_mission
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+QUICKSTART = REPO_ROOT / "examples" / "quickstart-gr00t" / "mission.yaml"
+
+ISAAC_GR00T_REPO = os.getenv("ISAAC_GR00T_REPO_PATH")
+
+pytestmark = pytest.mark.skipif(
+    not ISAAC_GR00T_REPO,
+    reason="ISAAC_GR00T_REPO_PATH not set — Isaac-GR00T conformance skipped",
+)
+
+
+def _repo() -> Path:
+    assert ISAAC_GR00T_REPO is not None  # guarded by pytestmark
+    return Path(ISAAC_GR00T_REPO)
+
+
+def _upstream_finetune_fields() -> set[str]:
+    """Field names of upstream FinetuneConfig, discovered via ast.
+
+    tyro turns each dataclass field into a kebab-case CLI flag, so
+    these are the complete legal flag surface of launch_finetune.
+    """
+    config_path = _repo() / "gr00t" / "configs" / "finetune_config.py"
+    assert config_path.is_file(), (
+        f"Upstream layout changed: {config_path} not found — the runner's "
+        "entry assumptions need re-validation."
+    )
+    tree = ast.parse(config_path.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "FinetuneConfig":
+            return {
+                stmt.target.id
+                for stmt in node.body
+                if isinstance(stmt, ast.AnnAssign)
+                and isinstance(stmt.target, ast.Name)
+            }
+    raise AssertionError(
+        "FinetuneConfig class not found in upstream finetune_config.py"
+    )
+
+
+def _quickstart_training_task() -> TrainingTask:
+    mission = load_mission(QUICKSTART)
+    task = mission.tasks[0]
+    assert isinstance(task, TrainingTask)
+    return task
+
+
+def test_entry_module_exists_upstream() -> None:
+    module_path = _repo().joinpath(*_ENTRY_MODULE.split(".")).with_suffix(".py")
+    assert module_path.is_file(), (
+        f"Runner entry module {_ENTRY_MODULE!r} has no source file at "
+        f"{module_path} — upstream moved the finetune entrypoint."
+    )
+
+
+def test_quickstart_demo_dataset_ships_in_repo() -> None:
+    task = _quickstart_training_task()
+    assert task.dataset is not None
+    dataset_dir = _repo() / task.dataset.ref
+    assert dataset_dir.is_dir(), (
+        f"Quickstart dataset ref {task.dataset.ref!r} not found in the "
+        "Isaac-GR00T checkout — pick a demo set that ships upstream."
+    )
+
+
+def test_quickstart_argv_flags_all_exist_upstream() -> None:
+    """Every flag the runner emits for the shipped quickstart must be a
+    real FinetuneConfig field — tyro rejects unknown flags."""
+    fields = _upstream_finetune_fields()
+    argv = build_gr00t_argv(
+        task=_quickstart_training_task(),
+        agent_model_base="nvidia/GR00T-N1.7-3B",
+        output_dir=Path("/tmp/out"),
+    )
+    flags = [arg for arg in argv if arg.startswith("--")]
+    unknown = [
+        flag for flag in flags
+        if flag.removeprefix("--").replace("-", "_") not in fields
+    ]
+    assert not unknown, (
+        f"Runner emits flags with no upstream FinetuneConfig field: "
+        f"{unknown}. Upstream fields: {sorted(fields)}"
+    )
+
+
+def test_core_contract_fields_exist_upstream() -> None:
+    """The fields the runner injects itself (not user passthrough)."""
+    fields = _upstream_finetune_fields()
+    required = {"base_model_path", "dataset_path", "output_dir"}
+    missing = required - fields
+    assert not missing, (
+        f"Upstream FinetuneConfig lost core fields the runner relies on: "
+        f"{sorted(missing)}"
+    )

--- a/tests/integration/test_cli_run.py
+++ b/tests/integration/test_cli_run.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from odyssey.cli.main import cli
@@ -18,9 +19,17 @@ from odyssey.persistence import SqlitePersistence
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_MISSION = REPO_ROOT / "examples" / "quickstart-openvla" / "mission.yaml"
+EXAMPLE_MISSION_GR00T = REPO_ROOT / "examples" / "quickstart-gr00t" / "mission.yaml"
 
 
-def test_run_example_with_mock_runner_succeeds(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "mission_path",
+    [EXAMPLE_MISSION, EXAMPLE_MISSION_GR00T],
+    ids=["quickstart-openvla", "quickstart-gr00t"],
+)
+def test_run_example_with_mock_runner_succeeds(
+    tmp_path: Path, mission_path: Path
+) -> None:
     db_path = tmp_path / "missions.db"
     work_dir = tmp_path / "runs"
     runner = CliRunner()
@@ -28,7 +37,7 @@ def test_run_example_with_mock_runner_succeeds(tmp_path: Path) -> None:
         cli,
         [
             "run",
-            str(EXAMPLE_MISSION),
+            str(mission_path),
             "--use-mock-runner",
             "--db",
             str(db_path),

--- a/tests/unit/test_engine.py
+++ b/tests/unit/test_engine.py
@@ -311,3 +311,104 @@ async def test_start_already_started_raises() -> None:
     await engine.start_mission(run.id)  # now COMPLETED
     with pytest.raises(InvalidStateTransitionError):
         await engine.start_mission(run.id)
+
+
+# ---------------------------------------------------------------------------
+# Runner selection: task-level override + engine force_runner
+# ---------------------------------------------------------------------------
+
+class _CountingRunner(Runner):
+    """Wildcard runner that counts how many tasks it executed."""
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+        self.ran = 0
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING, TaskKind.EVALUATION}
+
+    @property
+    def supported_types(self) -> set[str]:
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        self.ran += 1
+        # Eval-shaped summary so mission grading has what it needs.
+        return {
+            "runner": self._name,
+            "success_rate": 1.0,
+            "performance_score": 1.0,
+            "passed": True,
+        }
+
+
+async def _make_engine_with_runners(
+    *runners: Runner, force_runner: str | None = None
+) -> MissionEngine:
+    registry = RunnerRegistry()
+    for runner in runners:
+        registry.register(runner)
+    engine = MissionEngine(
+        persistence=InMemoryPersistence(),
+        runners=registry,
+        event_publisher=CapturingPublisher(),
+        force_runner=force_runner,
+    )
+    await engine.initialize()
+    return engine
+
+
+async def test_task_config_runner_override_selects_named_runner() -> None:
+    # Two wildcard runners: first registered wins by default, but a
+    # task-level ``config: {runner: ...}`` reroutes that task.
+    default = _CountingRunner("default")
+    special = _CountingRunner("special")
+    engine = await _make_engine_with_runners(default, special)
+
+    spec = _spec()
+    spec.tasks[0].config["runner"] = "special"  # training task only
+    run = await engine.create_mission(spec)
+    final = await engine.start_mission(run.id)
+
+    assert final.status == MissionStatus.COMPLETED
+    assert special.ran == 1  # the training task
+    assert default.ran == 1  # the eval task (no override)
+
+
+async def test_force_runner_beats_task_override() -> None:
+    # --use-mock-runner semantics: the forced runner takes every task,
+    # even when the spec names another runner.
+    default = _CountingRunner("default")
+    special = _CountingRunner("special")
+    engine = await _make_engine_with_runners(
+        default, special, force_runner="default"
+    )
+
+    spec = _spec()
+    spec.tasks[0].config["runner"] = "special"
+    run = await engine.create_mission(spec)
+    final = await engine.start_mission(run.id)
+
+    assert final.status == MissionStatus.COMPLETED
+    assert default.ran == 2
+    assert special.ran == 0
+
+
+async def test_unknown_runner_override_fails_task() -> None:
+    default = _CountingRunner("default")
+    engine = await _make_engine_with_runners(default)
+
+    spec = _spec()
+    spec.tasks[0].config["runner"] = "does-not-exist"
+    run = await engine.create_mission(spec)
+    final = await engine.start_mission(run.id)
+
+    assert final.status == MissionStatus.FAILED
+    failed = [t for t in final.tasks if t.status == TaskStatus.FAILED]
+    assert len(failed) == 1
+    assert failed[0].error_code == "no_runner_registered"

--- a/tests/unit/test_gr00t.py
+++ b/tests/unit/test_gr00t.py
@@ -93,6 +93,29 @@ def test_argv_resolves_relative_local_dataset_against_repo(
     assert argv[idx + 1] == "/opt/isaac-gr00t/demo_data/cube_to_bowl_5"
 
 
+def test_argv_resolves_relative_modality_config_against_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # NEW_EMBODIMENT finetunes require a modality config file; a relative ref
+    # resolves against the Isaac-GR00T checkout, exactly like the dataset ref.
+    monkeypatch.setenv("ISAAC_GR00T_REPO_PATH", "/opt/isaac-gr00t")
+    task = _task(config={"modality_config_path": "examples/SO100/so100_config.py"})
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--modality-config-path")
+    assert argv[idx + 1] == "/opt/isaac-gr00t/examples/SO100/so100_config.py"
+
+
+def test_argv_passes_absolute_modality_config_unchanged(tmp_path: Path) -> None:
+    task = _task(config={"modality_config_path": "/abs/cfg.py"})
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--modality-config-path")
+    assert argv[idx + 1] == "/abs/cfg.py"
+
+
 def test_argv_passes_absolute_local_dataset_unchanged(tmp_path: Path) -> None:
     task = _task(
         dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/my_episodes"),

--- a/tests/unit/test_gr00t.py
+++ b/tests/unit/test_gr00t.py
@@ -1,0 +1,179 @@
+"""Tests for the GR00T runner's argv builder + stdout parser.
+
+We don't invoke the real ``launch_finetune`` — that requires the
+Isaac-GR00T package, torch with CUDA, and a GPU. The testable pieces are
+the construction of the CLI argv from a TrainingTask spec (with the
+agent's model base passed alongside) and the parser that turns the
+HF-Trainer-style stdout into progress events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.runners.gr00t import build_gr00t_argv, parse_gr00t_line
+from odyssey.spec import DatasetRef, DatasetSource, TrainingTask, TrainingType
+
+
+def _task(**overrides: Any) -> TrainingTask:
+    fields: dict[str, Any] = {
+        "name": "finetune",
+        "training_type": TrainingType.DEMONSTRATION,
+        "agent_id": "pilot",
+    }
+    fields.update(overrides)
+    return TrainingTask(**fields)
+
+
+HF_BASE = "nvidia/GR00T-N1.7-3B"
+
+
+# ---------------------------------------------------------------------------
+# argv builder
+# ---------------------------------------------------------------------------
+
+def test_argv_uses_agent_model_base_when_no_override(tmp_path: Path) -> None:
+    argv = build_gr00t_argv(
+        task=_task(), agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--base-model-path")
+    assert argv[idx + 1] == HF_BASE
+
+
+def test_argv_prefers_config_base_model_path(tmp_path: Path) -> None:
+    task = _task(config={"base_model_path": "/local/gr00t-n1.7-3b"})
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--base-model-path")
+    assert argv[idx + 1] == "/local/gr00t-n1.7-3b"
+
+
+def test_argv_uses_env_var_when_no_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Dots in the version id map to underscores in the env-var name.
+    monkeypatch.setenv("NVIDIA_GR00T_N1_7_3B_PATH", "/env/gr00t-n1.7-3b")
+    argv = build_gr00t_argv(
+        task=_task(), agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--base-model-path")
+    assert argv[idx + 1] == "/env/gr00t-n1.7-3b"
+
+
+def test_argv_errors_when_nothing_resolvable(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="base_model_path"):
+        build_gr00t_argv(task=_task(), agent_model_base=None, output_dir=tmp_path)
+
+
+def test_argv_includes_output_dir(tmp_path: Path) -> None:
+    argv = build_gr00t_argv(
+        task=_task(), agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--output-dir")
+    assert argv[idx + 1] == str(tmp_path)
+
+
+def test_argv_resolves_relative_local_dataset_against_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ISAAC_GR00T_REPO_PATH", "/opt/isaac-gr00t")
+    task = _task(
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="demo_data/cube_to_bowl_5"
+        ),
+    )
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--dataset-path")
+    assert argv[idx + 1] == "/opt/isaac-gr00t/demo_data/cube_to_bowl_5"
+
+
+def test_argv_passes_absolute_local_dataset_unchanged(tmp_path: Path) -> None:
+    task = _task(
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/my_episodes"),
+    )
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--dataset-path")
+    assert argv[idx + 1] == "/data/my_episodes"
+
+
+def test_argv_passes_hf_dataset_ref_through(tmp_path: Path) -> None:
+    task = _task(
+        dataset=DatasetRef(
+            source=DatasetSource.HUGGINGFACE, ref="nvidia/some-lerobot-set"
+        ),
+    )
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--dataset-path")
+    assert argv[idx + 1] == "nvidia/some-lerobot-set"
+
+
+def test_argv_passthrough_is_kebab_case(tmp_path: Path) -> None:
+    task = _task(config={"embodiment_tag": "new_embodiment", "max_steps": 1000})
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    idx = argv.index("--embodiment-tag")
+    assert argv[idx + 1] == "new_embodiment"
+    idx = argv.index("--max-steps")
+    assert argv[idx + 1] == "1000"
+
+
+def test_argv_excludes_runner_routing_key(tmp_path: Path) -> None:
+    task = _task(config={"runner": "gr00t", "max_steps": 10})
+    argv = build_gr00t_argv(
+        task=task, agent_model_base=HF_BASE, output_dir=tmp_path
+    )
+    assert "--runner" not in argv
+
+
+# ---------------------------------------------------------------------------
+# stdout parser
+# ---------------------------------------------------------------------------
+
+def test_parse_trainer_loss_line() -> None:
+    line = "{'loss': 0.6931, 'grad_norm': 1.21, 'learning_rate': 1e-05, 'epoch': 0.25}"
+    event = parse_gr00t_line(line)
+    assert event is not None
+    assert event["stage"] == "executing"
+    assert event["step"] == "training_step"
+    assert "loss=0.6931" in event["step_label"]
+    assert "epoch=0.25" in event["step_label"]
+
+
+def test_parse_tqdm_progress_line() -> None:
+    event = parse_gr00t_line(" 10%|█         | 100/1000 [00:42<06:18,  2.38it/s]")
+    assert event is not None
+    assert event["step_index"] == 100
+    assert event["step_total"] == 1000
+
+
+def test_parse_checkpoint_save_line() -> None:
+    event = parse_gr00t_line("Saving model checkpoint to ./out/checkpoint-500")
+    assert event is not None
+    assert event["stage"] == "checkpoint_saving"
+
+
+def test_parse_dataset_loading_line() -> None:
+    event = parse_gr00t_line("Loading LeRobot dataset from demo_data/cube_to_bowl_5")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+
+
+def test_parse_model_loading_line() -> None:
+    event = parse_gr00t_line("Loading checkpoint shards: 100%")
+    assert event is not None
+    assert event["stage"] == "model_loading"
+
+
+def test_parse_unrelated_line_returns_none() -> None:
+    assert parse_gr00t_line("nothing interesting here") is None

--- a/tests/unit/test_hf_providers.py
+++ b/tests/unit/test_hf_providers.py
@@ -86,6 +86,23 @@ async def test_model_resolve_raises_when_api_returns_no_sha() -> None:
         await provider.resolve(HFModelRef(base="x/y"))
 
 
+async def test_model_resolve_falls_back_when_hub_unreachable() -> None:
+    # Offline / air-gapped (or a gated repo with no token): model_info raises,
+    # and resolve falls back to a cache-resolvable revision instead of failing
+    # — HEAD maps to ``main`` (no cached ``HEAD`` ref); a concrete pin is kept.
+    class _OfflineApi:
+        def model_info(self, repo_id: str, revision: str | None = None) -> Any:
+            raise OSError("offline mode is enabled")
+
+    provider = HFModelProvider(api=_OfflineApi())
+    resolved = await provider.resolve(
+        HFModelRef(base="nvidia/GR00T-N1.7-3B", revision="HEAD")
+    )
+    assert resolved.revision == "main"
+    pinned = await provider.resolve(HFModelRef(base="x/y", revision="v9"))
+    assert pinned.revision == "v9"
+
+
 def test_model_provider_lazy_imports_hf() -> None:
     # Constructor without api should not raise; the import only happens
     # when a method is called and api is None.

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -1,0 +1,43 @@
+"""Import-order regression tests.
+
+Each public module must be importable as the *first* odyssey import in
+a fresh interpreter. In-process tests can't check this (modules cache
+after the first test imports anything), so these spawn a clean child
+interpreter per module.
+
+Regression: ``odyssey.runners.base`` imported ``odyssey.engine.records``
+at runtime, which initialized the engine package, whose
+``mission_engine`` imports ``runners.base`` right back — a cycle that
+only bit when a runner module was the entry import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+ENTRY_MODULES = [
+    "odyssey.runners.base",
+    "odyssey.runners.gr00t",
+    "odyssey.runners.isaac_lab",
+    "odyssey.runners.openvla",
+    "odyssey.runners.robosuite",
+    "odyssey.engine",
+    "odyssey.spec",
+    "odyssey.cli.main",
+]
+
+
+@pytest.mark.parametrize("module", ENTRY_MODULES)
+def test_module_imports_clean_as_first_import(module: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module}"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"`import {module}` failed in a fresh interpreter:\n{result.stderr}"
+    )

--- a/tests/unit/test_isaac_lab.py
+++ b/tests/unit/test_isaac_lab.py
@@ -1,0 +1,281 @@
+"""Tests for the Isaac Lab evaluation runner.
+
+No Isaac Sim here — the runner's testable pieces are the launch
+contract (argv, script/launcher resolution), the ODYSSEY_* stdout
+protocol collector, and summary scoring. One integration-ish test runs
+a fake eval script (plain python printing protocol lines) through the
+real subprocess machinery end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.engine import TaskStatus
+from odyssey.engine.records import MissionRun
+from odyssey.runners.base import TaskContext
+from odyssey.runners.isaac_lab import (
+    EvalProtocolCollector,
+    IsaacLabRunner,
+    build_isaac_lab_argv,
+    resolve_eval_script,
+    resolve_launcher,
+    summarize,
+)
+from odyssey.runners.subprocess import TrainingProcessSpec
+from odyssey.spec import (
+    AgentRole,
+    AgentSpec,
+    EvaluationTask,
+    EvaluationType,
+    HFModelRef,
+    Mission,
+    MissionMetadata,
+    RobotSpec,
+    TrainingTask,
+    TrainingType,
+)
+from odyssey.telemetry import EventPublisher
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "eval-isaac",
+        "evaluation_type": EvaluationType.ISAAC_LAB,
+        "benchmark_name": "Isaac-Lift-Cube-Franka-v0",
+        "num_episodes": 10,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Launch contract
+# ---------------------------------------------------------------------------
+
+def test_argv_contains_contract_flags(tmp_path: Path) -> None:
+    argv = build_isaac_lab_argv(task=_eval_task(), checkpoint=tmp_path / "ckpt")
+    assert argv[argv.index("--task") + 1] == "Isaac-Lift-Cube-Franka-v0"
+    assert argv[argv.index("--num_episodes") + 1] == "10"
+    assert argv[argv.index("--checkpoint") + 1] == str(tmp_path / "ckpt")
+    assert "--headless" in argv
+
+
+def test_argv_headless_false_omits_flag(tmp_path: Path) -> None:
+    task = _eval_task(config={"headless": False})
+    argv = build_isaac_lab_argv(task=task, checkpoint=tmp_path)
+    assert "--headless" not in argv
+
+
+def test_argv_passthrough_keeps_snake_case(tmp_path: Path) -> None:
+    task = _eval_task(config={"num_envs": 4})
+    argv = build_isaac_lab_argv(task=task, checkpoint=tmp_path)
+    assert argv[argv.index("--num_envs") + 1] == "4"
+
+
+def test_argv_excludes_runner_keys(tmp_path: Path) -> None:
+    task = _eval_task(config={"eval_script": "/x.py", "runner": "isaac_lab"})
+    argv = build_isaac_lab_argv(task=task, checkpoint=tmp_path)
+    assert "--eval_script" not in argv
+    assert "--runner" not in argv
+
+
+def test_eval_script_from_config() -> None:
+    assert resolve_eval_script({"eval_script": "/opt/eval.py"}) == "/opt/eval.py"
+
+
+def test_eval_script_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ISAACLAB_EVAL_SCRIPT", "/env/eval.py")
+    assert resolve_eval_script({}) == "/env/eval.py"
+
+
+def test_eval_script_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ISAACLAB_EVAL_SCRIPT", raising=False)
+    with pytest.raises(RuntimeError, match="eval_script"):
+        resolve_eval_script({})
+
+
+def test_launcher_from_isaaclab_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ISAACLAB_PATH", "/opt/IsaacLab")
+    assert resolve_launcher() == ["/opt/IsaacLab/isaaclab.sh", "-p"]
+
+
+def test_launcher_none_without_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ISAACLAB_PATH", raising=False)
+    assert resolve_launcher() is None
+
+
+def test_process_spec_rejects_launcher_with_entry_module() -> None:
+    with pytest.raises(ValueError, match="launcher"):
+        TrainingProcessSpec(entry_module="some.module", launcher=["x.sh", "-p"])
+
+
+# ---------------------------------------------------------------------------
+# Protocol collector
+# ---------------------------------------------------------------------------
+
+def test_collector_records_episode_and_emits_progress() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse(
+        'ODYSSEY_EPISODE {"index": 3, "total": 10, "success": true, "return": 1.5}'
+    )
+    assert event is not None
+    assert event["step"] == "episode_complete"
+    assert event["step_index"] == 3
+    assert event["step_total"] == 10
+    assert collector.episodes[0]["success"] is True
+
+
+def test_collector_records_result_line() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse('ODYSSEY_RESULT {"success_rate": 0.4}')
+    assert event is not None
+    assert collector.result == {"success_rate": 0.4}
+
+
+def test_collector_skips_malformed_protocol_line() -> None:
+    collector = EvalProtocolCollector()
+    assert collector.parse("ODYSSEY_EPISODE {not json") is None
+    assert collector.episodes == []
+
+
+def test_collector_ignores_boot_noise() -> None:
+    collector = EvalProtocolCollector()
+    assert collector.parse("[INFO] Simulation App Startup Complete") is None
+
+
+# ---------------------------------------------------------------------------
+# Summary scoring
+# ---------------------------------------------------------------------------
+
+def _collector_with_episodes(*successes: bool) -> EvalProtocolCollector:
+    collector = EvalProtocolCollector()
+    total = len(successes)
+    for i, success in enumerate(successes, start=1):
+        collector.parse(
+            f'ODYSSEY_EPISODE {{"index": {i}, "total": {total}, '
+            f'"success": {str(success).lower()}, "return": {1.0 if success else 0.0}}}'
+        )
+    return collector
+
+
+def test_summary_computed_from_episodes(tmp_path: Path) -> None:
+    collector = _collector_with_episodes(True, True, False, False)
+    summary = summarize(
+        collector=collector,
+        spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt",
+        eval_script="/opt/eval.py",
+    )
+    assert summary["num_episodes"] == 4
+    assert summary["success_rate"] == 0.5
+    assert summary["passed"] is True
+    assert summary["metrics"]["successes"] == 2
+    assert summary["metrics"]["benchmark"] == "Isaac-Lift-Cube-Franka-v0"
+
+
+def test_summary_prefers_explicit_result(tmp_path: Path) -> None:
+    collector = _collector_with_episodes(True, False)
+    collector.parse(
+        'ODYSSEY_RESULT {"success_rate": 0.9, "performance_score": 0.8, '
+        '"metrics": {"sim_steps": 1234}}'
+    )
+    summary = summarize(
+        collector=collector,
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert summary["success_rate"] == 0.9
+    assert summary["performance_score"] == 0.8
+    assert summary["letter_grade"] == "A"
+    assert summary["metrics"]["sim_steps"] == 1234
+
+
+def test_summary_without_protocol_output_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="protocol"):
+        summarize(
+            collector=EvalProtocolCollector(),
+            spec=_eval_task(),
+            checkpoint=tmp_path,
+            eval_script="/opt/eval.py",
+        )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real subprocess machinery
+# ---------------------------------------------------------------------------
+
+class _NullPublisher(EventPublisher):
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        pass
+
+
+FAKE_EVAL_SCRIPT = """\
+import json, sys
+args = sys.argv[1:]
+num_episodes = int(args[args.index("--num_episodes") + 1])
+for i in range(1, num_episodes + 1):
+    print("ODYSSEY_EPISODE " + json.dumps(
+        {"index": i, "total": num_episodes, "success": i % 2 == 1, "return": 1.0}
+    ))
+print("ODYSSEY_RESULT " + json.dumps({"success_rate": 0.5}))
+"""
+
+
+def _context_for(spec_task: EvaluationTask, tmp_path: Path) -> TaskContext:
+    mission = Mission(
+        metadata=MissionMetadata(name="msn-isaac"),
+        objective="objective",
+        acceptance_criteria="acceptance",
+        robot=RobotSpec(
+            embodiment="franka_panda",
+            agents=[
+                AgentSpec(
+                    id="pilot",
+                    role=AgentRole.PILOT,
+                    model=HFModelRef(base="nvidia/GR00T-N1.7-3B"),
+                ),
+            ],
+        ),
+        tasks=[
+            TrainingTask(
+                name="train",
+                training_type=TrainingType.DEMONSTRATION,
+                agent_id="pilot",
+            ),
+            spec_task,
+        ],
+    )
+    run = MissionRun.from_spec(mission)
+    # Mark the training task complete with a checkpoint so the eval's
+    # loadout walk finds one.
+    train_run = run.tasks[0]
+    train_run.status = TaskStatus.COMPLETED
+    train_run.result_summary = {"checkpoint_path": str(tmp_path / "ckpt")}
+    eval_run = run.tasks[1]
+    return TaskContext(
+        task=eval_run,
+        mission=run,
+        publisher=_NullPublisher(),
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_runner_end_to_end_with_fake_script(tmp_path: Path) -> None:
+    script = tmp_path / "fake_eval.py"
+    script.write_text(FAKE_EVAL_SCRIPT)
+    task = _eval_task(num_episodes=4, config={"eval_script": str(script)})
+    context = _context_for(task, tmp_path)
+
+    runner = IsaacLabRunner()
+    summary = asyncio.run(runner.run(context))
+
+    assert summary["num_episodes"] == 4
+    assert summary["success_rate"] == 0.5
+    assert summary["passed"] is True
+    assert summary["metrics"]["successes"] == 2

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -30,6 +30,7 @@ from odyssey.spec.loader import LoadError
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 EXAMPLE_MISSION = REPO_ROOT / "examples" / "quickstart-openvla" / "mission.yaml"
+EXAMPLE_MISSION_GR00T = REPO_ROOT / "examples" / "quickstart-gr00t" / "mission.yaml"
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +102,26 @@ def test_shipped_example_loads() -> None:
     assert sum(1 for t in mission.tasks if t.kind == "training") == 1
     assert sum(1 for t in mission.tasks if t.kind == "evaluation") == 1
     assert mission.robot.agents[0].id == "pilot"
+
+
+def test_shipped_gr00t_example_loads() -> None:
+    """The GR00T quickstart YAML must always be a valid spec.
+
+    Pins the shapes the v0.2.x GR00T training runner and Isaac Lab
+    eval runner will execute — if the spec moves, this example (and
+    the Command Center import conformance pin) must move with it.
+    """
+    mission = load_mission(EXAMPLE_MISSION_GR00T)
+    assert mission.metadata.name == "gr00t-cube-to-bowl"
+    assert mission.robot.agents[0].model.base == "nvidia/GR00T-N1.7-3B"
+    training = [t for t in mission.tasks if t.kind == "training"]
+    evaluation = [t for t in mission.tasks if t.kind == "evaluation"]
+    assert len(training) == 1 and len(evaluation) == 1
+    assert training[0].dataset is not None
+    assert training[0].dataset.format is not None
+    assert training[0].dataset.format.value == "lerobot"
+    assert evaluation[0].evaluation_type.value == "isaac_lab"
+    assert evaluation[0].benchmark_name == "Isaac-Lift-Cube-Franka-v0"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements #17 — the GR00T path for the June 22 launch and the NVIDIA Automate session. Two commits: the GR00T training side, then the Isaac Lab evaluation side.

## Summary

- **`examples/quickstart-gr00t/mission.yaml`** — fine-tune `nvidia/GR00T-N1.7-3B` (demonstration training) on the LeRobot-v2-flavor demo set shipped inside the [Isaac-GR00T repo](https://github.com/NVIDIA/Isaac-GR00T) (`demo_data/cube_to_bowl_5`, no separate download), evaluated on Isaac Lab `Isaac-Lift-Cube-Franka-v0`. Validates and mock-runs everywhere today.
- **`src/odyssey/runners/gr00t.py`** — subprocess runner invoking `python -m gr00t.experiment.launch_finetune`, mirroring the OpenVLA runner: base-model resolution ladder (task config → `NVIDIA_GR00T_N1_7_3B_PATH`-style env var → HF id) with starting-checkpoint chaining and HF provider fetch; mission config keys pass through 1:1 as kebab-case upstream flags; HF-Trainer stdout parser. Contains no NVIDIA code — users install Isaac-GR00T and accept the upstream weight license themselves.
- **`src/odyssey/runners/isaac_lab.py`** — subprocess eval runner (Isaac Lab scripts must run under Isaac Sim's bundled Python, so in-process like Robosuite isn't an option). Launches a user-supplied eval script via `${ISAACLAB_PATH}/isaaclab.sh -p <script> --task <benchmark> --num_episodes <N> --checkpoint <path> --headless` and scores the `ODYSSEY_EPISODE` / `ODYSSEY_RESULT` JSON lines it prints (boot noise ignored, episodes stream as live progress). The eval script is the deliberate slot for the blessed GR00T/VLA recipe (#17); checkpoint resolution reuses the Robosuite loadout walk so fine-tune → eval composes in one mission. `TrainingProcessSpec` gains an optional `launcher` prefix to support non-python launchers.
- **Task-level runner selection** — OpenVLA and GR00T are both wildcard training runners and the registry can't see the model family, so the engine now honors `config: {runner: <name>}` per task via the registry's previously-unused `override` parameter. `--use-mock-runner` becomes an engine-level `force_runner` that beats any task override, preserving its semantics exactly.

## Review notes

- The GR00T argv/flag surface is derived from NVIDIA's current Isaac-GR00T docs. **Please diff against the battle-tested `gr00t_runner.py` in `lai-inference`** before the real-GPU smoke — production quirks beat documentation.
- The engine API addition (override + `force_runner`) is the piece flagged in #17 for design eyes.
- The Isaac Lab stdout protocol (`ODYSSEY_EPISODE` / `ODYSSEY_RESULT`) is new surface — naming and shape feedback welcome before it calcifies.

## Test plan

- [x] 212/212 tests (`pytest`), `mypy --strict` clean on 54 files, `ruff` clean
- [x] GR00T runner: argv ladder, env-var resolution (incl. dotted version ids), dataset resolution against `ISAAC_GR00T_REPO_PATH`, kebab-case passthrough, stdout parser
- [x] Engine selection: config override selects the named runner; `force_runner` beats the override; unknown override fails the task with `no_runner_registered`
- [x] Isaac Lab runner: launch contract, script/launcher resolution, protocol parsing (incl. malformed lines), scoring paths, and an end-to-end run of a fake eval script through the real subprocess machinery
- [x] Both quickstarts pinned in spec tests and parametrized through the CLI mock-run integration test; `odyssey validate` + `odyssey run --use-mock-runner` green
- [ ] Real-GPU training smoke with Isaac-GR00T installed (24 GB+ GPU)
- [ ] Real Isaac Lab eval smoke — needs the GR00T-policy eval script (the #17 recipe ask)

🤖 Generated with [Claude Code](https://claude.com/claude-code)