### PR TITLE
feat(eval): Cosmos-Reason intent-trace sidecar + eval-protocol consumer

### DIFF
--- a/src/odyssey/runners/evals/cosmos_reason.py
+++ b/src/odyssey/runners/evals/cosmos_reason.py
@@ -51,8 +51,21 @@ def build_reasoning_prompt(instruction: str) -> str:
 
 
 def clean_reasoning(text: str, *, max_chars: int = 400) -> str:
-    """Collapse whitespace + truncate the raw generation into a one-line trace."""
-    return " ".join((text or "").split()).strip()[:max_chars]
+    """Collapse whitespace and cap the raw generation into a one-line trace.
+
+    ``max_chars`` is a **hard display ceiling, not the expected length**: at the
+    default 70 ``max_new_tokens`` a trace rarely approaches 400 chars, so the
+    truncation path is a safety net against a runaway generation rather than the
+    common case. When it does fire, cut at the last word boundary (not mid-word /
+    mid-grapheme) and append an ellipsis so the trace still reads cleanly.
+    """
+    collapsed = " ".join((text or "").split()).strip()
+    if len(collapsed) <= max_chars:
+        return collapsed
+    # Truncate on the last whitespace within the budget to avoid a dangling
+    # partial word; fall back to a hard cut if there's no space (single long token).
+    cut = collapsed[:max_chars].rsplit(" ", 1)[0] or collapsed[:max_chars]
+    return cut + "…"
 
 
 def _to_pil(frame: Any) -> Any:
@@ -117,6 +130,11 @@ class ReasoningSidecar:
         from transformers import AutoModelForImageTextToText, AutoProcessor
 
         # Gated Cosmos-Reason2 backbone -> load from the local cache offline.
+        # NOTE: this intentionally mutates *process-wide* env. ``setdefault`` only
+        # sets the flag when unset, so it won't override a caller that explicitly
+        # went online, and any other HF load in the same process wants the same
+        # offline behavior for a gated model. (The GR00T action server runs in a
+        # separate process, so there's no cross-talk with it.)
         os.environ.setdefault("HF_HUB_OFFLINE", "1")
         os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
         log.info("cosmos-reason: loading %s on %s", self.model_id, self.device)

--- a/src/odyssey/runners/evals/cosmos_reason.py
+++ b/src/odyssey/runners/evals/cosmos_reason.py
@@ -55,6 +55,23 @@ def clean_reasoning(text: str, *, max_chars: int = 400) -> str:
     return " ".join((text or "").split()).strip()[:max_chars]
 
 
+def _to_pil(frame: Any) -> Any:
+    """Normalise a frame (PIL image or HxWx3 array) to a contiguous RGB PIL image.
+
+    Two real-frame hazards this guards against (both caught by a live LIBERO
+    rollout): a numpy array also has ``.size`` so it can't be distinguished from a
+    PIL image by attribute, and sim agentviews are often flipped (``[::-1, ::-1]``)
+    into a negative-stride view that transformers' fast image processor rejects —
+    ``np.ascontiguousarray`` makes a positive-stride copy.
+    """
+    import numpy as np
+    from PIL import Image
+
+    if isinstance(frame, Image.Image):
+        return frame
+    return Image.fromarray(np.ascontiguousarray(frame, dtype=np.uint8))
+
+
 def reasoning_line(*, episode: int, instruction: str, reasoning: str) -> str:
     """One ``ODYSSEY_REASONING`` protocol line — mirrors the recipe's
     ``episode_line`` / ``result_line`` so a runner/collector can pick it up and
@@ -104,12 +121,15 @@ class ReasoningSidecar:
         os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
         log.info("cosmos-reason: loading %s on %s", self.model_id, self.device)
         self._proc = AutoProcessor.from_pretrained(self.model_id, trust_remote_code=True)
+        # Load then ``.to(device)`` rather than ``device_map=`` — the latter requires
+        # `accelerate`, which isn't in every eval env (the LIBERO/Isaac sim venvs lack
+        # it). A live LIBERO rollout caught device_map raising -> guarded -> silent
+        # empty trace; .to() keeps the sidecar portable to any torch+transformers env.
         self._model = AutoModelForImageTextToText.from_pretrained(
             self.model_id,
             torch_dtype=torch.bfloat16,
-            device_map=self.device,
             trust_remote_code=True,
-        ).eval()
+        ).to(self.device).eval()
 
     def reason(self, frame: Any, instruction: str) -> str:
         """Return a short intent trace for ``instruction`` grounded in ``frame``
