### PR TITLE
fix(ci): set mypy python_version to 3.12 so it parses numpy's PEP 695 stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ ignore = [
 ]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 strict = true
 files = ["src/odyssey"]
 warn_unused_configs = true


### PR DESCRIPTION
## Problem
The **`Test (Python 3.12)`** CI job fails at the `mypy src/odyssey` step (and has been failing on `develop` itself, independent of any PR):

```
.../python3.12/site-packages/numpy/__init__.pyi:737: error:
  Type statement is only supported in Python 3.12 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

mypy is configured `python_version = "3.10"`. On the 3.12 runner the installed **numpy (≥2.2) ships stubs that use PEP 695 `type` aliases** (3.12-only syntax); mypy, told to target 3.10, refuses to parse them → exit 2. The 3.10/3.11 jobs pass because their numpy stubs predate PEP 695. (numpy is in mypy's ignore-list, but `follow_imports = "skip"` doesn't stop the stub from being parsed.)

## Fix
Bump the mypy target to `python_version = "3.12"`. The code already runs on 3.10–3.12, and `pytest` still runs per-version, so version-specific *runtime* issues are still caught.

## Verification
Reproduced the exact error and confirmed the fix with `mypy` + `numpy 2.5.0`:
- `mypy --python-version 3.10` on `import numpy` → `numpy/__init__.pyi:737: ... Type statement is only supported in Python 3.12 and greater` (identical to CI)
- `mypy --python-version 3.12` → `Success: no issues found`

Unblocks the 3.12 job on `develop` and every open PR (incl. #36).
