### PR TITLE
refactor: extract shared evaluation helpers and improve environment compatibility

### DIFF
--- a/src/odyssey/runners/cpu_mock.py
+++ b/src/odyssey/runners/cpu_mock.py
@@ -90,12 +90,13 @@ class CPUMockRunner(Runner):
             await self._sleep(context)
 
         success_rate = successes / episodes if episodes else 1.0
+        from odyssey.runners.evals._common import grade
         return {
             "_mock": True,
             "num_episodes": episodes,
             "success_rate": success_rate,
             "performance_score": success_rate,
-            "letter_grade": "A" if success_rate >= 0.9 else "B",
+            "letter_grade": grade(success_rate),
             "passed": success_rate >= 0.5,
             "benchmark_name": spec.benchmark_name,
         }

--- a/src/odyssey/runners/evals/_common.py
+++ b/src/odyssey/runners/evals/_common.py
@@ -1,0 +1,86 @@
+"""Shared evaluation runner utilities and results contracts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import TaskContext
+
+
+def grade(success_rate: float) -> str:
+    """Map a success rate to the A-F letter grade. Single source of truth."""
+    if success_rate >= 0.9:
+        return "A"
+    if success_rate >= 0.8:
+        return "B"
+    if success_rate >= 0.7:
+        return "C"
+    if success_rate >= 0.6:
+        return "D"
+    return "F"
+
+
+def build_eval_summary(
+    *,
+    num_episodes: int,
+    successes: int,
+    episode_returns: list[float],
+    benchmark_name: str,
+    checkpoint_path: Path | str,
+    metrics: dict[str, Any] | None = None,
+    success_rate: float | None = None,
+    performance_score: float | None = None,
+) -> dict[str, Any]:
+    """Build the success_rate / performance_score / letter_grade / passed / metrics
+
+    dictionary that the trainer expects. One place to evolve the contract.
+    """
+    if success_rate is None:
+        success_rate = successes / num_episodes if num_episodes else 0.0
+    if performance_score is None:
+        performance_score = (
+            sum(episode_returns) / num_episodes if num_episodes else 0.0
+        )
+
+    out_metrics = dict(metrics or {})
+    out_metrics.setdefault("successes", successes)
+    out_metrics.setdefault(
+        "episode_returns", [round(r, 4) for r in episode_returns]
+    )
+    out_metrics.setdefault("benchmark", benchmark_name)
+    out_metrics.setdefault("checkpoint_path", str(checkpoint_path))
+
+    return {
+        "num_episodes": num_episodes,
+        "success_rate": round(success_rate, 4),
+        "performance_score": round(performance_score, 4),
+        "letter_grade": grade(success_rate),
+        "passed": success_rate >= 0.5,
+        "metrics": out_metrics,
+    }
+
+
+def resolve_eval_checkpoint(context: TaskContext) -> Path:
+    """Find the PILOT checkpoint the evaluation should run.
+
+    Uses ``context.agent_checkpoints`` (populated by the engine) to find
+    the first PILOT agent with a trained checkpoint. Multi-agent loadouts
+    (PILOT + SPECIALIST) are supported — the SPECIALIST doesn't need a
+    checkpoint (it uses its base model for inference only).
+    """
+    from odyssey.spec.agents import AgentRole
+
+    for agent in context.agents or context.mission.spec.robot.agents:
+        if agent.role != AgentRole.PILOT:
+            continue
+        checkpoint = (context.agent_checkpoints or {}).get(agent.id)
+        if not checkpoint:
+            checkpoint = context.mission.latest_checkpoint_for(agent.id)
+        if checkpoint:
+            return Path(checkpoint)
+
+    raise ValueError(
+        "No completed training task produced a checkpoint for any PILOT "
+        "agent on this mission — cannot evaluate."
+    )

--- a/src/odyssey/runners/evals/isaac_lab.py
+++ b/src/odyssey/runners/evals/isaac_lab.py
@@ -46,9 +46,11 @@ from typing import Any
 
 from odyssey.runners.base import Runner, TaskContext
 
-# Shared eval helpers; extract to a common module when a third
-# evaluation runner needs them.
-from odyssey.runners.evals.robosuite import _grade, _resolve_eval_checkpoint
+# Shared eval helpers
+from odyssey.runners.evals._common import (
+    build_eval_summary,
+    resolve_eval_checkpoint,
+)
 from odyssey.runners.subprocess import (
     TrainingProcessSpec,
     run_training_subprocess,
@@ -235,26 +237,22 @@ def summarize(
             "the protocol. See src/odyssey/runners/isaac_lab.py."
         )
 
-    metrics.setdefault("successes", successes)
-    metrics.setdefault(
-        "episode_returns", [round(r, 4) for r in episode_returns]
-    )
-    metrics.setdefault("benchmark", spec.benchmark_name)
-    metrics.setdefault("checkpoint_path", str(checkpoint))
     metrics.setdefault("eval_script", eval_script)
     # Carry the per-episode intent traces (if the eval emitted any) into the
     # summary so Command Center / Episode Review can show reasoning beside the
     # grade. Absent when the eval doesn't speak ODYSSEY_REASONING.
     if collector.reasoning:
         metrics.setdefault("reasoning", collector.reasoning)
-    return {
-        "num_episodes": num_episodes,
-        "success_rate": round(success_rate, 4),
-        "performance_score": round(performance_score, 4),
-        "letter_grade": _grade(success_rate),
-        "passed": success_rate >= 0.5,
-        "metrics": metrics,
-    }
+    return build_eval_summary(
+        num_episodes=num_episodes,
+        successes=successes,
+        episode_returns=episode_returns,
+        benchmark_name=spec.benchmark_name,
+        checkpoint_path=checkpoint,
+        metrics=metrics,
+        success_rate=success_rate,
+        performance_score=performance_score,
+    )
 
 
 class IsaacLabRunner(Runner):
@@ -279,7 +277,7 @@ class IsaacLabRunner(Runner):
                 f"IsaacLabRunner expects EvaluationTask, got {type(spec).__name__}"
             )
 
-        checkpoint = _resolve_eval_checkpoint(context)
+        checkpoint = resolve_eval_checkpoint(context)
         eval_script = resolve_eval_script(spec.config or {})
         launcher = resolve_launcher()
 

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -38,6 +38,10 @@ from pathlib import Path
 from typing import Any
 
 from odyssey.runners.base import Runner, TaskContext
+from odyssey.runners.evals._common import (
+    build_eval_summary,
+    resolve_eval_checkpoint,
+)
 from odyssey.spec.mission import RobotSpec
 from odyssey.spec.tasks import EvaluationTask, EvaluationType, TaskKind
 
@@ -183,7 +187,7 @@ class RobosuiteRunner(Runner):
                 f"RobosuiteRunner expects EvaluationTask, got {type(spec).__name__}"
             )
 
-        checkpoint = _resolve_eval_checkpoint(context)
+        checkpoint = resolve_eval_checkpoint(context)
         await context.emit_progress(
             "model_loading",
             step="load_policy",
@@ -313,37 +317,13 @@ class RobosuiteRunner(Runner):
             runtime.close()
 
         attempted = len(episode_returns)
-        success_rate = (successes / attempted) if attempted else 0.0
-        performance_score = (
-            sum(episode_returns) / max(attempted, 1)
-            if episode_returns
-            else 0.0
+        return build_eval_summary(
+            num_episodes=attempted,
+            successes=successes,
+            episode_returns=episode_returns,
+            benchmark_name=spec.benchmark_name,
+            checkpoint_path=checkpoint,
         )
-        return {
-            "num_episodes": attempted,
-            "success_rate": round(success_rate, 4),
-            "performance_score": round(performance_score, 4),
-            "letter_grade": _grade(success_rate),
-            "passed": success_rate >= 0.5,
-            "metrics": {
-                "successes": successes,
-                "episode_returns": [round(r, 4) for r in episode_returns],
-                "benchmark": spec.benchmark_name,
-                "checkpoint_path": str(checkpoint),
-            },
-        }
-
-
-def _grade(success_rate: float) -> str:
-    if success_rate >= 0.9:
-        return "A"
-    if success_rate >= 0.8:
-        return "B"
-    if success_rate >= 0.7:
-        return "C"
-    if success_rate >= 0.6:
-        return "D"
-    return "F"
 
 
 def _resolve_robosuite_robot(robot: RobotSpec) -> str | None:
@@ -372,29 +352,7 @@ def _resolve_robosuite_robot(robot: RobotSpec) -> str | None:
     return name
 
 
-def _resolve_eval_checkpoint(context: TaskContext) -> Path:
-    """Find the PILOT checkpoint the eval should run.
 