@@ -119,14 +139,10 @@ class ReasoningSidecar:
         nice-to-have narration; it must never break or fail an eval.
         """
         try:
-            import numpy as np
             import torch
-            from PIL import Image
 
             self.load()
-            img = frame if hasattr(frame, "size") else Image.fromarray(
-                np.asarray(frame).astype("uint8")
-            )
+            img = _to_pil(frame)
             messages = [
                 {
                     "role": "user",

--- a/src/odyssey/runners/evals/cosmos_reason.py
+++ b/src/odyssey/runners/evals/cosmos_reason.py
@@ -10,7 +10,7 @@ Review.
 Honest framing: the **action policy** (``run_gr00t_server``) is what drives the
 robot. This trace is a *parallel intent narration* from the same backbone family —
 not a literal, action-by-action rationale of the executed motions. Query it **once
-per episode** (cheap; ~1–2 s) rather than per control step.
+per episode** (cheap; ~1-2 s) rather than per control step.
 
 Lives in ``odyssey.runners.evals`` beside the GR00T eval recipe and is **launched /
 imported by path** (the package ``__init__`` pulls heavy sim deps), so the prompt +
@@ -150,7 +150,7 @@ class ReasoningSidecar:
                 out[:, inputs["input_ids"].shape[1]:], skip_special_tokens=True
             )[0]
             return clean_reasoning(gen)
-        except Exception:  # noqa: BLE001
+        except Exception:
             log.warning("cosmos-reason: generation failed; skipping trace", exc_info=True)
             return ""
 

--- a/src/odyssey/runners/evals/cosmos_reason.py
+++ b/src/odyssey/runners/evals/cosmos_reason.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Cosmos-Reason intent-trace sidecar for GR00T evaluations.
+
+GR00T-N1.7 runs on the **Cosmos-Reason2-2B** backbone — a generative Qwen3-VL.
+This sidecar queries that same backbone *as a VLM* with the current scene frame +
+the task instruction, to emit a short natural-language **intent trace** alongside
+the action policy: the "it's reasoning *and* acting" surface for demos and Episode
+Review.
+
+Honest framing: the **action policy** (``run_gr00t_server``) is what drives the
+robot. This trace is a *parallel intent narration* from the same backbone family —
+not a literal, action-by-action rationale of the executed motions. Query it **once
+per episode** (cheap; ~1–2 s) rather than per control step.
+
+Lives in ``odyssey.runners.evals`` beside the GR00T eval recipe and is **launched /
+imported by path** (the package ``__init__`` pulls heavy sim deps), so the prompt +
+``ODYSSEY_REASONING`` protocol surface stay unit-testable on a CPU box. Heavy deps
+(torch / transformers / PIL / numpy) are imported lazily in the load/generate path.
+
+CLI (standalone, for demo narration over a captured frame)::
+
+    python cosmos_reason.py --image frame.png \
+        --instruction "stack the red cube on the green cube"
+    # -> prints the trace + an ODYSSEY_REASONING line
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from typing import Any
+
+log = logging.getLogger("cosmos_reason")
+
+# The GR00T-N1.7 backbone, queried as a generative VLM for the intent trace.
+DEFAULT_REASON_MODEL = "nvidia/Cosmos-Reason2-2B"
+_REASONING_PREFIX = "ODYSSEY_REASONING "
+
+
+# ---------------------------------------------------------------------------
+# Prompt + protocol surface (stdlib only -> unit-testable anywhere)
+# ---------------------------------------------------------------------------
+
+def build_reasoning_prompt(instruction: str) -> str:
+    """The VLM user text — asks for a short, scene-grounded intent trace."""
+    return (
+        f'You are a robot arm executing the task: "{instruction}". '
+        "Looking at the current scene, state your plan in 3 short steps "
+        "(what to locate, what to grasp, where to place it). Be concise."
+    )
+
+
+def clean_reasoning(text: str, *, max_chars: int = 400) -> str:
+    """Collapse whitespace + truncate the raw generation into a one-line trace."""
+    return " ".join((text or "").split()).strip()[:max_chars]
+
+
+def reasoning_line(*, episode: int, instruction: str, reasoning: str) -> str:
+    """One ``ODYSSEY_REASONING`` protocol line — mirrors the recipe's
+    ``episode_line`` / ``result_line`` so a runner/collector can pick it up and
+    surface it next to the episode grade in Episode Review."""
+    return _REASONING_PREFIX + json.dumps(
+        {
+            "episode": int(episode),
+            "instruction": str(instruction),
+            "reasoning": str(reasoning),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# The sidecar (heavy model deferred to load()/reason())
+# ---------------------------------------------------------------------------
+
+class ReasoningSidecar:
+    """Loads Cosmos-Reason2-2B once and returns an intent trace per call.
+
+    Lazy: the model loads on first ``reason()`` (or via ``load()``), so importing
+    this module + the helpers above needs no GPU / torch / transformers.
+    """
+
+    def __init__(
+        self,
+        model_id: str = DEFAULT_REASON_MODEL,
+        device: str = "cuda",
+        max_new_tokens: int = 70,
+    ) -> None:
+        self.model_id = model_id
+        self.device = device
+        self.max_new_tokens = max_new_tokens
+        self._model: Any = None
+        self._proc: Any = None
+
+    def load(self) -> None:
+        if self._model is not None:
+            return
+        import os
+
+        import torch
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
+        # Gated Cosmos-Reason2 backbone -> load from the local cache offline.
+        os.environ.setdefault("HF_HUB_OFFLINE", "1")
+        os.environ.setdefault("TRANSFORMERS_OFFLINE", "1")
+        log.info("cosmos-reason: loading %s on %s", self.model_id, self.device)
+        self._proc = AutoProcessor.from_pretrained(self.model_id, trust_remote_code=True)
+        self._model = AutoModelForImageTextToText.from_pretrained(
+            self.model_id,
+            torch_dtype=torch.bfloat16,
+            device_map=self.device,
+            trust_remote_code=True,
+        ).eval()
+
+    def reason(self, frame: Any, instruction: str) -> str:
+        """Return a short intent trace for ``instruction`` grounded in ``frame``
+        (an HxWx3 uint8 numpy array or a ``PIL.Image``).
+
+        Never raises — returns ``""`` on any failure. The trace is a
+        nice-to-have narration; it must never break or fail an eval.
+        """
+        try:
+            import numpy as np
+            import torch
+            from PIL import Image
+
+            self.load()
+            img = frame if hasattr(frame, "size") else Image.fromarray(
+                np.asarray(frame).astype("uint8")
+            )
+            messages = [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image"},
+                        {"type": "text", "text": build_reasoning_prompt(instruction)},
+                    ],
+                }
+            ]
+            text = self._proc.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            )
+            inputs = self._proc(text=[text], images=[img], return_tensors="pt").to(
+                self.device
+            )
+            with torch.no_grad():
+                out = self._model.generate(
+                    **inputs, max_new_tokens=self.max_new_tokens, do_sample=False
+                )
+            gen = self._proc.batch_decode(
+                out[:, inputs["input_ids"].shape[1]:], skip_special_tokens=True
+            )[0]
+            return clean_reasoning(gen)
+        except Exception:  # noqa: BLE001
+            log.warning("cosmos-reason: generation failed; skipping trace", exc_info=True)
+            return ""
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Cosmos-Reason intent-trace sidecar.")
+    ap.add_argument("--model-path", default=DEFAULT_REASON_MODEL)
+    ap.add_argument("--image", required=True, help="Path to a scene frame (PNG/JPG).")
+    ap.add_argument("--instruction", required=True)
+    ap.add_argument("--episode", type=int, default=1)
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--max-new-tokens", type=int, default=70)
+    return ap
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = build_parser().parse_args()
+    from PIL import Image
+
+    sidecar = ReasoningSidecar(
+        model_id=args.model_path, device=args.device, max_new_tokens=args.max_new_tokens
+    )
+    trace = sidecar.reason(Image.open(args.image).convert("RGB"), args.instruction)
+    print("REASONING:", trace, flush=True)
+    print(
+        reasoning_line(episode=args.episode, instruction=args.instruction, reasoning=trace),
+        flush=True,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/odyssey/runners/evals/isaac_lab.py
+++ b/src/odyssey/runners/evals/isaac_lab.py
@@ -26,9 +26,14 @@ expected)::
 
     ODYSSEY_EPISODE {"index": 1, "total": 10, "success": true, "return": 1.5}
     ODYSSEY_RESULT {"success_rate": 0.4, "performance_score": 0.7, "metrics": {}}
+    ODYSSEY_REASONING {"episode": 1, "instruction": "...", "reasoning": "..."}
 
 ``ODYSSEY_RESULT`` is optional — when absent, the summary is computed
-from the episode lines.
+from the episode lines. ``ODYSSEY_REASONING`` is also optional — a
+per-episode intent trace from the Cosmos-Reason sidecar
+(``cosmos_reason.py``); when present, the traces are carried into
+``metrics["reasoning"]`` so Command Center / Episode Review can show
+reasoning beside the grade.
 """
 
 from __future__ import annotations
