### PR TITLE
chore(release): bump version to v0.1.0-alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lovell-odyssey"
-version = "0.0.1"
+version = "0.1.0a1"
 description = "Open-source framework for defining, running, and benchmarking robot training missions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
 """Odyssey — open-source framework for robot training missions."""
 
-__version__ = "0.0.1"
+__version__ = "0.1.0a1"


### PR DESCRIPTION
## What
Version bump for the **first public alpha** — `0.0.1` → `0.1.0a1` (the PEP 440 form of `v0.1.0-alpha`).

This lands on `develop` first so develop and main agree on the version; the release PR `develop → main` will then carry it.

## Changes
- `pyproject.toml`: `version = "0.1.0a1"`
- `src/odyssey/__init__.py`: `__version__ = "0.1.0a1"` (the CLI's `--version` reads this)

## Verification
`odyssey --version` → `odyssey, version 0.1.0a1`. ruff + mypy --strict clean.

Next: open the release PR `develop → main` and tag `v0.1.0-alpha` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)