### PR TITLE
fix(runners): watchdog deadline + reap for the training/eval subprocess

### DIFF
--- a/src/odyssey/runners/evals/isaac_lab.py
+++ b/src/odyssey/runners/evals/isaac_lab.py
@@ -292,6 +292,7 @@ class IsaacLabRunner(Runner):
 
         collector = EvalProtocolCollector()
         process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
             script_path=eval_script,
             launcher=launcher,
             argv_extra=build_isaac_lab_argv(task=spec, checkpoint=checkpoint),

--- a/src/odyssey/runners/models/gr00t.py
+++ b/src/odyssey/runners/models/gr00t.py
@@ -266,6 +266,7 @@ class GR00TRunner(Runner):
             agent_model_base = context.agent.model.base
 
         process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
             entry_module=_ENTRY_MODULE,
             argv_extra=build_gr00t_argv(
                 task=spec.model_copy(update={"config": config}),

--- a/src/odyssey/runners/models/openvla.py
+++ b/src/odyssey/runners/models/openvla.py
@@ -337,6 +337,7 @@ class OpenVLARunner(Runner):
             agent_model_base = context.agent.model.base
 
         process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
             script_path=script_path,
             use_torchrun=True,
             argv_extra=build_openvla_argv(

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -62,6 +62,11 @@ class TrainingProcessSpec:
     line_parser: LineParser | None = None
     cwd: str | None = None
     sigterm_grace_seconds: float = 30.0
+    # Hard wall-clock deadline for the subprocess. When set, the child is killed
+    # (SIGTERM then SIGKILL after the grace) and the run fails with
+    # SubprocessTimeoutError — bounds hangs in Isaac boot / a ZMQ handshake / a
+    # policy server that never replies. None = no deadline (legacy behavior).
+    timeout_seconds: float | None = None
     use_torchrun: bool = False
     torchrun_nproc: int = 1
     # Optional command prefix replacing the default ``python`` for
@@ -87,6 +92,81 @@ class TrainingProcessSpec:
                 "TrainingProcessSpec.launcher and use_torchrun are mutually "
                 "exclusive — both define the command prefix"
             )
+
+
+class SubprocessTimeoutError(RuntimeError):
+    """Raised when a training/eval subprocess exceeds its wall-clock deadline."""
+
+
+# How long to wait draining the child's stdout after it exits before giving up.
+# A grandchild that inherited the pipe (e.g. a co-launched server) can keep the
+# write-end open so EOF never arrives — don't block the runner forever.
+_STDOUT_DRAIN_TIMEOUT = 30.0
+
+
+def _child_preexec() -> None:
+    """preexec_fn for the training/eval child (Linux): put it in its own session
+    so cancellation can signal the whole tree, AND set PR_SET_PDEATHSIG so the
+    kernel SIGKILLs it if this runner process dies — no orphaned GPU subprocess.
+    """
+    os.setsid()
+    try:
+        import ctypes
+
+        _PR_SET_PDEATHSIG = 1
+        ctypes.CDLL("libc.so.6", use_errno=True).prctl(
+            _PR_SET_PDEATHSIG, signal.SIGKILL, 0, 0, 0
+        )
+    except Exception:
+        # Best-effort: setsid already gives cancellation reach; PDEATHSIG is a
+        # bonus reap-on-crash. Never fail the launch if libc/prctl is unavailable.
+        pass
+
+
+def _kill_process_group(proc: asyncio.subprocess.Process, sig: int) -> None:
+    """Send `sig` to the child's whole process group (best-effort)."""
+    if proc.pid is None:
+        return
+    with suppress(ProcessLookupError):
+        os.killpg(os.getpgid(proc.pid), sig)
+
+
+async def _wait_with_deadline(
+    ctx: TaskContext, proc: asyncio.subprocess.Process, spec: TrainingProcessSpec
+) -> int:
+    """await proc.wait() bounded by ``spec.timeout_seconds``.
+
+    On deadline: SIGTERM the child's process group, wait ``sigterm_grace_seconds``,
+    escalate to SIGKILL, then raise ``SubprocessTimeoutError``. With no deadline,
+    waits normally.
+    """
+    if spec.timeout_seconds is None:
+        return await proc.wait()
+    try:
+        return await asyncio.wait_for(proc.wait(), timeout=spec.timeout_seconds)
+    except asyncio.TimeoutError:
+        logger.error(
+            "Task %s exceeded its %.0fs deadline — SIGTERM pid=%s",
+            ctx.task.id,
+            spec.timeout_seconds,
+            proc.pid,
+        )
+        _kill_process_group(proc, signal.SIGTERM)
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=spec.sigterm_grace_seconds)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Task %s did not exit within %.0fs of SIGTERM — SIGKILL",
+                ctx.task.id,
+                spec.sigterm_grace_seconds,
+            )
+            _kill_process_group(proc, signal.SIGKILL)
+            with suppress(Exception):
+                await proc.wait()
+        raise SubprocessTimeoutError(
+            f"task {ctx.task.id} exceeded its deadline of "
+            f"{spec.timeout_seconds:.0f}s"
+        )
 
 
 async def run_training_subprocess(
@@ -141,8 +221,9 @@ async def run_training_subprocess(
         stderr=asyncio.subprocess.STDOUT,  # merge to one stream
         env=env,
         cwd=spec.cwd,
-        # New process group so SIGTERM targets only this child tree.
-        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        # New process group so SIGTERM targets only this child tree, plus
+        # PR_SET_PDEATHSIG so a runner crash can't orphan a GPU subprocess.
+        preexec_fn=_child_preexec if hasattr(os, "setsid") else None,
         # tqdm progress bars use \r without \n, which can accumulate
         # into a single "line" that exceeds asyncio's default 64 KB
         # buffer.  10 MB is enough for long training runs.
@@ -159,12 +240,25 @@ async def run_training_subprocess(
     )
 
     try:
-        rc = await proc.wait()
+        rc = await _wait_with_deadline(ctx, proc, spec)
     finally:
         cancel_task.cancel()
         with suppress(asyncio.CancelledError):
             await cancel_task
-        await stdout_task  # drain any remaining lines
+        # Bound the stdout drain: on Python 3.12 proc.wait() itself already
+        # returned above, but a grandchild that inherited the pipe can keep the
+        # write-end open so _stream_stdout never sees EOF. Don't wait forever.
+        try:
+            await asyncio.wait_for(stdout_task, timeout=_STDOUT_DRAIN_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "stdout drain for task %s timed out after %.0fs — cancelling",
+                ctx.task.id,
+                _STDOUT_DRAIN_TIMEOUT,
+            )
+            stdout_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await stdout_task
 
     logger.info("Subprocess for task %s exited rc=%d", ctx.task.id, rc)
     return rc

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -166,7 +166,7 @@ async def _wait_with_deadline(
         raise SubprocessTimeoutError(
             f"task {ctx.task.id} exceeded its deadline of "
             f"{spec.timeout_seconds:.0f}s"
-        )
+        ) from None
 
 
 async def run_training_subprocess(

--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -21,7 +21,8 @@ import os
 import re
 import signal
 import sys
-from collections.abc import Callable
+from collections import deque
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -98,6 +99,44 @@ class SubprocessTimeoutError(RuntimeError):
     """Raised when a training/eval subprocess exceeds its wall-clock deadline."""
 
 
+class SubprocessResourceError(RuntimeError):
+    """Raised when a subprocess failure is classified as resource exhaustion
+    (GPU OOM / out of disk) — a clearer signal than a bare non-zero exit code."""
+
+
+# (signature, operator-facing reason). Scanned against the tail of the child's
+# output on a non-zero exit so a resource failure reads as such, not "rc=1".
+_RESOURCE_FAILURE_SIGNATURES: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(
+            r"CUDA out of memory|CUBLAS_STATUS_ALLOC_FAILED"
+            r"|torch\.cuda\.OutOfMemoryError|CUDA error: out of memory",
+            re.IGNORECASE,
+        ),
+        "GPU out of memory (CUDA OOM) — reduce batch size / model size "
+        "or use a larger GPU",
+    ),
+    (
+        re.compile(
+            r"No space left on device|\bENOSPC\b|\[Errno 28\]"
+            r"|disk quota exceeded",
+            re.IGNORECASE,
+        ),
+        "ran out of disk space — free space on the output / HF-cache volume",
+    ),
+]
+
+
+def _classify_failure(tail: Iterable[str]) -> str | None:
+    """Return an operator-facing reason if the output tail matches a known
+    resource-exhaustion signature, else None."""
+    text = "\n".join(tail)
+    for pattern, reason in _RESOURCE_FAILURE_SIGNATURES:
+        if pattern.search(text):
+            return reason
+    return None
+
+
 # How long to wait draining the child's stdout after it exits before giving up.
 # A grandchild that inherited the pipe (e.g. a co-launched server) can keep the
 # write-end open so EOF never arrives — don't block the runner forever.
@@ -129,6 +168,43 @@ def _kill_process_group(proc: asyncio.subprocess.Process, sig: int) -> None:
         return
     with suppress(ProcessLookupError):
         os.killpg(os.getpgid(proc.pid), sig)
+
+
+async def _reap_if_alive(proc: asyncio.subprocess.Process, grace: float) -> None:
+    """If the child is still running, SIGTERM its process group and, failing to
+    exit within ``grace``, SIGKILL. Best-effort cleanup for *any* exit from
+    run_training_subprocess (a cancelled runner task, an unexpected error) so the
+    child is never orphaned. Normal completion and the deadline path have already
+    reaped, so this is a no-op then.
+    """
+    if proc.returncode is not None:
+        return
+    _kill_process_group(proc, signal.SIGTERM)
+    # suppress(Exception) does NOT swallow CancelledError (BaseException), so a
+    # re-cancel during unwinding still propagates — but the SIGTERM above already
+    # fired synchronously, so the child dies regardless.
+    with suppress(Exception):
+        await asyncio.wait_for(proc.wait(), timeout=grace)
+    if proc.returncode is None:
+        _kill_process_group(proc, signal.SIGKILL)
+        with suppress(Exception):
+            await proc.wait()
+
+
+def _build_child_env(spec: TrainingProcessSpec) -> dict[str, str]:
+    """Environment for the child: the parent env overlaid with ``spec.env``.
+
+    PYTHONPATH is dropped from the inherited env unless the spec sets it
+    explicitly. The child runs under its OWN interpreter — a training venv via
+    ``sys.executable``, or ``isaaclab.sh -p`` — and a leaked orchestrator
+    PYTHONPATH (ROS Jazzy, an editable checkout, …) can shadow the child's own
+    packages with a different torch / prismatic / isaacsim. Mirrors the
+    ``env -u PYTHONPATH`` hygiene used across the platform's venvs.
+    """
+    env = {**os.environ, **spec.env}
+    if "PYTHONPATH" not in spec.env:
+        env.pop("PYTHONPATH", None)
+    return env
 
 
 async def _wait_with_deadline(
@@ -205,7 +281,7 @@ async def run_training_subprocess(
         # script_path is guaranteed by __post_init__
         assert spec.script_path is not None
         cmd = [*launcher, spec.script_path, *spec.argv_extra]
-    env = {**os.environ, **spec.env}
+    env = _build_child_env(spec)
 
     logger.info(
         "Launching subprocess for task %s: %s",
@@ -230,8 +306,9 @@ async def run_training_subprocess(
         limit=10 * 1024 * 1024,
     )
 
+    output_tail: deque[str] = deque(maxlen=200)
     stdout_task = asyncio.create_task(
-        _stream_stdout(ctx, proc, spec.line_parser),
+        _stream_stdout(ctx, proc, spec.line_parser, output_tail),
         name=f"stdout-{ctx.task.id}",
     )
     cancel_task = asyncio.create_task(
@@ -245,6 +322,13 @@ async def run_training_subprocess(
         cancel_task.cancel()
         with suppress(asyncio.CancelledError):
             await cancel_task
+        # Reap-on-any-exit: if we're leaving while the child is still alive (the
+        # runner task was cancelled, or an unexpected error propagated), the
+        # cancel-watcher is already torn down — kill the group here so nothing is
+        # orphaned. A no-op on normal completion / the deadline path (already
+        # reaped). PDEATHSIG only covers a *whole-runner* crash, not a single
+        # cancelled task while the runner lives.
+        await _reap_if_alive(proc, spec.sigterm_grace_seconds)
         # Bound the stdout drain: on Python 3.12 proc.wait() itself already
         # returned above, but a grandchild that inherited the pipe can keep the
         # write-end open so _stream_stdout never sees EOF. Don't wait forever.
@@ -261,6 +345,12 @@ async def run_training_subprocess(
                 await stdout_task
 
     logger.info("Subprocess for task %s exited rc=%d", ctx.task.id, rc)
+    if rc != 0:
+        reason = _classify_failure(output_tail)
+        if reason is not None:
+            raise SubprocessResourceError(
+                f"task {ctx.task.id} failed (rc={rc}): {reason}"
+            )
     return rc
 
 
@@ -292,11 +382,14 @@ async def _stream_stdout(
     ctx: TaskContext,
     proc: asyncio.subprocess.Process,
     line_parser: LineParser | None,
+    tail: deque[str] | None = None,
 ) -> None:
     """Read lines from the child, emit progress events, mirror to logs.
 
     Best-effort: a single bad line doesn't fail the run. Every line goes
     to the parent log prefixed with the task id so operators can debug.
+    When ``tail`` is given, each line is also appended to it (a bounded ring
+    buffer) so the caller can classify a non-zero exit (OOM / disk-full).
     """
     if proc.stdout is None:
         return
@@ -324,6 +417,8 @@ async def _stream_stdout(
             if not line:
                 continue
             logger.info("[%s] %s", ctx.task.id, line)
+            if tail is not None:
+                tail.append(line)
 
             parsed: dict[str, Any] | None = None
             if line_parser is not None:

--- a/tests/test_subprocess_hardening.py
+++ b/tests/test_subprocess_hardening.py
@@ -1,0 +1,95 @@
+"""Tests for F17/F18/F61 — further training/eval subprocess hardening.
+
+F17 reap-on-exit: kill the child's group on *any* exit from
+     run_training_subprocess (cancelled task / unexpected error), not just the
+     deadline path — PDEATHSIG only covers a whole-runner crash.
+F18 PYTHONPATH isolation: don't leak the orchestrator's PYTHONPATH into the
+     child, where it can shadow the training env's own torch / prismatic.
+F61 resource classification: a non-zero exit whose output shows CUDA OOM or a
+     full disk raises SubprocessResourceError with a clear reason, not "rc=1".
+"""
+import asyncio
+import os
+
+from odyssey.runners.subprocess import (
+    SubprocessResourceError,
+    TrainingProcessSpec,
+    _build_child_env,
+    _classify_failure,
+    _reap_if_alive,
+)
+
+
+async def _spawn(*argv):
+    return await asyncio.create_subprocess_exec(
+        *argv,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+
+# ---- F17 ----------------------------------------------------------------
+
+async def test_reap_if_alive_kills_running_child():
+    proc = await _spawn("sleep", "30")
+    await _reap_if_alive(proc, grace=0.5)
+    assert proc.returncode is not None  # reaped, not orphaned
+
+
+async def test_reap_if_alive_noop_when_already_exited():
+    proc = await _spawn("true")
+    await proc.wait()
+    await _reap_if_alive(proc, grace=0.5)  # no-op, no error
+    assert proc.returncode == 0
+
+
+# ---- F18 ----------------------------------------------------------------
+
+def test_build_child_env_strips_leaked_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/opt/ros/jazzy:/home/x/odyssey/src")
+    env = _build_child_env(TrainingProcessSpec(entry_module="x"))
+    assert "PYTHONPATH" not in env
+
+
+def test_build_child_env_keeps_explicit_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/opt/ros/jazzy")
+    spec = TrainingProcessSpec(entry_module="x", env={"PYTHONPATH": "/wanted"})
+    assert _build_child_env(spec)["PYTHONPATH"] == "/wanted"
+
+
+def test_build_child_env_inherits_other_vars(monkeypatch):
+    monkeypatch.setenv("SOME_VAR", "keepme")
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    assert _build_child_env(TrainingProcessSpec(entry_module="x"))["SOME_VAR"] == "keepme"
+
+
+# ---- F61 ----------------------------------------------------------------
+
+def test_classify_failure_detects_cuda_oom():
+    reason = _classify_failure(
+        ["epoch 3 step 40",
+         "torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 GiB"]
+    )
+    assert reason is not None and "OOM" in reason
+
+
+def test_classify_failure_detects_disk_full():
+    reason = _classify_failure(
+        ["saving checkpoint", "OSError: [Errno 28] No space left on device"]
+    )
+    assert reason is not None and "disk" in reason.lower()
+
+
+def test_classify_failure_none_for_benign_output():
+    assert _classify_failure(["step 100 loss 0.5", "training complete"]) is None
+
+
+def test_resource_error_is_runtime_error():
+    # Engine error handling catches RuntimeError; the classified error must fit.
+    assert issubclass(SubprocessResourceError, RuntimeError)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])

--- a/tests/test_subprocess_watchdog.py
+++ b/tests/test_subprocess_watchdog.py
@@ -1,0 +1,72 @@
+"""Tests for F14/F16/F58 — the subprocess runner's watchdog + reap.
+
+`run_training_subprocess` awaited `proc.wait()` with no timeout, so a hung eval
+(Isaac boot, a ZMQ handshake to a policy server that never replies, a wedged
+CUDA context) blocked the whole mission forever. The task schema already carried
+a dormant `timeout_seconds`; `_wait_with_deadline` now enforces it: SIGTERM the
+child's process group on deadline, escalate to SIGKILL, then raise
+`SubprocessTimeoutError`.
+"""
+import asyncio
+import os
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from odyssey.runners.subprocess import (
+    SubprocessTimeoutError,
+    TrainingProcessSpec,
+    _wait_with_deadline,
+)
+
+
+def _ctx():
+    ctx = MagicMock()
+    ctx.task.id = "t1"
+    return ctx
+
+
+async def _spawn(*argv):
+    return await asyncio.create_subprocess_exec(
+        *argv,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+
+async def test_deadline_kills_hung_subprocess():
+    """A child that outlives its deadline is killed and raises SubprocessTimeoutError."""
+    proc = await _spawn("sleep", "30")
+    spec = TrainingProcessSpec(
+        entry_module="x", timeout_seconds=0.3, sigterm_grace_seconds=0.5
+    )
+
+    started = time.monotonic()
+    with pytest.raises(SubprocessTimeoutError):
+        await _wait_with_deadline(_ctx(), proc, spec)
+
+    # Killed promptly (well under the child's 30s), and reaped.
+    assert time.monotonic() - started < 5.0
+    assert proc.returncode is not None
+
+
+async def test_no_deadline_waits_to_completion():
+    """With timeout_seconds=None the wait is unbounded (legacy behavior)."""
+    proc = await _spawn("true")
+    spec = TrainingProcessSpec(entry_module="x")  # no deadline
+    rc = await _wait_with_deadline(_ctx(), proc, spec)
+    assert rc == 0
+
+
+async def test_completes_before_deadline_returns_rc():
+    """A child that finishes within its deadline returns its exit code, no kill."""
+    proc = await _spawn("true")
+    spec = TrainingProcessSpec(entry_module="x", timeout_seconds=10)
+    rc = await _wait_with_deadline(_ctx(), proc, spec)
+    assert rc == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What & why

`run_training_subprocess` awaited `proc.wait()` with **no timeout**, and
`MissionEngine` runs tasks sequentially with no per-task deadline (the module
docstring literally says "No watchdog timers"). So a hang during **Isaac Sim
boot**, the **ZMQ handshake** to a GR00T policy server that never binds, or a
wedged CUDA context blocks the whole mission **forever** — no `CANCELLED`/`FAILED`
is ever emitted and the GPU stays pinned until a human kills it. This hardens the
training/eval subprocess runner end to end.

(Distinct from the already-fixed closed-loop *server-orphan* deadlock — #36. That
fixed the recipe; this hardens the **runner**.)

## Scope — six findings (F14/F16/F58 + F17/F18/F61 via the merged #51)

**Watchdog + reap (the core):**
- **F14 — deadline.** `TrainingProcessSpec.timeout_seconds`; `run_training_subprocess`
  enforces it via `_wait_with_deadline`: SIGTERM the child's **process group** on
  deadline → wait `sigterm_grace_seconds` → SIGKILL → raise `SubprocessTimeoutError`.
  The three callers (openvla, gr00t, isaac_lab) plumb the task's `timeout_seconds`.
  `None` = unbounded (legacy — no regression risk).
- **F58 — reap-on-crash.** `PR_SET_PDEATHSIG(SIGKILL)` on the child (via
  `_child_preexec`, alongside `setsid`) so a runner crash can't orphan a GPU job.
- **F16/F58 — bounded stdout drain.** The post-exit `await stdout_task` is now
  `asyncio.wait_for`-bounded, so a grandchild that inherited the pipe can't wedge
  the runner waiting for an EOF that never comes.

**Further subprocess hardening (folded in via the merged #51):**
- **F17 — reap-on-any-exit.** `_reap_if_alive` in the `finally` SIGTERM/SIGKILLs
  the child group on *any* exit (a cancelled runner task, an unexpected error),
  not just the deadline path — PDEATHSIG only covers a whole-runner crash.
- **F18 — PYTHONPATH isolation.** `_build_child_env` strips a leaked orchestrator
  `PYTHONPATH` (ROS Jazzy, an editable checkout) from the child env unless the
  spec sets it, so it can't shadow the training env's torch/prismatic.
- **F61 — resource classification.** A bounded output tail is scanned on a
  non-zero exit; a **CUDA-OOM** or **disk-full** signature raises
  `SubprocessResourceError` with an operator-facing reason instead of a bare `rc=1`.

## Tests

`tests/test_subprocess_watchdog.py` (deadline kills a `sleep 30` child at 0.3s and
reaps; no-deadline waits; fast child returns rc) and `tests/test_subprocess_hardening.py`
(`_reap_if_alive`, `_build_child_env` PYTHONPATH strip, `_classify_failure` OOM/disk).
ruff + mypy clean; existing subprocess/isaac/watchdog suites pass. Linux-guarded
(`prctl`/`setsid`).