-    Uses ``context.agent_checkpoints`` (populated by the engine) to find
-    the first PILOT agent with a trained checkpoint. Multi-agent loadouts
-    (PILOT + SPECIALIST) are supported — the SPECIALIST doesn't need a
-    checkpoint (it uses its base model for inference only).
-    """
-    from odyssey.spec.agents import AgentRole
-
-    for agent in context.agents or context.mission.spec.robot.agents:
-        if agent.role != AgentRole.PILOT:
-            continue
-        checkpoint = (context.agent_checkpoints or {}).get(agent.id)
-        if not checkpoint:
-            checkpoint = context.mission.latest_checkpoint_for(agent.id)
-        if checkpoint:
-            return Path(checkpoint)
-
-    raise ValueError(
-        "No completed training task produced a checkpoint for any PILOT "
-        "agent on this mission — cannot evaluate."
-    )
 
 
 def _has_specialist(context: TaskContext) -> bool:

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -352,9 +352,6 @@ def _resolve_robosuite_robot(robot: RobotSpec) -> str | None:
     return name
 
 
-
-
-
 def _has_specialist(context: TaskContext) -> bool:
     """Check whether the loadout includes a SPECIALIST agent."""
     from odyssey.spec.agents import AgentRole

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -108,7 +108,7 @@ async def run_training_subprocess(
             f"--nproc_per_node={spec.torchrun_nproc}",
         ]
     else:
-        launcher = ["python"]
+        launcher = [sys.executable]
 
     if spec.entry_module is not None:
         cmd = [*launcher, "-m", spec.entry_module, *spec.argv_extra]


### PR DESCRIPTION
This pull request refactors the evaluation runner components in lovellai-dev/odyssey to extract a shared evaluation results module (src/odyssey/runners/evals/_common.py). This eliminates code duplication and fragile cross-runner private imports.

Closes #40

Changes:
1. Created src/odyssey/runners/evals/_common.py providing grade(), build_eval_summary(), and resolve_eval_checkpoint().
2. Refactored robosuite.py, isaac_lab.py, and cpu_mock.py to import and use the new shared functions instead of duplicating implementation or using sibling private imports.
3. Updated src/odyssey/runners/subprocess.py to use sys.executable as the default python launcher command, ensuring test execution and process execution succeed in environments where python is not in the PATH.
