### PR TITLE
docs(contributors): add Yang Yu and Matias Molinas

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,6 +22,7 @@ In order of first contribution:
 - **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
 - **Owolabi Temitope E** ([@Temitope3003](https://github.com/Temitope3003)) — Windows test-suite portability bug report ([#52](https://github.com/lovellai-dev/odyssey/issues/52))
 - **Yang Yu** ([@paranoa233](https://github.com/paranoa233)) — cross-platform RemotePlanner cleanup fix ([#54](https://github.com/lovellai-dev/odyssey/pull/54)) & GR00T eval test-isolation fix ([#56](https://github.com/lovellai-dev/odyssey/pull/56))
+- **Matias Molinas** ([@matiasmolinas](https://github.com/matiasmolinas)) — community blog post: [Evolving Robot](https://evolvingagentslabs.github.io/evolving-robot/)
 
 ---
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,6 +21,7 @@ In order of first contribution:
 
 - **Pratik Mishra** ([@pratik1258m](https://github.com/pratik1258m)) — shared evaluation-helpers refactor ([#41](https://github.com/lovellai-dev/odyssey/pull/41))
 - **Owolabi Temitope E** ([@Temitope3003](https://github.com/Temitope3003)) — Windows test-suite portability bug report ([#52](https://github.com/lovellai-dev/odyssey/issues/52))
+- **Yang Yu** ([@paranoa233](https://github.com/paranoa233)) — cross-platform RemotePlanner cleanup fix ([#54](https://github.com/lovellai-dev/odyssey/pull/54)) & GR00T eval test-isolation fix ([#56](https://github.com/lovellai-dev/odyssey/pull/56))
 
 ---
 


### PR DESCRIPTION
## Summary
Add two contributors to `CONTRIBUTORS.md`:

- **Yang Yu** ([@paranoa233](https://github.com/paranoa233)) — two well-scoped fixes: cross-platform `RemotePlanner` cleanup (#54, merged) and the GR00T eval test-isolation fix (#56, `Closes #48`).
- **Matias Molinas** ([@matiasmolinas](https://github.com/matiasmolinas)) — community blog post about the project: [Evolving Robot](https://evolvingagentslabs.github.io/evolving-robot/). 🙌

## Scope
- Docs only: two lines added to the Contributors list, in order of first contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)