### PR TITLE
[GOVERNANCE] Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
## Summary
Adds standard GitHub issue templates under `.github/ISSUE_TEMPLATE/` so new issues follow a consistent, structured format:

- **`bug_report.md`** — guided fields: describe the bug, steps to reproduce, expected behavior, screenshots, environment (OS / version), and additional context.
- **`feature_request.md`** — guided fields: problem statement, proposed solution, alternatives considered, and additional context.

## Motivation
Part of the ongoing governance / community-standards work. Structured templates make reports easier to triage and raise the baseline quality of incoming issues (repro steps, environment, scope) — the same qualities that made recent contributor reports so easy to act on.

## Scope
- Docs / governance only. No code or behavior changes.
- Two new files added; nothing modified or removed.

## Notes
- These are GitHub's default template scaffolds as a starting point. We can tailor the fields to Odyssey specifics (e.g. mission YAML, GPU/driver info, extras installed) in a follow-up if we want a tighter fit.