### PR TITLE
feat(evals): decouple the rollout-video camera from the policy camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,27 @@ for the policy, so capture only adds a list append per step plus one encode per
 episode (offloaded to a thread). Optional knobs: `video_fps` (default 24),
 `video_format` (default `mp4`).
 
+### Choosing the video camera
+
+By default the clip records the **policy's own input frame** (`agentview` at
+256×256) — a view framed for the model, not for humans, so the robot may sit
+partially out of frame. To record from a dedicated, better-framed camera
+*without changing what the policy sees*, set `video_camera`:
+
+```yaml
+    config:
+      capture_video: true
+      video_camera: frontview    # any robosuite camera, e.g. frontview, sideview
+      video_height: 512          # optional, default 512
+      video_width: 512           # optional, default 512
+```
+
+The env then renders both cameras each step — the policy keeps consuming its
+own camera and the MP4 records the other — at the cost of one extra render
+stream per step. When `video_camera` is unset, behavior is exactly the near-free
+default above. Setting it to the policy's own camera raises an error: unset it
+instead to record the policy view.
+
 > **Dependency.** MP4 encoding needs `imageio[ffmpeg]`, which ships with the
 > `[robosuite]` (and `[all]`) extra — no extra install step if you already run
 > eval. It's best-effort: if the encoder is missing it logs a warning and the

--- a/examples/multiagent-openvla-gemma/mission.yaml
+++ b/examples/multiagent-openvla-gemma/mission.yaml
@@ -100,6 +100,9 @@ tasks:
     config:
       unnorm_key: bridge_orig
       capture_video: true   # one MP4 per episode (README: "Recording rollout videos")
+      # video_camera: frontview   # record from a dedicated camera instead of the
+      # video_height: 512         # policy's 256x256 agentview frame; unset =
+      # video_width: 512          # record the policy frame (near-free default)
 
 leaderboard:
   publish: false

--- a/examples/quickstart-openvla/mission.yaml
+++ b/examples/quickstart-openvla/mission.yaml
@@ -59,6 +59,9 @@ tasks:
     config:
       unnorm_key: bridge_orig
       capture_video: true   # one MP4 per episode (README: "Recording rollout videos")
+      # video_camera: frontview   # record from a dedicated camera instead of the
+      # video_height: 512         # policy's 256x256 agentview frame; unset =
+      # video_width: 512          # record the policy frame (near-free default)
 
 leaderboard:
   publish: false   # Backend not live yet in v0.1.0-alpha.

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -115,6 +115,53 @@ def _default_env_factory(benchmark_name: str, robosuite_robot: str | None) -> An
     return robosuite.make(**kwargs)
 
 
