### PR TITLE
feat(eval): GR00T policy eval recipe for the Isaac Lab runner (#17)

### DIFF
--- a/examples/quickstart-gr00t/isaac_eval_mission.yaml
+++ b/examples/quickstart-gr00t/isaac_eval_mission.yaml
@@ -1,0 +1,77 @@
+# GR00T policy eval in Isaac Lab, orchestrated by Odyssey (odyssey#17).
+#
+# Fills the eval_script slot that examples/quickstart-gr00t/mission.yaml leaves
+# open: the subprocess IsaacLabRunner launches scripts/eval/gr00t_isaac_eval.py,
+# which drives a GR00T policy server in the Franka visuomotor cube-stack env and
+# reports each episode over the ODYSSEY_* stdout protocol.
+#
+# The training task is a cpu_mock stub — it only yields a PILOT checkpoint so the
+# eval's checkpoint resolution succeeds. No training happens here: GR00T weights
+# live on the server, and the eval connects to it via --host/--port.
+#
+# Plumbing only (no Isaac / GR00T), from the repo root:
+#   uv run odyssey run examples/quickstart-gr00t/isaac_eval_mission.yaml --use-mock-runner
+#
+# Real run (needs an Isaac Lab install + a running GR00T server):
+#   1. start the GR00T server (raw nested obs — NOT a sim-policy wrapper):
+#        CUDA_VISIBLE_DEVICES= <gr00t-venv>/python -m gr00t.eval.run_gr00t_server \
+#          --model-path nvidia/GR00T-N1.7-3B \
+#          --embodiment-tag oxe_droid_relative_eef_relative_joint --device cpu --port 5555
+#   2. point the runner at your Isaac install + run from the repo root:
+#        ISAACLAB_PATH=~/IsaacLab \
+#          uv run odyssey run examples/quickstart-gr00t/isaac_eval_mission.yaml
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: gr00t-isaac-eval
+  description: GR00T N1.7 policy evaluated in Isaac Lab via Odyssey's subprocess runner.
+  tags: [quickstart, gr00t, nvidia, isaac-lab, odyssey17]
+
+objective: |
+  Orchestrate a GR00T policy evaluation in NVIDIA Isaac Lab through an Odyssey
+  mission: the isaac_lab eval task launches the GR00T eval recipe, which drives a
+  GR00T policy server in the Franka cube-stack visuomotor env and reports a
+  success rate over the ODYSSEY_* protocol.
+
+acceptance_criteria: |
+  Mission completes; the isaac_lab eval runs GR00T-in-the-loop episodes against
+  the cube-stack visuomotor env and reports success_rate + performance_score.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: nvidia/GR00T-N1.7-3B
+
+tasks:
+  - name: provision-pilot-checkpoint
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    config:
+      runner: cpu_mock   # stub: yields a PILOT checkpoint for the eval's resolution
+
+  - name: gr00t-isaac-eval
+    kind: evaluation
+    evaluation_type: isaac_lab
+    benchmark_name: Isaac-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos-v0
+    num_episodes: 1   # one episode ~12 min zero-shot on CPU; bump for a real sweep
+    config:
+      # The blessed GR00T eval recipe (relative to the repo root; the runner also
+      # honours $ISAACLAB_EVAL_SCRIPT). Forwarded keys below pass through verbatim.
+      eval_script: scripts/eval/gr00t_isaac_eval.py
+      host: 127.0.0.1
+      port: 5555
+      instruction: "stack the red cube on the green cube"
+      pos_scale: 0.05   # raw GR00T eef deltas are large; scale into the IK-rel action
+
+leaderboard:
+  publish: false
+
+graph:
+  contribute: false

--- a/examples/quickstart-gr00t/mission.yaml
+++ b/examples/quickstart-gr00t/mission.yaml
@@ -61,13 +61,18 @@ tasks:
   - name: eval-in-isaac-lab
     kind: evaluation
     evaluation_type: isaac_lab
-    benchmark_name: Isaac-Lift-Cube-Franka-v0
-    num_episodes: 10
-    # For a real run: set $ISAACLAB_PATH and point eval_script at a
-    # script speaking the ODYSSEY_* stdout protocol (see
-    # src/odyssey/runners/isaac_lab.py). Mock-run needs neither.
-    # config:
-    #   eval_script: /path/to/gr00t_isaaclab_eval.py
+    benchmark_name: Isaac-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos-v0
+    num_episodes: 2
+    # Deploys the GR00T policy in Isaac Lab via the blessed eval recipe: the
+    # runner spawns it under $ISAACLAB_PATH and parses the ODYSSEY_* stdout
+    # protocol. Requires a GR00T policy server reachable at host:port and a
+    # visuomotor (camera) benchmark — see scripts/eval/gr00t_isaac_eval.py.
+    config:
+      eval_script: scripts/eval/gr00t_isaac_eval.py
+      host: 127.0.0.1
+      port: 5555
+      instruction: "stack the red cube on the green cube"
+      pos_scale: 0.05   # raw GR00T eef deltas are large; scale into the IK-rel action
 
 leaderboard:
   publish: false   # Backend not live yet.

--- a/scripts/eval/gr00t_isaac_eval.py
+++ b/scripts/eval/gr00t_isaac_eval.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Blessed GR00T evaluation recipe for Odyssey's Isaac Lab runner (odyssey#17).
+
+This is the *eval script* that ``odyssey``'s subprocess ``IsaacLabRunner``
+launches under Isaac Sim's bundled Python (``isaaclab.sh -p``). The runner owns
+the launch, the ODYSSEY_* stdout protocol, cancellation and scoring; this script
+owns the GR00T <-> Isaac recipe: boot the env, drive a GR00T policy server, and
+report each episode.
+
+Launch contract (built by ``odyssey.runners.isaac_lab.build_isaac_lab_argv``)::
+
+    isaaclab.sh -p gr00t_isaac_eval.py \
+        --task <env_id> --num_episodes <N> --checkpoint <path> --headless \
+        [--host H --port P --instruction "..." --pos_scale .. --rot_scale ..]
+
+It connects to a GR00T policy server (``run_gr00t_server.py``, raw nested obs)
+and prints, per the runner's protocol::
+
+    ODYSSEY_EPISODE {"index": 1, "total": 10, "success": true, "return": 1.0}
+    ODYSSEY_RESULT  {"success_rate": 0.1, "performance_score": 0.1, "metrics": {}}
+
+Env support: the obs extraction targets the DROID-style Franka *visuomotor*
+envs (dual cameras + eef/joint state), e.g.
+``Isaac-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos-v0``. The ``--checkpoint`` is
+informational here — GR00T weights live on the server.
+
+Heavy deps (numpy, gr00t_transforms, isaaclab, gymnasium, gr00t, torch) are
+imported lazily in the run path so the module imports under the bare stdlib and
+its argv + protocol surface stay unit-testable on a CPU box without Isaac.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+
+log = logging.getLogger("gr00t_isaac_eval")
+
+_EPISODE_PREFIX = "ODYSSEY_EPISODE "
+_RESULT_PREFIX = "ODYSSEY_RESULT "
+
+
+# ---------------------------------------------------------------------------
+# Launch contract + ODYSSEY_* protocol  (stdlib only -> unit-testable anywhere)
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argv per the Isaac Lab launch contract + GR00T passthrough config.
+
+    Contract flags (always sent by the runner): --task, --num_episodes,
+    --checkpoint, --headless. The rest come from ``task.config`` verbatim
+    (snake_case), so they are declared with underscores to match.
+    """
+    ap = argparse.ArgumentParser(description="GR00T policy eval in Isaac Lab.")
+    # --- contract flags ---
+    ap.add_argument("--task", required=True, help="Isaac Lab env id (gym registered).")
+    ap.add_argument("--num_episodes", type=int, default=10)
+    ap.add_argument("--checkpoint", default="", help="Informational; weights live on the GR00T server.")
+    ap.add_argument("--headless", action="store_true")
+    # --- GR00T server + recipe config (task.config passthrough) ---
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=5555)
+    ap.add_argument("--timeout_ms", type=int, default=600000,
+                    help="client recv timeout; CPU inference is slow (~30s/query).")
+    ap.add_argument("--instruction", default="stack the red cube on the green cube")
+    ap.add_argument("--num_envs", type=int, default=1)
+    ap.add_argument("--device", default="cuda:0")
+    ap.add_argument("--n_action_steps", type=int, default=16,
+                    help="steps replayed per GR00T chunk before re-querying.")
+    ap.add_argument("--max_steps", type=int, default=600)
+    ap.add_argument("--pos_scale", type=float, default=1.0)
+    ap.add_argument("--rot_scale", type=float, default=1.0)
+    ap.add_argument("--translation_only", action="store_true",
+                    help="de-risk: zero rotation + fixed-open gripper (CLI/debug only).")
+    ap.add_argument("--video_dir", default="", help="if set, write one mp4 per episode here.")
+    return ap
+
+
+def episode_line(*, index: int, total: int, success: bool, ret: float) -> str:
+    """One ``ODYSSEY_EPISODE`` protocol line (consumed by the runner's collector)."""
+    return _EPISODE_PREFIX + json.dumps(
+        {"index": int(index), "total": int(total),
+         "success": bool(success), "return": float(ret)})
+
+
+def result_line(*, success_rate: float, performance_score: float,
+                metrics: dict | None = None) -> str:
+    """The optional ``ODYSSEY_RESULT`` summary line."""
+    return _RESULT_PREFIX + json.dumps(
+        {"success_rate": float(success_rate),
+         "performance_score": float(performance_score),
+         "metrics": dict(metrics or {})})
+
+
+def _emit(line: str) -> None:
+    # The runner reads stdout line-by-line; flush so episodes stream in real
+    # time (progress events + responsive cancellation).
+    print(line, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Env-coupled obs/action glue (numpy + gr00t_transforms; imported lazily)
+# ---------------------------------------------------------------------------
+
+def _np(x):
+    """Torch (possibly CUDA) tensor -> numpy; pass-through otherwise."""
+    import numpy as np
+    return x.detach().cpu().numpy() if hasattr(x, "detach") else np.asarray(x)
+
+
+def _policy_group(obs: dict) -> dict:
+    return obs["policy"] if isinstance(obs, dict) and "policy" in obs else obs
+
+
+def _frames(obs: dict):
+    import numpy as np
+    p = _policy_group(obs)
+    table = _np(p["table_cam"]).squeeze(0).astype(np.uint8)  # (H,W,3)
+    wrist = _np(p["wrist_cam"]).squeeze(0).astype(np.uint8)
+    return table, wrist
+
+
+def _state(obs: dict):
+    p = _policy_group(obs)
+    eef_pos = _np(p["eef_pos"]).reshape(-1)[:3]
+    eef_quat = _np(p["eef_quat"]).reshape(-1)[:4]   # wxyz (FrameTransformer.target_quat_w)
+    gripper = float(_np(p["gripper_pos"]).reshape(-1)[0])  # (1,2) finger joints; take one
+    joints = _np(p["joint_pos"]).reshape(-1)[:7]    # 9 joints -> 7 arm
+    return eef_pos, eef_quat, gripper, joints
+
+
+def _build_obs(obs: dict, hist, instruction: str) -> dict:
+    import numpy as np
+    from gr00t_transforms import build_gr00t_obs
+    hist.append(_frames(obs))
+    cur = hist[-1]
+    past = hist[-16] if len(hist) >= 16 else hist[0]   # video delta_indices [-15, 0]
+    eef_pos, eef_quat, gripper, joints = _state(obs)
+    return build_gr00t_obs(
+        exterior_seq=np.stack([past[0], cur[0]]),
+        wrist_seq=np.stack([past[1], cur[1]]),
+        eef_pos=eef_pos, eef_quat_wxyz=eef_quat,
+        gripper=gripper, arm_joints=joints, instruction=instruction,
+    )
+
+
+def _read_success(env) -> bool:
+    """Read the ``success`` (cubes_stacked) term at the terminal step — tells a
+    real stack from a cube-drop termination. IsaacLab 2.3.2:
+    ``termination_manager.get_term(name)`` -> per-env bool buffer, with a
+    ``_last_episode_dones`` fallback robust to in-step auto-reset."""
+    import numpy as np
+    tm = env.unwrapped.termination_manager
+    try:
+        v = tm.get_term("success")
+        if bool(np.asarray(v.detach().cpu()).reshape(-1)[0]):
+            return True
+    except Exception as e:
+        log.warning("get_term('success') failed: %s", e)
+    try:
+        if "success" in tm.active_terms:
+            idx = tm.active_terms.index("success")
+            return bool(np.asarray(tm._last_episode_dones[:, idx].detach().cpu()).reshape(-1)[0])
+    except Exception:
+        pass
+    return False
+
+
+def _save_video(frames, path: str, fps: int = 24) -> None:
+    if not frames:
+        return
+    try:
+        import imageio.v2 as imageio
+        imageio.mimsave(path, frames, fps=fps)
+        log.info("wrote video -> %s (%d frames)", path, len(frames))
+    except Exception as e:
+        log.warning("could not write video %s: %s", path, e)
+
+
+def _video_frame(env, obs):
+    """A frame for the demo video: prefer Isaac's viewport render (higher-res,
+    3rd-person); fall back to the up-scaled policy table-cam if render is unavailable."""
+    import numpy as np
+    try:
+        r = env.render()
+        if r is not None:
+            a = np.asarray(r)
+            if a.ndim == 3 and a.shape[0] >= 128:
+                return a.astype(np.uint8)
+    except Exception:
+        pass
+    f = _frames(obs)[0]
+    try:
+        from PIL import Image
+        return np.asarray(Image.fromarray(f).resize((600, 600), Image.LANCZOS), np.uint8)
+    except Exception:
+        return f
+
+
+# ---------------------------------------------------------------------------
+# Run path (heavy imports live here)
+# ---------------------------------------------------------------------------
+
+def run_eval(args: argparse.Namespace) -> dict:
+    import collections
+
+    from gr00t_transforms import gr00t_action_to_isaac
+
+    # Isaac Sim kit-python stack.
+    from isaaclab.app import AppLauncher
+    simulation_app = AppLauncher(headless=args.headless, enable_cameras=True).app
+    import gymnasium as gym
+    import isaaclab_tasks  # noqa: F401  registers Isaac-* envs
+    import torch
+    from isaaclab_tasks.utils import parse_env_cfg
+
+    # GR00T client — light deps (msgpack/pyzmq); add Isaac-GR00T to path.
+    g = os.environ.get("ISAAC_GR00T_DIR", os.path.expanduser("~/Isaac-GR00T"))
+    if g not in sys.path:
+        sys.path.insert(0, g)
+    from gr00t.policy.server_client import PolicyClient
+
+    if args.checkpoint:
+        log.info("checkpoint (informational; weights on server): %s", args.checkpoint)
+    client = PolicyClient(host=args.host, port=args.port, timeout_ms=args.timeout_ms)
+    env_cfg = parse_env_cfg(args.task, device=args.device, num_envs=args.num_envs)
+    env = gym.make(args.task, cfg=env_cfg, render_mode="rgb_array")
+    dev = getattr(env.unwrapped, "device", "cpu")
+
+    successes, returns = 0, []
+    frames = [] if args.video_dir else None  # one combined clip across all episodes
+    try:
+        for ep in range(args.num_episodes):
+            obs, _ = env.reset()
+            hist: collections.deque = collections.deque(maxlen=16)
+            done, t, ep_success, ep_return = False, 0, False, 0.0
+            while not done and t < args.max_steps:
+                result = client.get_action(_build_obs(obs, hist, args.instruction))
+                chunk = result[0] if isinstance(result, tuple) else result
+                for k in range(args.n_action_steps):
+                    a = gr00t_action_to_isaac(
+                        chunk, k, pos_scale=args.pos_scale,
+                        rot_scale=0.0 if args.translation_only else args.rot_scale)
+                    if args.translation_only:
+                        a[6] = 1.0  # fixed-open gripper
+                    a_t = torch.as_tensor(a, dtype=torch.float32, device=dev).unsqueeze(0)
+                    obs, reward, terminated, truncated, _ = env.step(a_t)
+                    ep_return += float(_np(reward).reshape(-1)[0])
+                    if frames is not None:
+                        frames.append(_video_frame(env, obs))
+                    if bool(_np(terminated).reshape(-1)[0]):
+                        ep_success = _read_success(env)  # capture pre auto-reset
+                    done = bool(_np(terminated).reshape(-1)[0]) or bool(_np(truncated).reshape(-1)[0])
+                    t += 1
+                    if done:
+                        break
+            successes += int(ep_success)
+            returns.append(ep_return)
+            log.info("episode %d/%d: %s (steps=%d, return=%.3f)",
+                     ep + 1, args.num_episodes, "SUCCESS" if ep_success else "fail", t, ep_return)
+            _emit(episode_line(index=ep + 1, total=args.num_episodes,
+                               success=ep_success, ret=ep_return))
+        if frames:
+            os.makedirs(args.video_dir, exist_ok=True)
+            _save_video(frames, os.path.join(args.video_dir, "rollout.mp4"))
+    finally:
+        try:
+            env.close()
+        finally:
+            simulation_app.close()
+
+    n = max(args.num_episodes, 1)
+    success_rate = successes / n
+    summary = {
+        "success_rate": success_rate,
+        "performance_score": success_rate,
+        "metrics": {
+            "successes": successes,
+            "episode_returns": [round(r, 4) for r in returns],
+            "benchmark": args.task,
+        },
+    }
+    _emit(result_line(**summary))
+    return summary
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    run_eval(build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval/gr00t_transforms.py
+++ b/scripts/eval/gr00t_transforms.py
@@ -1,0 +1,108 @@
+"""Pure GR00T obs/action transforms for the Isaac Lab eval recipe (odyssey#17).
+
+NO heavy deps (numpy only) so it imports and unit-tests without gr00t / isaaclab /
+torch. This is the design-agnostic core of the GR00T<->Isaac adapter — it carried
+over unchanged when odyssey#17 moved from an in-process runner onto Jeanine's
+subprocess ``IsaacLabRunner`` contract; only the surrounding harness changed.
+
+Embodiment: ``oxe_droid_relative_eef_relative_joint`` (GR00T-N1.7 DROID-family).
+The GR00T policy server (``run_gr00t_server.py``) expects a NESTED obs dict and
+returns ``(action, info)`` with action keys ``eef_9d`` / ``gripper_position`` /
+``joint_position``. rot6d = first two columns of R (Zhou et al. 2019;
+identity rotation -> ``[1,0,0, 0,1,0]``).
+"""
+from __future__ import annotations
+
+import numpy as np
+
+DROID_VIDEO_KEYS = ["exterior_image_1_left", "wrist_image_left"]
+T_VIDEO = 2          # video delta_indices = [-15, 0]
+ACTION_HORIZON = 40  # action delta_indices = range(40)
+
+
+def quat_wxyz_to_matrix(q) -> np.ndarray:
+    q = np.asarray(q, dtype=np.float64)
+    n = np.linalg.norm(q)
+    if n < 1e-12:
+        return np.eye(3)
+    w, x, y, z = q / n
+    return np.array([
+        [1 - 2 * (y * y + z * z), 2 * (x * y - w * z),     2 * (x * z + w * y)],
+        [2 * (x * y + w * z),     1 - 2 * (x * x + z * z), 2 * (y * z - w * x)],
+        [2 * (x * z - w * y),     2 * (y * z + w * x),     1 - 2 * (x * x + y * y)],
+    ])
+
+
+def matrix_to_rot6d(R) -> np.ndarray:
+    R = np.asarray(R, dtype=np.float64)
+    return np.concatenate([R[:, 0], R[:, 1]]).astype(np.float32)  # first two columns
+
+
+def rot6d_to_matrix(r6) -> np.ndarray:
+    r6 = np.asarray(r6, dtype=np.float64)
+    a1, a2 = r6[0:3], r6[3:6]
+    b1 = a1 / (np.linalg.norm(a1) + 1e-12)
+    a2p = a2 - np.dot(b1, a2) * b1
+    b2 = a2p / (np.linalg.norm(a2p) + 1e-12)
+    b3 = np.cross(b1, b2)
+    return np.stack([b1, b2, b3], axis=1)
+
+
+def matrix_to_axis_angle(R) -> np.ndarray:
+    R = np.asarray(R, dtype=np.float64)
+    cos = np.clip((np.trace(R) - 1.0) / 2.0, -1.0, 1.0)
+    angle = np.arccos(cos)
+    if angle < 1e-6:
+        return np.zeros(3, dtype=np.float32)
+    if abs(angle - np.pi) < 1e-6:
+        axis = np.sqrt(np.clip((np.diag(R) + 1.0) / 2.0, 0.0, None))
+        s = np.sign([R[2, 1] - R[1, 2], R[0, 2] - R[2, 0], R[1, 0] - R[0, 1]])
+        axis = axis * np.where(s == 0, 1.0, s)
+        return (axis * angle).astype(np.float32)
+    axis = np.array([R[2, 1] - R[1, 2], R[0, 2] - R[2, 0], R[1, 0] - R[0, 1]]) / (2 * np.sin(angle))
+    return (axis * angle).astype(np.float32)
+
+
+def quat_wxyz_to_rot6d(q) -> np.ndarray:
+    return matrix_to_rot6d(quat_wxyz_to_matrix(q))
+
+
+def rot6d_to_axis_angle(r6) -> np.ndarray:
+    return matrix_to_axis_angle(rot6d_to_matrix(r6))
+
+
+def build_gr00t_obs(*, exterior_seq, wrist_seq, eef_pos, eef_quat_wxyz,
+                    gripper, arm_joints, instruction) -> dict:
+    """Nested GR00T obs dict (video/state/language) the server validates.
+    exterior_seq/wrist_seq: (T_VIDEO,H,W,3) uint8; language is list[list[str]] (B,T)."""
+    eef_9d = np.concatenate([
+        np.asarray(eef_pos, dtype=np.float32).reshape(3),
+        quat_wxyz_to_rot6d(eef_quat_wxyz),
+    ]).astype(np.float32)
+    return {
+        "video": {
+            "exterior_image_1_left": np.asarray(exterior_seq, dtype=np.uint8)[None],
+            "wrist_image_left": np.asarray(wrist_seq, dtype=np.uint8)[None],
+        },
+        "state": {
+            "eef_9d": eef_9d.reshape(1, 1, 9),
+            "gripper_position": np.asarray(gripper, dtype=np.float32).reshape(1, 1, 1),
+            "joint_position": np.asarray(arm_joints, dtype=np.float32).reshape(1, 1, 7),
+        },
+        "language": {
+            "annotation.language.language_instruction": [[str(instruction)]],
+        },
+    }
+
+
+def gr00t_action_to_isaac(chunk, k, *, pos_scale=1.0, rot_scale=1.0,
+                          gripper_threshold=0.5, gripper_open=1.0,
+                          gripper_close=-1.0) -> np.ndarray:
+    """Map step k of GR00T's action chunk to the env's 7-D IK-rel + gripper action.
+    Uses eef_9d (relative xyz + rot6d) + gripper; ignores joint_position (env is EEF/IK)."""
+    eef = np.asarray(chunk["eef_9d"]).reshape(-1, 9)[k]
+    grip = float(np.asarray(chunk["gripper_position"]).reshape(-1, 1)[k, 0])
+    dpos = eef[0:3].astype(np.float64) * pos_scale
+    drot = rot6d_to_axis_angle(eef[3:9]).astype(np.float64) * rot_scale
+    g = gripper_open if grip < gripper_threshold else gripper_close
+    return np.concatenate([dpos, drot, [g]]).astype(np.float32)

--- a/tests/unit/test_gr00t_isaac_eval.py
+++ b/tests/unit/test_gr00t_isaac_eval.py
@@ -1,0 +1,125 @@
+"""Tests for the GR00T Isaac Lab eval recipe (odyssey#17).
+
+The recipe (``scripts/eval/gr00t_isaac_eval.py``) is the pluggable eval script
+that Jeanine's subprocess ``IsaacLabRunner`` spawns. These tests pin the two
+things that make it interoperate WITHOUT booting Isaac Sim or GR00T:
+
+  * the launch-contract argv it accepts (--task/--num_episodes/--checkpoint/...);
+  * that the ODYSSEY_* protocol lines it emits are consumed correctly by the
+    runner's own ``EvalProtocolCollector`` + ``summarize`` (the real contract).
+
+Heavy deps (isaaclab, gymnasium, gr00t, torch, numpy) are deferred into the run
+path, so importing the module here needs only the stdlib — that deferral is
+itself asserted below.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.isaac_lab import EvalProtocolCollector, summarize
+from odyssey.spec import EvaluationTask, EvaluationType
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "eval"))
+import gr00t_isaac_eval as E
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "gr00t-isaac-eval",
+        "evaluation_type": EvaluationType.ISAAC_LAB,
+        "benchmark_name": "Isaac-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos-v0",
+        "num_episodes": 4,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Heavy deps are deferred — the module imports under the bare stdlib.
+# ---------------------------------------------------------------------------
+
+def test_module_imports_without_sim_deps() -> None:
+    # isaaclab / gymnasium / gr00t / torch are not installed in the core env;
+    # a clean import proves they are imported lazily in the run path, never at
+    # module load (otherwise this file would have failed to import at all).
+    for mod in ("isaaclab", "isaaclab_tasks", "gymnasium", "gr00t", "torch"):
+        assert mod not in sys.modules, f"{mod} leaked into module-load imports"
+
+
+# ---------------------------------------------------------------------------
+# Launch contract (matches build_isaac_lab_argv in the runner)
+# ---------------------------------------------------------------------------
+
+def test_parser_accepts_contract_flags() -> None:
+    args = E.build_parser().parse_args(
+        ["--task", "Isaac-Foo-v0", "--num_episodes", "7",
+         "--checkpoint", "/tmp/ckpt", "--headless"]
+    )
+    assert args.task == "Isaac-Foo-v0"
+    assert args.num_episodes == 7
+    assert args.checkpoint == "/tmp/ckpt"
+    assert args.headless is True
+
+
+def test_parser_accepts_passthrough_config() -> None:
+    # Extra config keys the runner forwards verbatim (snake_case).
+    args = E.build_parser().parse_args(
+        ["--task", "X", "--num_episodes", "1", "--checkpoint", "/c",
+         "--host", "10.0.0.2", "--port", "6000",
+         "--instruction", "stack the red cube", "--pos_scale", "0.05"]
+    )
+    assert args.host == "10.0.0.2"
+    assert args.port == 6000
+    assert args.instruction == "stack the red cube"
+    assert args.pos_scale == 0.05
+
+
+def test_parser_headless_defaults_off_without_flag() -> None:
+    args = E.build_parser().parse_args(
+        ["--task", "X", "--num_episodes", "1", "--checkpoint", "/c"])
+    assert args.headless is False
+
+
+# ---------------------------------------------------------------------------
+# Protocol emission is consumed by the runner's OWN collector + scorer.
+# ---------------------------------------------------------------------------
+
+def test_episode_line_parsed_by_runner_collector() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse(E.episode_line(index=3, total=10, success=True, ret=1.5))
+    assert event is not None and event["step"] == "episode_complete"
+    assert event["step_index"] == 3 and event["step_total"] == 10
+    assert collector.episodes[0]["success"] is True
+    assert collector.episodes[0]["return"] == 1.5
+
+
+def test_result_line_parsed_by_runner_collector() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse(
+        E.result_line(success_rate=0.4, performance_score=0.7, metrics={"sim_steps": 99}))
+    assert event is not None
+    assert collector.result["success_rate"] == 0.4
+    assert collector.result["performance_score"] == 0.7
+    assert collector.result["metrics"]["sim_steps"] == 99
+
+
+def test_full_protocol_scored_by_runner_summarize(tmp_path: Path) -> None:
+    # Emit a full rollout the way the recipe does, then score it with the
+    # runner's summarize() — the exact path Odyssey takes in production.
+    collector = EvalProtocolCollector()
+    outcomes = [True, True, False, False]
+    for i, ok in enumerate(outcomes, start=1):
+        collector.parse(E.episode_line(index=i, total=4, success=ok, ret=1.0 if ok else 0.0))
+    collector.parse(E.result_line(
+        success_rate=0.5, performance_score=0.5, metrics={"benchmark": "cosmos"}))
+    summary = summarize(
+        collector=collector, spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt", eval_script="scripts/eval/gr00t_isaac_eval.py")
+    assert summary["num_episodes"] == 4
+    assert summary["success_rate"] == 0.5
+    assert summary["passed"] is True
+    assert summary["letter_grade"] in {"C", "D", "F", "B", "A"}

--- a/tests/unit/test_gr00t_transforms.py
+++ b/tests/unit/test_gr00t_transforms.py
@@ -1,0 +1,78 @@
+"""Unit tests for the GR00T obs/action transforms (odyssey#17 eval recipe).
+
+The transforms back the blessed GR00T Isaac Lab eval script
+(``scripts/eval/gr00t_isaac_eval.py``). They are pure-numpy and live beside
+the script (run under Isaac Sim's bundled python), so the test imports the
+module by path. numpy is optional in the core env — skip when absent, the
+same convention as the Isaac-GR00T conformance tests.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+np = pytest.importorskip("numpy")
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "scripts", "eval"))
+import gr00t_transforms as T  # noqa: E402
+
+
+def _Rz(theta):
+    c, s = np.cos(theta), np.sin(theta)
+    return np.array([[c, -s, 0], [s, c, 0], [0, 0, 1]], dtype=float)
+
+
+def test_identity_quat_to_rot6d():
+    assert np.allclose(T.quat_wxyz_to_rot6d([1, 0, 0, 0]), [1, 0, 0, 0, 1, 0], atol=1e-6)
+
+
+def test_identity_rot6d_to_axis_angle_zero():
+    assert np.allclose(T.rot6d_to_axis_angle([1, 0, 0, 0, 1, 0]), [0, 0, 0], atol=1e-6)
+
+
+def test_rz90_rot6d_and_axis_angle():
+    R = _Rz(np.pi / 2)
+    assert np.allclose(T.matrix_to_rot6d(R), [0, 1, 0, -1, 0, 0], atol=1e-6)
+    assert np.allclose(T.matrix_to_axis_angle(R), [0, 0, np.pi / 2], atol=1e-5)
+
+
+def test_rot6d_matrix_roundtrip_proper_rotation():
+    rng = np.random.default_rng(0)
+    for _ in range(20):
+        q = rng.normal(size=4)
+        q /= np.linalg.norm(q)
+        R = T.quat_wxyz_to_matrix(q)
+        R2 = T.rot6d_to_matrix(T.matrix_to_rot6d(R))
+        assert np.allclose(R, R2, atol=1e-5)
+        assert np.isclose(np.linalg.det(R2), 1.0, atol=1e-5)
+
+
+def test_build_gr00t_obs_nested_shapes():
+    ext = np.zeros((2, 16, 16, 3), np.uint8)
+    obs = T.build_gr00t_obs(exterior_seq=ext, wrist_seq=ext, eef_pos=np.zeros(3),
+                            eef_quat_wxyz=[1, 0, 0, 0], gripper=0.0,
+                            arm_joints=np.zeros(7), instruction="stack")
+    assert obs["video"]["exterior_image_1_left"].shape == (1, 2, 16, 16, 3)
+    assert obs["video"]["exterior_image_1_left"].dtype == np.uint8
+    assert obs["state"]["eef_9d"].shape == (1, 1, 9) and obs["state"]["eef_9d"].dtype == np.float32
+    assert obs["state"]["gripper_position"].shape == (1, 1, 1)
+    assert obs["state"]["joint_position"].shape == (1, 1, 7)
+    assert obs["language"]["annotation.language.language_instruction"] == [["stack"]]
+    assert np.allclose(obs["state"]["eef_9d"].reshape(9)[3:], [1, 0, 0, 0, 1, 0], atol=1e-6)
+
+
+def test_gr00t_action_to_isaac_shape_scale_gripper():
+    eef = np.array([0.1, 0.2, 0.3, 1, 0, 0, 0, 1, 0], np.float32)  # identity rot6d
+    chunk = {
+        "eef_9d": np.tile(eef, (T.ACTION_HORIZON, 1))[None],
+        "gripper_position": np.zeros((1, T.ACTION_HORIZON, 1), np.float32),
+        "joint_position": np.zeros((1, T.ACTION_HORIZON, 7), np.float32),
+    }
+    a = T.gr00t_action_to_isaac(chunk, 0, pos_scale=2.0, rot_scale=1.0, gripper_threshold=0.5)
+    assert a.shape == (7,)
+    assert np.allclose(a[0:3], [0.2, 0.4, 0.6], atol=1e-6)   # pos_scale applied
+    assert np.allclose(a[3:6], [0, 0, 0], atol=1e-6)         # identity rot -> 0 axis-angle
+    assert a[6] == 1.0                                       # grip 0 < 0.5 -> open

--- a/tests/unit/test_spec.py
+++ b/tests/unit/test_spec.py
@@ -121,7 +121,13 @@ def test_shipped_gr00t_example_loads() -> None:
     assert training[0].dataset.format is not None
     assert training[0].dataset.format.value == "lerobot"
     assert evaluation[0].evaluation_type.value == "isaac_lab"
-    assert evaluation[0].benchmark_name == "Isaac-Lift-Cube-Franka-v0"
+    # cosmos visuomotor benchmark — the GR00T eval recipe needs camera obs
+    assert (
+        evaluation[0].benchmark_name
+        == "Isaac-Stack-Cube-Franka-IK-Rel-Visuomotor-Cosmos-v0"
+    )
+    # the eval is wired to the blessed recipe (no longer a placeholder)
+    assert evaluation[0].config["eval_script"] == "scripts/eval/gr00t_isaac_eval.py"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Brings the **blessed GR00T evaluation recipe** onto `develop`. This is the content of **#23**, which got merged into the now-superseded `gr00t-quickstart-runner` branch (after #18 had already squash-landed on `develop`), leaving the recipe orphaned — never reaching `develop`. This PR re-applies exactly those 7 files on top of `develop`.

Fills the `eval_script` slot the subprocess `IsaacLabRunner` leaves open: the runner owns launch / the `ODYSSEY_*` stdout protocol / cancellation / scoring; this recipe owns the GR00T↔Isaac obs/action loop — boots the Franka visuomotor env, drives a GR00T policy server, and reports each episode.

## Changes
- `scripts/eval/gr00t_isaac_eval.py` — the eval recipe
- `scripts/eval/gr00t_transforms.py` — quaternion / rot6d / matrix helpers
- `examples/quickstart-gr00t/isaac_eval_mission.yaml` — eval mission
- `examples/quickstart-gr00t/mission.yaml` — wire the eval task
- `tests/unit/test_gr00t_isaac_eval.py`, `tests/unit/test_gr00t_transforms.py`
- `tests/unit/test_spec.py` — spec assertions for the wired eval task

## Notes
- Original PR #23 (merged into `gr00t-quickstart-runner`, **not** `develop`) is superseded by this.
- Minor lint cleanup to satisfy the repo's ruff gate: removed dead `noqa` directives + an unused import, split a semicolon line.

## Verification
- `ruff check` clean · `mypy --strict` clean (54 files) · **244 passed, 4 skipped** (conformance skips need an Isaac-GR00T checkout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)