### PR TITLE
fix(ci): unblock Python 3.12 — skip numpy stubs in mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,12 @@ warn_unused_configs = true
 module = ["huggingface_hub", "datasets", "robosuite", "transformers", "peft", "torch", "PIL", "numpy", "numpy.typing"]
 ignore_missing_imports = true
 follow_imports = "skip"
+# Also skip these libs' bundled .pyi stubs. By default mypy follows imports into
+# stub files even when follow_imports="skip", so it parses numpy's installed
+# stubs — and numpy 2.5's stubs use PEP 695 `type` statements that fail under
+# our python_version=3.10 target (CI 3.12 job). Skipping stubs treats these as
+# Any (already the intent) and stops the parse error.
+follow_imports_for_stubs = true
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Problem
`main` CI is **red on the Python 3.12 job** (3.10 + 3.11 + all pytest are green). It's the **Mypy** step, not tests:

```
numpy/__init__.pyi:737: error: Type statement is only supported in Python 3.12 and greater  [syntax]
```

## Root cause — dependency drift, not a code change
CI doesn't pin dependencies, so each run installs the newest numpy. Between 2026-06-21 (green) and 2026-06-22 (red) **numpy 2.5.0** was published. The 3.12 job pulls it; its `numpy/__init__.pyi` uses PEP 695 `type X = ...` statements, which mypy rejects under our `python_version = "3.10"` target. The failing commits touch **docs only** — no code/config changed.

numpy is already meant to be excluded (`follow_imports = "skip"`), but **mypy follows imports into `.pyi` stubs by default even when skip is set**, so it parsed numpy's stub and hit the syntax error.

## Fix
Add `follow_imports_for_stubs = true` to the existing numpy/torch/etc. mypy override, so the skip applies to stub files too. numpy is treated as `Any` — which was already the intent.

## Why this is safe (not masking a bug)
- **pytest is green on all 3 versions**, so numpy 2.5 doesn't break the runtime.
- The repo never type-checked numpy (it was already `skip`ped); this only stops mypy parsing numpy's *own* stub file.
- Errors in **our** code are still reported.

## Verification (local, Python 3.10)
`mypy` clean (config accepted — `warn_unused_configs` didn't flag it) · ruff clean · 283 passed. The 3.12 green will be confirmed by this PR's CI.

> Follow-up (not this PR): pinning dependency versions would make CI reproducible and prevent this class of 'green yesterday, red today' breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)