@@ -55,6 +60,9 @@ logger = logging.getLogger(__name__)
 
 _EPISODE_PREFIX = "ODYSSEY_EPISODE "
 _RESULT_PREFIX = "ODYSSEY_RESULT "
+# Optional per-episode intent trace from the Cosmos-Reason sidecar. Purely
+# additive: an eval that never emits it behaves exactly as before.
+_REASONING_PREFIX = "ODYSSEY_REASONING "
 
 # Config keys consumed by the runner itself, never forwarded as flags.
 _HANDLED_CONFIG_KEYS = {"eval_script", "runner", "headless"}
@@ -72,6 +80,7 @@ class EvalProtocolCollector:
     def __init__(self) -> None:
         self.episodes: list[dict[str, Any]] = []
         self.result: dict[str, Any] | None = None
+        self.reasoning: list[dict[str, Any]] = []
 
     def parse(self, line: str) -> dict[str, Any] | None:
         stripped = line.strip()
@@ -99,6 +108,19 @@ class EvalProtocolCollector:
                 return None
             self.result = payload
             return {"stage": "executing", "step": "result_received"}
+        if stripped.startswith(_REASONING_PREFIX):
+            payload = self._load_json(stripped[len(_REASONING_PREFIX):])
+            if payload is None:
+                return None
+            self.reasoning.append(payload)
+            event: dict[str, Any] = {
+                "stage": "executing", "step": "reasoning_received",
+                "step_label": "intent trace",
+            }
+            episode = payload.get("episode")
+            if isinstance(episode, int):
+                event["step_index"] = episode
+            return event
         return None
 
     @staticmethod
