### PR TITLE
fix(runners): further subprocess hardening (reap-on-exit, PYTHONPATH isolation, resource classification)

### DIFF
--- a/src/odyssey/runners/subprocess.py
+++ b/src/odyssey/runners/subprocess.py
@@ -21,7 +21,8 @@ import os
 import re
 import signal
 import sys
-from collections.abc import Callable
+from collections import deque
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -98,6 +99,44 @@ class SubprocessTimeoutError(RuntimeError):
     """Raised when a training/eval subprocess exceeds its wall-clock deadline."""
 
 
+class SubprocessResourceError(RuntimeError):
+    """Raised when a subprocess failure is classified as resource exhaustion
+    (GPU OOM / out of disk) — a clearer signal than a bare non-zero exit code."""
+
+
+# (signature, operator-facing reason). Scanned against the tail of the child's
+# output on a non-zero exit so a resource failure reads as such, not "rc=1".
+_RESOURCE_FAILURE_SIGNATURES: list[tuple[re.Pattern[str], str]] = [
+    (
+        re.compile(
+            r"CUDA out of memory|CUBLAS_STATUS_ALLOC_FAILED"
+            r"|torch\.cuda\.OutOfMemoryError|CUDA error: out of memory",
+            re.IGNORECASE,
+        ),
+        "GPU out of memory (CUDA OOM) — reduce batch size / model size "
+        "or use a larger GPU",
+    ),
+    (
+        re.compile(
+            r"No space left on device|\bENOSPC\b|\[Errno 28\]"
+            r"|disk quota exceeded",
+            re.IGNORECASE,
+        ),
+        "ran out of disk space — free space on the output / HF-cache volume",
+    ),
+]
+
+
+def _classify_failure(tail: Iterable[str]) -> str | None:
+    """Return an operator-facing reason if the output tail matches a known
+    resource-exhaustion signature, else None."""
+    text = "\n".join(tail)
+    for pattern, reason in _RESOURCE_FAILURE_SIGNATURES:
+        if pattern.search(text):
+            return reason
+    return None
+
+
 # How long to wait draining the child's stdout after it exits before giving up.
 # A grandchild that inherited the pipe (e.g. a co-launched server) can keep the
 # write-end open so EOF never arrives — don't block the runner forever.
@@ -129,6 +168,43 @@ def _kill_process_group(proc: asyncio.subprocess.Process, sig: int) -> None:
         return
     with suppress(ProcessLookupError):
         os.killpg(os.getpgid(proc.pid), sig)
