### PR TITLE
docs(contributors): recognize Owolabi Temitope E (#52 Windows report)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,6 +20,7 @@ welcome to add yourself in the same PR that lands your contribution.
 In order of first contribution:
 
 - **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
+- **Owolabi Temitope E** ([@Temitope3003](https://github.com/Temitope3003)) — Windows test-suite portability bug report ([#52](https://github.com/lovellai-dev/odyssey/issues/52))
 
 ---
 


### PR DESCRIPTION
## What & why

Adds **Owolabi Temitope E** ([@Temitope3003](https://github.com/Temitope3003)) to `CONTRIBUTORS.md`.

Per `CONTRIBUTORS.md`, bug reports count as contributions — and [#52](https://github.com/lovellai-dev/odyssey/issues/52) is an exemplary one: it diagnosed the POSIX-only `os.killpg` crash in `RemotePlanner.close()` and the path-separator test failures on Windows, separated the two root causes, listed every failing test, and noted that `test_subprocess.py` already *skips* rather than fixes the same POSIX-group gap.

Recognizing the report; the code fix (guarding `os.killpg` for non-POSIX platforms) is tracked on #52 and warmly open to them.

## Changes

- `CONTRIBUTORS.md`: one line under **Contributors**, in order of first contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