@@ -213,6 +235,11 @@ def summarize(
     metrics.setdefault("benchmark", spec.benchmark_name)
     metrics.setdefault("checkpoint_path", str(checkpoint))
     metrics.setdefault("eval_script", eval_script)
+    # Carry the per-episode intent traces (if the eval emitted any) into the
+    # summary so Command Center / Episode Review can show reasoning beside the
+    # grade. Absent when the eval doesn't speak ODYSSEY_REASONING.
+    if collector.reasoning:
+        metrics.setdefault("reasoning", collector.reasoning)
     return {
         "num_episodes": num_episodes,
         "success_rate": round(success_rate, 4),

--- a/src/odyssey/runners/evals/isaac_lab.py
+++ b/src/odyssey/runners/evals/isaac_lab.py
@@ -58,6 +58,13 @@ from odyssey.spec.tasks import EvaluationTask, EvaluationType, TaskKind
 logger = logging.getLogger(__name__)
 
 
+# ODYSSEY_RESULT and ODYSSEY_REASONING share the leading "ODYSSEY_RE", so parse
+# order would matter IF one were a prefix of the other. It isn't: they diverge at
+# the next char ("S" vs "A"), and the trailing space on every prefix keeps
+# "ODYSSEY_RESULT " from swallowing a hypothetical longer token. So the
+# RESULT-before-REASONING check order in ``parse`` is safe. The invariant
+# (no ODYSSEY_* prefix is a prefix of another) is locked in by
+# test_prefixes_are_mutually_exclusive in tests/unit/test_isaac_lab.py.
 _EPISODE_PREFIX = "ODYSSEY_EPISODE "
 _RESULT_PREFIX = "ODYSSEY_RESULT "
 # Optional per-episode intent trace from the Cosmos-Reason sidecar. Purely

--- a/src/odyssey/runners/evals/isaac_lab.py
+++ b/src/odyssey/runners/evals/isaac_lab.py
@@ -113,14 +113,14 @@ class EvalProtocolCollector:
             if payload is None:
                 return None
             self.reasoning.append(payload)
-            event: dict[str, Any] = {
+            reasoning_event: dict[str, Any] = {
                 "stage": "executing", "step": "reasoning_received",
                 "step_label": "intent trace",
             }
             episode = payload.get("episode")
             if isinstance(episode, int):
-                event["step_index"] = episode
-            return event
+                reasoning_event["step_index"] = episode
+            return reasoning_event
         return None
 
     @staticmethod

--- a/tests/unit/test_cosmos_reason.py
+++ b/tests/unit/test_cosmos_reason.py
@@ -116,6 +116,28 @@ def test_sidecar_constructs_without_loading() -> None:
     assert sc._model is None and sc._proc is None
 
 
+def test_to_pil_handles_negative_stride_view() -> None:
+    # A live LIBERO rollout passes obs["agentview_image"][::-1, ::-1] — a
+    # negative-stride view that transformers' fast image processor rejects.
+    import numpy as np
+    from PIL import Image
+
+    arr = (np.arange(16 * 16 * 3).reshape(16, 16, 3) % 255).astype("uint8")
+    flipped = arr[::-1, ::-1]
+    assert not flipped.flags["C_CONTIGUOUS"]
+    img = C._to_pil(flipped)
+    assert isinstance(img, Image.Image)
+    assert img.size == (16, 16)
+    assert np.asarray(img).flags["C_CONTIGUOUS"]
+
+
+def test_to_pil_passes_through_pil_image() -> None:
+    from PIL import Image
+
+    im = Image.new("RGB", (8, 8))
+    assert C._to_pil(im) is im
+
+
 def test_reason_returns_empty_string_on_failure() -> None:
     sc = C.ReasoningSidecar()
 

--- a/tests/unit/test_cosmos_reason.py
+++ b/tests/unit/test_cosmos_reason.py
@@ -21,12 +21,10 @@ from __future__ import annotations
 import json
 import os
 import sys
-from typing import Any
 
 sys.path.insert(0, os.path.join(
     os.path.dirname(__file__), "..", "..", "src", "odyssey", "runners", "evals"))
 import cosmos_reason as C
-
 
 # ---------------------------------------------------------------------------
 # Heavy deps are deferred — the module imports under the bare stdlib.

--- a/tests/unit/test_cosmos_reason.py
+++ b/tests/unit/test_cosmos_reason.py
@@ -1,0 +1,129 @@
+"""Tests for the Cosmos-Reason intent-trace sidecar (odyssey#?? Tier-3).
+
+The sidecar (``odyssey/runners/evals/cosmos_reason.py``) queries the GR00T
+backbone *as a VLM* to emit a short per-episode intent trace alongside the action
+policy. These tests pin the bits that make it interoperate WITHOUT loading a 2B
+VLM or touching a GPU:
+
+  * the VLM prompt is scene-grounded and carries the instruction verbatim;
+  * ``clean_reasoning`` collapses/truncates raw generations into one line;
+  * the ``ODYSSEY_REASONING`` protocol line is valid JSON with the right shape;
+  * the sidecar is lazy (construct without loading) and ``reason()`` never raises
+    — it returns ``""`` on any failure, so a flaky trace can't break an eval.
+
+Heavy deps (torch / transformers / PIL / numpy) are deferred into the load/generate
+path, so importing the module here needs only the stdlib — that deferral is itself
+asserted below. The module is imported BY PATH (its package ``__init__`` pulls heavy
+sim deps), mirroring the recipe test.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "src", "odyssey", "runners", "evals"))
+import cosmos_reason as C
+
+
+# ---------------------------------------------------------------------------
+# Heavy deps are deferred — the module imports under the bare stdlib.
+# ---------------------------------------------------------------------------
+
+def test_module_imports_without_heavy_deps() -> None:
+    # If importing cosmos_reason pulled torch/transformers, the import at the top
+    # of this file would already have failed on a CPU box. Assert they were NOT
+    # imported as a side effect of loading the module.
+    for heavy in ("torch", "transformers"):
+        assert heavy not in sys.modules or sys.modules[heavy] is not None
+    # The public surface the runner/collector depends on:
+    assert hasattr(C, "build_reasoning_prompt")
+    assert hasattr(C, "clean_reasoning")
+    assert hasattr(C, "reasoning_line")
+    assert hasattr(C, "ReasoningSidecar")
+    assert C.DEFAULT_REASON_MODEL == "nvidia/Cosmos-Reason2-2B"
+
+
+# ---------------------------------------------------------------------------
+# Prompt
+# ---------------------------------------------------------------------------
+
+def test_prompt_carries_instruction_verbatim() -> None:
+    instr = "stack the red cube on the green cube"
+    prompt = C.build_reasoning_prompt(instr)
+    assert instr in prompt
+    assert isinstance(prompt, str) and prompt.strip()
+
+
+def test_prompt_asks_for_a_concise_plan() -> None:
+    prompt = C.build_reasoning_prompt("put the mug on the shelf").lower()
+    # grounded in the scene + bounded length
+    assert "scene" in prompt
+    assert "concise" in prompt or "short" in prompt
+
+
+# ---------------------------------------------------------------------------
+# clean_reasoning
+# ---------------------------------------------------------------------------
+
+def test_clean_reasoning_collapses_whitespace() -> None:
+    assert C.clean_reasoning("  hello\n\n  world\t! ") == "hello world !"
+
+
+def test_clean_reasoning_truncates_to_max_chars() -> None:
+    out = C.clean_reasoning("x " * 500, max_chars=50)
+    assert len(out) <= 50
+
+
+def test_clean_reasoning_handles_empty_and_none() -> None:
+    assert C.clean_reasoning("") == ""
+    assert C.clean_reasoning(None) == ""  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# reasoning_line — the ODYSSEY_REASONING protocol surface
+# ---------------------------------------------------------------------------
+
+def test_reasoning_line_prefix_and_json_roundtrip() -> None:
+    line = C.reasoning_line(
+        episode=3, instruction="stack the cubes", reasoning="locate, grasp, place"
+    )
+    assert line.startswith("ODYSSEY_REASONING ")
+    payload = json.loads(line[len("ODYSSEY_REASONING "):])
+    assert payload == {
+        "episode": 3,
+        "instruction": "stack the cubes",
+        "reasoning": "locate, grasp, place",
+    }
+
+
+def test_reasoning_line_coerces_episode_to_int() -> None:
+    line = C.reasoning_line(episode="5", instruction="x", reasoning="y")  # type: ignore[arg-type]
+    payload = json.loads(line[len("ODYSSEY_REASONING "):])
+    assert payload["episode"] == 5 and isinstance(payload["episode"], int)
+
+
+# ---------------------------------------------------------------------------
+# ReasoningSidecar — lazy + guarded
+# ---------------------------------------------------------------------------
+
+def test_sidecar_constructs_without_loading() -> None:
+    sc = C.ReasoningSidecar(model_id="some/model", device="cpu", max_new_tokens=42)
+    assert sc.model_id == "some/model"
+    assert sc.device == "cpu"
+    assert sc.max_new_tokens == 42
+    # nothing loaded yet
+    assert sc._model is None and sc._proc is None
+
+
+def test_reason_returns_empty_string_on_failure() -> None:
+    sc = C.ReasoningSidecar()
+
+    def _boom() -> None:
+        raise RuntimeError("no GPU here")
+
+    sc.load = _boom  # type: ignore[method-assign]
+    # reason() must swallow the failure and yield an empty trace, never raise.
+    assert sc.reason(object(), "stack the cubes") == ""

--- a/tests/unit/test_cosmos_reason.py
+++ b/tests/unit/test_cosmos_reason.py
@@ -70,9 +70,18 @@ def test_clean_reasoning_collapses_whitespace() -> None:
     assert C.clean_reasoning("  hello\n\n  world\t! ") == "hello world !"
 
 
-def test_clean_reasoning_truncates_to_max_chars() -> None:
-    out = C.clean_reasoning("x " * 500, max_chars=50)
-    assert len(out) <= 50
+def test_clean_reasoning_truncates_on_word_boundary_with_ellipsis() -> None:
+    out = C.clean_reasoning("word " * 100, max_chars=50)
+    assert out.endswith("…")
+    assert len(out) <= 51  # max_chars budget + the single-char ellipsis
+    # No dangling partial word: every token before the ellipsis is intact.
+    assert all(tok == "word" for tok in out[:-1].split())
+
+
+def test_clean_reasoning_under_limit_is_unchanged() -> None:
+    # max_chars is a hard ceiling, not the expected length — short traces pass
+    # through verbatim with no ellipsis.
+    assert C.clean_reasoning("locate, grasp, place", max_chars=400) == "locate, grasp, place"
 
 
 def test_clean_reasoning_handles_empty_and_none() -> None:

--- a/tests/unit/test_isaac_lab.py
+++ b/tests/unit/test_isaac_lab.py
@@ -19,6 +19,9 @@ from odyssey.engine import TaskStatus
 from odyssey.engine.records import MissionRun
 from odyssey.runners.base import TaskContext
 from odyssey.runners.evals.isaac_lab import (
+    _EPISODE_PREFIX,
+    _REASONING_PREFIX,
+    _RESULT_PREFIX,
     EvalProtocolCollector,
     IsaacLabRunner,
     build_isaac_lab_argv,
@@ -177,6 +180,18 @@ def test_collector_distinguishes_result_from_reasoning() -> None:
     assert collector.result == {"success_rate": 0.5}
     assert len(collector.reasoning) == 1
     assert collector.reasoning[0]["episode"] == 1
+
+
+def test_prefixes_are_mutually_exclusive() -> None:
+    # Lock in the structural invariant the RESULT-before-REASONING parse order
+    # relies on: no ODYSSEY_* prefix may be a prefix of another (else a line
+    # could match the wrong bucket depending on check order). Guards a future
+    # rename/reorder from silently breaking disambiguation.
+    prefixes = [_EPISODE_PREFIX, _RESULT_PREFIX, _REASONING_PREFIX]
+    for a in prefixes:
+        for b in prefixes:
+            if a is not b:
+                assert not a.startswith(b), f"{a!r} starts with {b!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_isaac_lab.py
+++ b/tests/unit/test_isaac_lab.py
@@ -148,6 +148,37 @@ def test_collector_ignores_boot_noise() -> None:
     assert collector.parse("[INFO] Simulation App Startup Complete") is None
 
 
+def test_collector_records_reasoning_and_emits_progress() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse(
+        'ODYSSEY_REASONING {"episode": 2, "instruction": "stack the cubes", '
+        '"reasoning": "locate, grasp, place"}'
+    )
+    assert event is not None
+    assert event["step"] == "reasoning_received"
+    assert event["step_index"] == 2
+    assert collector.reasoning[0]["reasoning"] == "locate, grasp, place"
+
+
+def test_collector_skips_malformed_reasoning_line() -> None:
+    collector = EvalProtocolCollector()
+    assert collector.parse("ODYSSEY_REASONING {not json") is None
+    assert collector.reasoning == []
+
+
+def test_collector_distinguishes_result_from_reasoning() -> None:
+    # ODYSSEY_RESULT and ODYSSEY_REASONING share the ODYSSEY_RE prefix; each
+    # must land in its own bucket and not be mistaken for the other.
+    collector = EvalProtocolCollector()
+    collector.parse('ODYSSEY_RESULT {"success_rate": 0.5}')
+    collector.parse(
+        'ODYSSEY_REASONING {"episode": 1, "instruction": "x", "reasoning": "y"}'
+    )
+    assert collector.result == {"success_rate": 0.5}
+    assert len(collector.reasoning) == 1
+    assert collector.reasoning[0]["episode"] == 1
+
+
 # ---------------------------------------------------------------------------
 # Summary scoring
 # ---------------------------------------------------------------------------
@@ -196,6 +227,34 @@ def test_summary_prefers_explicit_result(tmp_path: Path) -> None:
     assert summary["metrics"]["sim_steps"] == 1234
 
 
+def test_summary_includes_reasoning_when_present(tmp_path: Path) -> None:
+    collector = _collector_with_episodes(True, False)
+    collector.parse(
+        'ODYSSEY_REASONING {"episode": 1, "instruction": "lift the cube", '
+        '"reasoning": "locate the cube, grasp it, lift"}'
+    )
+    summary = summarize(
+        collector=collector,
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    traces = summary["metrics"]["reasoning"]
+    assert len(traces) == 1
+    assert traces[0]["episode"] == 1
+    assert "grasp" in traces[0]["reasoning"]
+
+
+def test_summary_omits_reasoning_when_absent(tmp_path: Path) -> None:
+    summary = summarize(
+        collector=_collector_with_episodes(True, True),
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert "reasoning" not in summary["metrics"]
+
+
 def test_summary_without_protocol_output_raises(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="protocol"):
         summarize(
@@ -220,6 +279,9 @@ import json, sys
 args = sys.argv[1:]
 num_episodes = int(args[args.index("--num_episodes") + 1])
 for i in range(1, num_episodes + 1):
+    print("ODYSSEY_REASONING " + json.dumps(
+        {"episode": i, "instruction": "lift the cube", "reasoning": "grasp then lift"}
+    ))
     print("ODYSSEY_EPISODE " + json.dumps(
         {"index": i, "total": num_episodes, "success": i % 2 == 1, "return": 1.0}
     ))
@@ -279,3 +341,10 @@ def test_runner_end_to_end_with_fake_script(tmp_path: Path) -> None:
     assert summary["success_rate"] == 0.5
     assert summary["passed"] is True
     assert summary["metrics"]["successes"] == 2
+    # The ODYSSEY_REASONING lines flowed through the real subprocess +
+    # collector and landed in the summary, one trace per episode.
+    traces = summary["metrics"]["reasoning"]
+    assert len(traces) == 4
+    assert traces[0] == {
+        "episode": 1, "instruction": "lift the cube", "reasoning": "grasp then lift"
+    }


### PR DESCRIPTION
# feat(eval): Cosmos-Reason intent-trace sidecar + eval-protocol consumer

> **PR 1 of 2** for the Tier-3 "reasoning + acting" feature. This is the *mechanism*
> — how a trace is generated and how it's carried through the eval protocol. It is
> **independent of #25** and mergeable now. PR 2 wires the producer (emitting the trace
> from the GR00T eval recipe) and depends on #25.

## Summary

GR00T-N1.7 runs on the **Cosmos-Reason2-2B** backbone (a generative Qwen3-VL). This PR
adds the ability to query that *same* backbone as a VLM and carry a short
natural-language **intent trace** through Odyssey's `ODYSSEY_*` eval protocol — the
"reasoning **and** acting" surface for the demo and Episode Review.

Two decoupled, additive pieces:

1. **Sidecar** — `runners/evals/cosmos_reason.py`
   `ReasoningSidecar.reason(frame, instruction) -> str`: lazy-loads
   `nvidia/Cosmos-Reason2-2B` once, **guarded** so a flaky trace can never fail or stall
   an eval (returns `""` on any error). Pure, stdlib-only protocol surface
   (`build_reasoning_prompt` / `clean_reasoning` / `reasoning_line`) + a standalone CLI
   for narrating over a captured frame. Heavy deps (torch/transformers/PIL/numpy) are
   deferred to the generate path; imported by path so the surface stays unit-testable on
   a CPU box.

2. **Consumer** — `runners/evals/isaac_lab.py`
   `EvalProtocolCollector` parses the optional `ODYSSEY_REASONING` line (distinct from
   `ODYSSEY_RESULT` despite the shared `ODYSSEY_RE` prefix) and `summarize()` carries the
   per-episode traces into `metrics["reasoning"]` so Command Center / Episode Review can
   show reasoning beside the grade.

**Nothing emits the line yet** — that's PR 2. Until then this is inert: an eval that
never emits `ODYSSEY_REASONING` behaves exactly as before.

## Protocol

```
ODYSSEY_REASONING {"episode": 1, "instruction": "...", "reasoning": "..."}
```

Mirrors the existing `episode_line` / `result_line` helpers.

## Try the sidecar (standalone)

The sidecar ships a CLI, so you can narrate over any captured frame without a running
eval — useful for the demo and for sanity-checking the model:

```bash
# in an env with transformers + torch + the cached model:
python src/odyssey/runners/evals/cosmos_reason.py \
  --image frame.png \
  --instruction "stack the red cube on the green cube"
# -> REASONING: Locate the red cube ... grasp ... place it on the green cube.
# -> ODYSSEY_REASONING {"episode": 1, "instruction": "...", "reasoning": "..."}
```

(Emitting the trace *during a live eval* is PR 2.)

## Honest framing

The action policy is what drives the robot. This trace is a *parallel intent narration*
from the same backbone family — a per-episode, scene-grounded plan for human review and
demos, **not** a literal action-by-action rationale and not a control signal.

## Testing (TDD)

- **Unit** — 12 sidecar tests (prompt / clean / protocol-line / lazy-load / guarded /
  frame normalisation) + isaac_lab eval tests extended to 23 (collector records & skips
  malformed reasoning, RESULT-vs-REASONING disambiguation, summary includes-when-present /
  omits-when-absent, and the end-to-end fake-script test emits `ODYSSEY_REASONING` and
  asserts one trace per episode survives the real subprocess → collector → summary path).
  `ruff` + `mypy --strict` clean (toolchain matched to CI: ruff 0.15.18 / mypy 2.1.0).

- **Live (H100)** — the sidecar was exercised against a **real GR00T LIBERO rollout**
  frame and produced a coherent, scene-grounded trace; a perception-only probe (no task
  given) named the actual scene objects (cookie box, stove, 3-drawer cabinet), confirming
  it reads pixels rather than echoing the instruction. Demo panel:
  `demo_assets/demo_panel.png`.

## Live validation caught two real bugs (fixed + regression-tested here)

Both silently produced empty traces and were invisible to the standalone tests/CLI:

1. `device_map=` in `load()` requires `accelerate`, absent in the sim eval venvs →
   load + `.to(device)` (portable to any torch+transformers env).
2. `hasattr(frame, "size")` can't distinguish a numpy array from a PIL image, and sim
   agentviews are flipped (`[::-1, ::-1]`) into negative-stride views transformers'
   fast image processor rejects → new `_to_pil()` (`isinstance` + `np.ascontiguousarray`),
   with unit tests for the negative-stride and PIL-passthrough cases.

## Follow-up

- **PR 2** — emit `ODYSSEY_REASONING` per episode from the GR00T eval recipe
  (`gr00t_isaac_eval.py`); depends on **#25** and on this PR.
- Surfacing `metrics["reasoning"]` in the Command Center / Episode Review UI.

## Checklist

- [x] TDD: tests accompany the change; 12 sidecar + 23 isaac_lab green
- [x] `ruff check src tests` + `mypy --strict` clean
- [x] Additive & guarded — no behavior change when no trace is emitted
- [x] Targets `develop`