+def _resolve_cameras(cfg: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    """Compute the env's camera kwargs and the video-capture obs key.
+
+    Opt-in ``video_camera`` (with ``video_height``/``video_width``, default 512)
+    adds a second render camera dedicated to the rollout video, decoupled from
+    the policy's camera. Unset — or with ``capture_video`` off, where it would
+    be pure render cost — the kwargs and capture key (None) match the near-free
+    path: the video reuses the policy frame.
+    """
+    camera_names = cfg.get("camera_names", "agentview")
+    camera_height = cfg.get("camera_height", 256)
+    camera_width = cfg.get("camera_width", 256)
+    video_camera = cfg.get("video_camera")
+    if video_camera is None or not cfg.get("capture_video", False):
+        return (
+            {
+                "camera_names": camera_names,
+                "camera_heights": camera_height,
+                "camera_widths": camera_width,
+            },
+            None,
+        )
+    video_camera = str(video_camera)
+    policy_cameras = (
+        [camera_names] if isinstance(camera_names, str) else list(camera_names)
+    )
+    if video_camera in policy_cameras:
+        raise ValueError(
+            f"video_camera {video_camera!r} is already a policy camera — robosuite "
+            "renders each camera at a single resolution, so the video would just be "
+            "the policy frame. Unset video_camera to record the policy view, or "
+            "pick a different camera (e.g. 'frontview')."
+        )
+
+    def _per_camera(value: Any) -> list[Any]:
+        return list(value) if isinstance(value, list | tuple) else [value] * len(policy_cameras)
+
+    return (
+        {
+            "camera_names": [*policy_cameras, video_camera],
+            "camera_heights": [*_per_camera(camera_height), int(cfg.get("video_height", 512))],
+            "camera_widths": [*_per_camera(camera_width), int(cfg.get("video_width", 512))],
+        },
+        f"{video_camera}_image",
+    )
+
+
 def _make_eval_env(
     benchmark_name: str,
     robosuite_robot: str | None,
@@ -128,18 +175,13 @@ def _make_eval_env(
             "Robosuite eval requires the 'robosuite' extra. "
             "Install with: pip install 'lovell-odyssey[robosuite]'"
         ) from e
-    cfg = config or {}
-    camera_names = cfg.get("camera_names", "agentview")
-    camera_height = cfg.get("camera_height", 256)
-    camera_width = cfg.get("camera_width", 256)
+    camera_kwargs, _ = _resolve_cameras(config or {})
     kwargs: dict[str, Any] = {
         "env_name": benchmark_name,
         "has_renderer": False,
         "has_offscreen_renderer": True,
         "use_camera_obs": True,
-        "camera_names": camera_names,
-        "camera_heights": camera_height,
-        "camera_widths": camera_width,
+        **camera_kwargs,
     }
     if robosuite_robot is not None:
         kwargs["robots"] = robosuite_robot
@@ -198,6 +240,10 @@ class RobosuiteRunner(Runner):
 
         cfg = spec.config or {}
         image_key = cfg.get("image_key", "agentview_image")
+        # An opt-in `video_camera` records the rollout from its own camera;
+        # unset, the video reuses the policy frame (capture_key == image_key).
+        _, video_key = _resolve_cameras(cfg)
+        capture_key = video_key or image_key
         # Opt-in rollout video. The camera-enabled eval env already renders the
         # frame each step (the policy uses it), so capture is near-free: a list
         # append per step plus one mp4 encode per episode, offloaded to a thread.
@@ -311,12 +357,17 @@ class RobosuiteRunner(Runner):
                 if runtime:
                     image = _extract_image(obs, image_key)
                     if capture_video:
-                        _capture_frame(frames, image)
+                        _capture_frame(
+                            frames,
+                            image
+                            if capture_key == image_key
+                            else _extract_image(obs, capture_key),
+                        )
                     action = runtime.get_action(image)
                 else:
                     assert policy is not None
                     if capture_video:
-                        _capture_frame(frames, _extract_image(obs, image_key))
+                        _capture_frame(frames, _extract_image(obs, capture_key))
                     action = policy(obs if isinstance(obs, dict) else {"observation": obs})
 
                 step_result = env.step(action)

--- a/tests/unit/test_rollout_video.py
+++ b/tests/unit/test_rollout_video.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import imageio.v2 as iio
 import numpy as np
+import pytest
 
 from odyssey.engine.lifecycle import TaskStatus
 from odyssey.engine.records import MissionRun, TaskRun
 from odyssey.runners.base import TaskContext
-from odyssey.runners.evals.robosuite import RobosuiteRunner
+from odyssey.runners.evals import robosuite as robosuite_runner
+from odyssey.runners.evals.robosuite import RobosuiteRunner, _resolve_cameras
 from odyssey.runners.video import save_rollout_video, to_uint8_frame
 from odyssey.spec import (
     AgentRole,
@@ -189,3 +192,184 @@ async def test_no_capture_leaves_videos_empty(tmp_path: Path) -> None:
     )
     result = await runner.run(_ctx(mission, eval_task, tmp_path))
     assert result["artifacts"]["videos"] == []
+
+
+# ---------------------------------------------------------------------------
+# Dedicated video camera, decoupled from the policy camera
+# ---------------------------------------------------------------------------
+
+def test_resolve_cameras_defaults_unchanged_without_video_camera() -> None:
+    kwargs, capture_key = _resolve_cameras({"capture_video": True})
+    assert kwargs == {
+        "camera_names": "agentview",
+        "camera_heights": 256,
+        "camera_widths": 256,
+    }
+    assert capture_key is None
+
+
+def test_resolve_cameras_inert_when_capture_video_off() -> None:
+    # A video camera without capture would be pure render cost — stay on defaults.
+    kwargs, capture_key = _resolve_cameras({"video_camera": "frontview"})
+    assert kwargs["camera_names"] == "agentview"
+    assert capture_key is None
+
+
+def test_resolve_cameras_appends_video_camera() -> None:
+    kwargs, capture_key = _resolve_cameras(
+        {
+            "capture_video": True,
+            "video_camera": "frontview",
+            "video_height": 480,
+            "video_width": 640,
+        }
+    )
+    assert kwargs == {
+        "camera_names": ["agentview", "frontview"],
+        "camera_heights": [256, 480],
+        "camera_widths": [256, 640],
+    }
+    assert capture_key == "frontview_image"
+
+
+def test_resolve_cameras_video_resolution_defaults_512() -> None:
+    kwargs, _ = _resolve_cameras({"capture_video": True, "video_camera": "frontview"})
+    assert kwargs["camera_heights"] == [256, 512]
+    assert kwargs["camera_widths"] == [256, 512]
+
+
+def test_resolve_cameras_handles_policy_camera_list() -> None:
+    kwargs, _ = _resolve_cameras(
+        {
+            "capture_video": True,
+            "camera_names": ["agentview", "robot0_eye_in_hand"],
+            "video_camera": "frontview",
+        }
+    )
+    assert kwargs["camera_names"] == ["agentview", "robot0_eye_in_hand", "frontview"]
+    assert kwargs["camera_heights"] == [256, 256, 512]
+    assert kwargs["camera_widths"] == [256, 256, 512]
+
+
+def test_resolve_cameras_rejects_policy_camera_collision() -> None:
+    with pytest.raises(ValueError, match="already a policy camera"):
+        _resolve_cameras({"capture_video": True, "video_camera": "agentview"})
+
+
+class _DualCamFakeEnv(_ImageFakeEnv):
+    """Fake env with a 16x16 policy camera and a 32x32 video camera."""
+
+    def _obs(self) -> dict[str, Any]:
+        return {
+            "agentview_image": np.zeros((16, 16, 3), dtype=np.uint8),
+            "frontview_image": np.zeros((32, 32, 3), dtype=np.uint8),
+        }
+
+
+def _gif_frame_shape(path: str) -> tuple[int, int]:
+    frame = iio.mimread(path)[0]
+    return frame.shape[0], frame.shape[1]
+
+
+async def test_video_camera_records_dedicated_camera(tmp_path: Path) -> None:
+    mission = _mission_with_video()
+    eval_task = mission.tasks[1]
+    eval_task.spec.config["video_camera"] = "frontview"
+    runner = RobosuiteRunner(
+        env_factory=lambda _b, _r: _DualCamFakeEnv(steps_per_episode=3, success=True),
+        policy_factory=lambda _: lambda obs: [0.0],
+    )
+    result = await runner.run(_ctx(mission, eval_task, tmp_path))
+
+    videos = result["artifacts"]["videos"]
+    assert len(videos) == 2
+    for v in videos:
+        assert _gif_frame_shape(v) == (32, 32)  # video cam, not the policy frame
+
+
+def _specialist_mission_with_video() -> MissionRun:
+    """Mission whose loadout adds a SPECIALIST, so the runner takes the
+    planned-runtime (multi-agent) path."""
+    spec = Mission(
+        metadata=MissionMetadata(name="msn-video-multiagent"),
+        objective="o",
+        acceptance_criteria="a",
+        robot=RobotSpec(
+            embodiment="franka_panda",
+            agents=[
+                AgentSpec(
+                    id="pilot",
+                    role=AgentRole.PILOT,
+                    model=HFModelRef(base="openvla/openvla-7b"),
+                ),
+                AgentSpec(
+                    id="planner",
+                    role=AgentRole.SPECIALIST,
+                    model=HFModelRef(base="google/gemma-4-E2B-it"),
+                ),
+            ],
+        ),
+        tasks=[
+            TrainingTask(
+                name="train",
+                training_type=TrainingType.DEMONSTRATION,
+                agent_id="pilot",
+            ),
+            EvaluationTask(
+                name="eval",
+                evaluation_type=EvaluationType.ROBOSUITE,
+                benchmark_name="Lift",
+                num_episodes=1,
+                config={
+                    "capture_video": True,
+                    "video_format": "gif",  # no ffmpeg in CI
+                    "image_key": "agentview_image",
+                    "video_camera": "frontview",
+                },
+            ),
+        ],
+    )
+    mission = MissionRun.from_spec(spec)
+    mission.tasks[0].status = TaskStatus.COMPLETED
+    mission.tasks[0].result_summary = {
+        "checkpoint_path": "/tmp/checkpoint",
+        "agent_id": "pilot",
+    }
+    return mission
+
+
+class _FakeRuntime:
+    """Stands in for PlannedEvalRuntime; records the pilot's input frames."""
+
+    def __init__(self) -> None:
+        self.frames_seen: list[tuple[int, ...]] = []
+
+    def begin_episode(self, instruction: str, first_image: Any = None) -> list[str]:
+        return ["do the task"]
+
+    def get_action(self, image: Any) -> Any:
+        self.frames_seen.append(tuple(image.shape))
+        return [0.0]
+
+    def close(self) -> None:
+        return
+
+
+async def test_video_camera_multiagent_keeps_policy_frame(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The planned-runtime path must extract TWO frames: the pilot keeps the
+    policy camera while the video records the dedicated camera."""
+    mission = _specialist_mission_with_video()
+    eval_task = mission.tasks[1]
+    fake_runtime = _FakeRuntime()
+    monkeypatch.setattr(
+        robosuite_runner, "_build_planned_runtime", lambda *a, **k: fake_runtime
+    )
+    runner = RobosuiteRunner(env_factory=lambda _b, _r: _DualCamFakeEnv())
+    result = await runner.run(_ctx(mission, eval_task, tmp_path))
+
+    assert set(fake_runtime.frames_seen) == {(16, 16, 3)}  # policy input untouched
+    videos = result["artifacts"]["videos"]
+    assert len(videos) == 1
+    assert _gif_frame_shape(videos[0]) == (32, 32)


### PR DESCRIPTION
## What

Adds an **opt-in dedicated video camera** for rollout MP4s on the robosuite
eval path (incl. the multi-agent planner+pilot runtime). New eval `config`
keys: `video_camera`, `video_height` / `video_width` (default 512). Set, the
env renders a second camera for the clip while the policy keeps consuming its
own frame; unset, behavior is exactly today's near-free path.

Follow-up to #38 — implements the "option 3" decision from that thread.
Closes #44.

## Why

The recorded clip **is the policy's observation image** (`agentview` at
256×256) — reused because that's what made capture near-free, but framed for
the model, not for humans, so the robot can sit partially out of frame
(reported by @Danny024 in #38). Camera choice isn't cosmetic today: picking a
nicer camera via `config` would also change what the policy sees.

## How

- New pure helper `_resolve_cameras(cfg)` in `runners/evals/robosuite.py`
  returns the env's camera kwargs plus the obs key capture should read; used
  by both `_make_eval_env` and `run()`.
- With `video_camera` set, it is appended to `camera_names`, and robosuite's
  per-camera `camera_heights`/`camera_widths` lists render the policy cam(s)
  at their configured size and the video cam at `video_height`×`video_width`
  — one env, one extra render stream per step. The MP4 reads
  `<video_camera>_image`; the policy keeps `image_key`.
- **Opt-in / backward compatible:** keys unset ⇒ identical env kwargs and
  capture key as today. Also inert when `capture_video` is off (a second
  camera would be pure render cost).
- `video_camera` colliding with a policy camera raises a clear `ValueError`
  (robosuite renders each camera at a single resolution, so the video would
  just be the policy frame — unset the key for that).
- The multi-agent runtime path now extracts **two** frames per step: the
  planner/pilot keep the policy frame, capture takes the video frame.
- Docs: README "Recording rollout videos" gains a **"Choosing the video
  camera"** subsection; the new keys ship commented-out in both example
  missions so they're discoverable without changing example behavior.

## Acceptance criteria (from #44)

- [x] Video frames come from a dedicated, configurable camera **without**
  changing the policy's input.
- [x] Default behavior unchanged when the new keys aren't set (near-free path
  preserved).
- [x] Works on the headless eval path (verified under EGL; the change only
  alters camera kwargs + which obs key is read, nothing backend-specific —
  same backend-agnostic capture as #38, which validated OSMesa).
- [x] Documented in the README "Recording rollout videos" section.

## Test plan

- [x] Unit tests (GPU-free), 8 new: `_resolve_cameras` (defaults, inert
  without `capture_video`, appending, 512 defaults, policy-camera lists,
  collision `ValueError`) + runner wiring via a dual-camera fake env serving a
  16×16 policy frame and a 32×32 video frame — the saved GIF reads back 32×32
  while the policy (and, on the multi-agent path, the planned runtime) still
  receives 16×16.
- [x] `ruff check`, `mypy --strict`, and the unit suite pass on the develop
  base.
- [x] EGL dual-camera render check (no model): `_make_eval_env` with
  `video_camera: frontview` steps a live Lift env — obs carries 256×256
  `agentview_image` **and** 512×512 `frontview_image`.
- [x] Real GPU run: `quickstart-openvla` mission end-to-end with
  `video_camera: frontview` — the MP4 records the full robot + workspace from
  frontview while the policy consumed agentview as before. (10-step LoRA
  smoke; grade F expected — the point is the capture path, as in #38.)

## Validated on

RTX 3090 (Ubuntu, headless EGL: `MUJOCO_GL=egl`), `quickstart-openvla`
mission, single-agent OpenVLA eval path; the multi-agent path is covered by
the GPU-free runtime-injection test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