+
+
+async def _reap_if_alive(proc: asyncio.subprocess.Process, grace: float) -> None:
+    """If the child is still running, SIGTERM its process group and, failing to
+    exit within ``grace``, SIGKILL. Best-effort cleanup for *any* exit from
+    run_training_subprocess (a cancelled runner task, an unexpected error) so the
+    child is never orphaned. Normal completion and the deadline path have already
+    reaped, so this is a no-op then.
+    """
+    if proc.returncode is not None:
+        return
+    _kill_process_group(proc, signal.SIGTERM)
+    # suppress(Exception) does NOT swallow CancelledError (BaseException), so a
+    # re-cancel during unwinding still propagates — but the SIGTERM above already
+    # fired synchronously, so the child dies regardless.
+    with suppress(Exception):
+        await asyncio.wait_for(proc.wait(), timeout=grace)
+    if proc.returncode is None:
+        _kill_process_group(proc, signal.SIGKILL)
+        with suppress(Exception):
+            await proc.wait()
+
+
+def _build_child_env(spec: TrainingProcessSpec) -> dict[str, str]:
+    """Environment for the child: the parent env overlaid with ``spec.env``.
+
+    PYTHONPATH is dropped from the inherited env unless the spec sets it
+    explicitly. The child runs under its OWN interpreter — a training venv via
+    ``sys.executable``, or ``isaaclab.sh -p`` — and a leaked orchestrator
+    PYTHONPATH (ROS Jazzy, an editable checkout, …) can shadow the child's own
+    packages with a different torch / prismatic / isaacsim. Mirrors the
+    ``env -u PYTHONPATH`` hygiene used across the platform's venvs.
+    """
+    env = {**os.environ, **spec.env}
+    if "PYTHONPATH" not in spec.env:
+        env.pop("PYTHONPATH", None)
+    return env
 
 
 async def _wait_with_deadline(
@@ -205,7 +281,7 @@ async def run_training_subprocess(
         # script_path is guaranteed by __post_init__
         assert spec.script_path is not None
         cmd = [*launcher, spec.script_path, *spec.argv_extra]
-    env = {**os.environ, **spec.env}
+    env = _build_child_env(spec)
 
     logger.info(
         "Launching subprocess for task %s: %s",
@@ -230,8 +306,9 @@ async def run_training_subprocess(
         limit=10 * 1024 * 1024,
     )
 
+    output_tail: deque[str] = deque(maxlen=200)
     stdout_task = asyncio.create_task(
-        _stream_stdout(ctx, proc, spec.line_parser),
+        _stream_stdout(ctx, proc, spec.line_parser, output_tail),
         name=f"stdout-{ctx.task.id}",
     )
     cancel_task = asyncio.create_task(
@@ -245,6 +322,13 @@ async def run_training_subprocess(
         cancel_task.cancel()
         with suppress(asyncio.CancelledError):
             await cancel_task
+        # Reap-on-any-exit: if we're leaving while the child is still alive (the
+        # runner task was cancelled, or an unexpected error propagated), the
+        # cancel-watcher is already torn down — kill the group here so nothing is
+        # orphaned. A no-op on normal completion / the deadline path (already
+        # reaped). PDEATHSIG only covers a *whole-runner* crash, not a single
+        # cancelled task while the runner lives.
+        await _reap_if_alive(proc, spec.sigterm_grace_seconds)
         # Bound the stdout drain: on Python 3.12 proc.wait() itself already
         # returned above, but a grandchild that inherited the pipe can keep the
         # write-end open so _stream_stdout never sees EOF. Don't wait forever.
@@ -261,6 +345,12 @@ async def run_training_subprocess(
                 await stdout_task
 
     logger.info("Subprocess for task %s exited rc=%d", ctx.task.id, rc)
+    if rc != 0:
+        reason = _classify_failure(output_tail)
+        if reason is not None:
+            raise SubprocessResourceError(
+                f"task {ctx.task.id} failed (rc={rc}): {reason}"
+            )
     return rc
 
 
@@ -292,11 +382,14 @@ async def _stream_stdout(
     ctx: TaskContext,
     proc: asyncio.subprocess.Process,
     line_parser: LineParser | None,
+    tail: deque[str] | None = None,
 ) -> None:
     """Read lines from the child, emit progress events, mirror to logs.
 
     Best-effort: a single bad line doesn't fail the run. Every line goes
     to the parent log prefixed with the task id so operators can debug.
+    When ``tail`` is given, each line is also appended to it (a bounded ring
+    buffer) so the caller can classify a non-zero exit (OOM / disk-full).
     """
     if proc.stdout is None:
         return
@@ -324,6 +417,8 @@ async def _stream_stdout(
             if not line:
                 continue
             logger.info("[%s] %s", ctx.task.id, line)
+            if tail is not None:
+                tail.append(line)
 
             parsed: dict[str, Any] | None = None
             if line_parser is not None:

--- a/tests/test_subprocess_hardening.py
+++ b/tests/test_subprocess_hardening.py
@@ -1,0 +1,95 @@
+"""Tests for F17/F18/F61 — further training/eval subprocess hardening.
+
+F17 reap-on-exit: kill the child's group on *any* exit from
+     run_training_subprocess (cancelled task / unexpected error), not just the
+     deadline path — PDEATHSIG only covers a whole-runner crash.
+F18 PYTHONPATH isolation: don't leak the orchestrator's PYTHONPATH into the
+     child, where it can shadow the training env's own torch / prismatic.
+F61 resource classification: a non-zero exit whose output shows CUDA OOM or a
+     full disk raises SubprocessResourceError with a clear reason, not "rc=1".
+"""
+import asyncio
+import os
+
+from odyssey.runners.subprocess import (
+    SubprocessResourceError,
+    TrainingProcessSpec,
+    _build_child_env,
+    _classify_failure,
+    _reap_if_alive,
+)
+
+
+async def _spawn(*argv):
+    return await asyncio.create_subprocess_exec(
+        *argv,
+        preexec_fn=os.setsid if hasattr(os, "setsid") else None,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+
+
+# ---- F17 ----------------------------------------------------------------
+
+async def test_reap_if_alive_kills_running_child():
+    proc = await _spawn("sleep", "30")
+    await _reap_if_alive(proc, grace=0.5)
+    assert proc.returncode is not None  # reaped, not orphaned
+
+
+async def test_reap_if_alive_noop_when_already_exited():
+    proc = await _spawn("true")
+    await proc.wait()
+    await _reap_if_alive(proc, grace=0.5)  # no-op, no error
+    assert proc.returncode == 0
+
+
+# ---- F18 ----------------------------------------------------------------
+
+def test_build_child_env_strips_leaked_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/opt/ros/jazzy:/home/x/odyssey/src")
+    env = _build_child_env(TrainingProcessSpec(entry_module="x"))
+    assert "PYTHONPATH" not in env
+
+
+def test_build_child_env_keeps_explicit_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/opt/ros/jazzy")
+    spec = TrainingProcessSpec(entry_module="x", env={"PYTHONPATH": "/wanted"})
+    assert _build_child_env(spec)["PYTHONPATH"] == "/wanted"
+
+
+def test_build_child_env_inherits_other_vars(monkeypatch):
+    monkeypatch.setenv("SOME_VAR", "keepme")
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    assert _build_child_env(TrainingProcessSpec(entry_module="x"))["SOME_VAR"] == "keepme"
+
+
+# ---- F61 ----------------------------------------------------------------
+
+def test_classify_failure_detects_cuda_oom():
+    reason = _classify_failure(
+        ["epoch 3 step 40",
+         "torch.cuda.OutOfMemoryError: CUDA out of memory. Tried to allocate 2.00 GiB"]
+    )
+    assert reason is not None and "OOM" in reason
+
+
+def test_classify_failure_detects_disk_full():
+    reason = _classify_failure(
+        ["saving checkpoint", "OSError: [Errno 28] No space left on device"]
+    )
+    assert reason is not None and "disk" in reason.lower()
+
+
+def test_classify_failure_none_for_benign_output():
+    assert _classify_failure(["step 100 loss 0.5", "training complete"]) is None
+
+
+def test_resource_error_is_runtime_error():
+    # Engine error handling catches RuntimeError; the classified error must fit.
+    assert issubclass(SubprocessResourceError, RuntimeError)
+
+
+if __name__ == "__main__":
+    import pytest
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Stacked on #49

Base is `fix/subprocess-watchdog-and-reap` (**#49**) so the diff shows only this
follow-up. Once #49 merges to `develop`, GitHub retargets this PR automatically.

Three further robustness fixes, all in `run_training_subprocess`:

### F17 — reap on *any* exit
The `finally` cancelled the watcher and drained stdout but never killed the child
if we left while it was still alive — e.g. the **runner task itself is cancelled**
(the engine cancels one task while the process keeps running), or an unexpected
error propagates. `_reap_if_alive` now SIGTERMs the child's process group (→
SIGKILL after the grace) on any such exit. `PR_SET_PDEATHSIG` (added in #49) only
covers a **whole-runner crash**, not a single cancelled task while the runner lives.

### F18 — don't leak the orchestrator's PYTHONPATH
`env = {**os.environ, **spec.env}` passed the engine's `PYTHONPATH` straight into
the training/eval child. The child runs under **its own** interpreter (a training
venv via `sys.executable`, or `isaaclab.sh -p`), so a leaked `PYTHONPATH` (ROS
Jazzy, an editable checkout, …) can **shadow the child's own packages** with a
different torch / prismatic / isaacsim. `_build_child_env` drops it unless the
spec sets `PYTHONPATH` explicitly — the same `env -u PYTHONPATH` hygiene used
across the platform's venvs.

### F61 — classify resource exhaustion
A non-zero exit surfaced only as `exited with code 1`. A bounded ring buffer of
the child's output tail is now scanned on failure; a **CUDA OOM** or **disk-full**
(`No space left on device` / `ENOSPC` / `[Errno 28]`) signature raises
`SubprocessResourceError` (a `RuntimeError` subclass, so existing engine error
handling still catches it) with an operator-facing reason. Other failures return
`rc` unchanged (callers raise the generic error as before).

## Tests

`tests/test_subprocess_hardening.py` (RED→GREEN): `_reap_if_alive` kills a live
child and no-ops on an exited one; `_build_child_env` strips a leaked `PYTHONPATH`
but keeps an explicit one and other vars; `_classify_failure` detects CUDA OOM and
disk-full and returns None for benign output. **ruff + mypy clean**; existing
subprocess / isaac / watchdog suites (45 tests) pass.
