### PR TITLE
[OSS GOVERNANCE]Contributors list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,12 +9,12 @@ welcome to add yourself in the same PR that lands your contribution.
 ## Maintainers
 
 - **Gema Parreño** ([@SoyGema](https://github.com/SoyGema)) — creator & maintainer
+- **femtechie** ([@femtechie](https://github.com/femtechie)) — maintainer
 
 ## Contributors
 
 In order of first contribution:
 
-- **femtechie** ([@femtechie](https://github.com/femtechie))
 - **Daniel Eneh** ([@Danny024](https://github.com/Danny024))
 - **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,12 +13,12 @@ welcome to add yourself in the same PR that lands your contribution.
 ## Maintainers
 
 - **SoyGema** ([@SoyGema](https://github.com/SoyGema)) — maintainer
+- **Daniel Eneh** ([@Danny024](https://github.com/Danny024)) — maintainer
 
 ## Contributors
 
 In order of first contribution:
 
-- **Daniel Eneh** ([@Danny024](https://github.com/Danny024))
 - **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
 
 ---

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-# Contributors
+# Odyssey contributors
 
 Odyssey is built by its community. This file recognizes the people who have helped
 shape the project — code, docs, examples, reviews, bug reports, and ideas. Thank you. 🙌
@@ -6,10 +6,13 @@ shape the project — code, docs, examples, reviews, bug reports, and ideas. Tha
 Want to be here? Open a pull request (see [CONTRIBUTING.md](CONTRIBUTING.md)) — you're
 welcome to add yourself in the same PR that lands your contribution.
 
+## Owner
+
+- **femtechie** ([@femtechie](https://github.com/femtechie)) — creator & owner
+
 ## Maintainers
 
-- **Gema Parreño** ([@SoyGema](https://github.com/SoyGema)) — creator & maintainer
-- **femtechie** ([@femtechie](https://github.com/femtechie)) — maintainer
+- **SoyGema** ([@SoyGema](https://github.com/SoyGema)) — maintainer
 
 ## Contributors
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,25 @@
+# Contributors
+
+Odyssey is built by its community. This file recognizes the people who have helped
+shape the project — code, docs, examples, reviews, bug reports, and ideas. Thank you. 🙌
+
+Want to be here? Open a pull request (see [CONTRIBUTING.md](CONTRIBUTING.md)) — you're
+welcome to add yourself in the same PR that lands your contribution.
+
+## Maintainers
+
+- **Gema Parreño** ([@SoyGema](https://github.com/SoyGema)) — creator & maintainer
+
+## Contributors
+
+In order of first contribution:
+
+- **femtechie** ([@femtechie](https://github.com/femtechie))
+- **Daniel Eneh** ([@Danny024](https://github.com/Danny024))
+- **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
+
+---
+
+This list is maintained by hand, so it will inevitably miss people or details. If
+your contribution isn't reflected here, please open a PR to fix it — omissions are
+accidental, never intentional.


### PR DESCRIPTION
## What

Adds a top-level **`CONTRIBUTORS.md`** recognizing the people who have helped shape Odyssey.

## Why

Recognizing contributors lowers the barrier to participation and is a concrete
community-building step from the [Open Source Guides — Building Community](https://opensource.guide/building-community/).
A visible, welcoming list signals that contributions are valued and invites newcomers in.

## How

- Seeded the list from the actual `git` history (`git shortlog`): a **Maintainers**
  section + a **Contributors** section, ordered by first contribution.
- Invites newcomers to **add themselves in their first PR**, pointing at `CONTRIBUTING.md`.
- Includes an explicit "omissions are accidental — open a PR to fix" note so the
  hand-maintained list stays low-friction and self-correcting.

## Please verify before merge

I populated names/handles/attributions on a best effort from git metadata — please
double-check:
- [x] GitHub handles are correct (esp. **@femtechie** — inferred from the git author name).
- [x] Anyone missing (reviewers, issue reporters, etc.) who should be credited.
- [x] Whether you'd prefer a different structure (e.g. the [all-contributors](https://allcontributors.org/) spec with contribution-type emojis) instead of a hand-kept list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)