### PR TITLE
Guard RemotePlanner cleanup without killpg

### DIFF
--- a/src/odyssey/runners/agents/remote_planner.py
+++ b/src/odyssey/runners/agents/remote_planner.py
@@ -26,6 +26,7 @@ import os
 import queue
 import signal
 import subprocess
+import sys
 import threading
 import time
 from collections.abc import Sequence
@@ -34,6 +35,24 @@ from typing import IO, Any
 logger = logging.getLogger(__name__)
 
 _SERVER_MODULE = "odyssey.runners.agents.planner_server"
+_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
+def _popen_creation_kwargs() -> dict[str, Any]:
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _terminate_process(proc: subprocess.Popen[str], sig: int) -> None:
+    killpg = getattr(os, "killpg", None)
+    getpgid = getattr(os, "getpgid", None)
+    if killpg is not None and getpgid is not None:
+        killpg(getpgid(proc.pid), sig)
+    elif sig == signal.SIGTERM:
+        proc.terminate()
+    else:
+        proc.kill()
 
 
 def _encode_image(image: Any) -> str:
@@ -107,14 +126,14 @@ class RemotePlanner:
             argv += ["--quantization", self._quantization]
         logger.info("RemotePlanner: launching specialist server: %s", " ".join(argv))
         # stderr inherited -> model-loading logs stay visible in the terminal.
-        # start_new_session -> own process group for clean teardown.
+        # POSIX gets its own process group; Windows falls back to direct cleanup.
         self._proc = subprocess.Popen(
             argv,
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             text=True,
             bufsize=1,
-            start_new_session=True,
+            **_popen_creation_kwargs(),
         )
         assert self._proc.stdout is not None
         self._reader = threading.Thread(
@@ -212,8 +231,8 @@ class RemotePlanner:
                 proc.stdin.close()
         with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
             if proc.poll() is None:
-                os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+                _terminate_process(proc, signal.SIGTERM)
                 try:
                     proc.wait(timeout=10)
                 except subprocess.TimeoutExpired:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    _terminate_process(proc, _SIGKILL)

--- a/tests/unit/test_remote_planner.py
+++ b/tests/unit/test_remote_planner.py
@@ -205,6 +205,53 @@ def test_remote_planner_roundtrip(tmp_path: Path) -> None:
         planner.close()  # idempotent
 
 
+def test_remote_planner_close_falls_back_without_posix_process_groups(monkeypatch) -> None:
+    import odyssey.runners.agents.remote_planner as remote_planner
+
+    monkeypatch.delattr(remote_planner.os, "killpg", raising=False)
+    monkeypatch.delattr(remote_planner.os, "getpgid", raising=False)
+
+    class _FakeStdin:
+        closed = False
+
+        def write(self, _text: str) -> None:
+            pass
+
+        def flush(self) -> None:
+            pass
+
+        def close(self) -> None:
+            self.closed = True
+
+    class _FakeProc:
+        stdin = _FakeStdin()
+        pid = 123
+        terminated = False
+        killed = False
+
+        def poll(self) -> None:
+            return None
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            self.killed = True
+
+        def wait(self, timeout: float | None = None) -> int:
+            return 0
+
+    planner = RemotePlanner("fake/model", python_path=sys.executable)
+    proc = _FakeProc()
+    planner._proc = proc  # type: ignore[assignment]
+
+    planner.close()
+
+    assert planner._proc is None
+    assert proc.terminated is True
+    assert proc.killed is False
+
+
 def test_remote_planner_encodes_image_into_request(tmp_path: Path) -> None:
     import numpy as np
 


### PR DESCRIPTION
Addresses the RemotePlanner `os.killpg` cleanup part of #52.

## Summary
- Start the RemotePlanner subprocess with platform-appropriate process creation kwargs.
- Keep POSIX process-group teardown via `killpg/getpgid` when available.
- Fall back to direct `terminate()` / `kill()` when those POSIX APIs are unavailable, avoiding the Windows `AttributeError` during `close()`.
- Add regression coverage for the no-POSIX-process-groups cleanup path.

## Scope note
I dropped the earlier path-separator changes from this PR. The issue discussion clarified that native Windows path support is not currently a project goal, while the RemotePlanner `os.killpg` crash should still degrade cleanly.

## Verification
- `python -m pytest tests/unit/test_remote_planner.py -q` -> 12 passed
- `python -m ruff check src/odyssey/runners/agents/remote_planner.py tests/unit/test_remote_planner.py`
- `python -m mypy --platform linux src/odyssey`