### PR TITLE
perf(openvla): FlashAttention/SDPA + inference_mode for lower per-step latency

### DIFF
--- a/src/odyssey/runners/models/openvla.py
+++ b/src/odyssey/runners/models/openvla.py
@@ -432,6 +432,56 @@ def _is_lora_checkpoint(checkpoint_path: Path) -> bool:
     return (checkpoint_path / "adapter_config.json").is_file()
 
 
+def _preferred_attn_implementations() -> list[str]:
+    """Attention backends to try at load time, fastest first.
+
+    FlashAttention-2 when the ``flash_attn`` package is importable, then
+    PyTorch SDPA (no extra dependency, still faster than the ``eager`` default).
+    ``_load_vla_model`` falls back to the model default if none are accepted by
+    the pinned OpenVLA remote code.
+    """
+    import importlib.util
+
+    impls: list[str] = []
+    if importlib.util.find_spec("flash_attn") is not None:
+        impls.append("flash_attention_2")
+    impls.append("sdpa")
+    return impls
+
+
+def _load_vla_model(model_ref: str) -> Any:
+    """Load an OpenVLA vision-to-seq model with the fastest available attention.
+
+    Same bf16 + ``low_cpu_mem_usage`` + ``trust_remote_code`` as before, but
+    tries FlashAttention-2 / SDPA first. If the custom OpenVLA modeling code
+    rejects ``attn_implementation`` (older pinned ``transformers``), it retries
+    without the kwarg so behaviour is unchanged on unsupported stacks.
+    """
+    import torch
+    from transformers import AutoModelForVision2Seq
+
+    common = {
+        "torch_dtype": torch.bfloat16,
+        "trust_remote_code": True,
+        "low_cpu_mem_usage": True,
+    }
+    for attn in _preferred_attn_implementations():
+        try:
+            model = AutoModelForVision2Seq.from_pretrained(
+                model_ref, attn_implementation=attn, **common
+            )
+            logger.info("Loaded %s with attn_implementation=%r", model_ref, attn)
+            return model
+        except (ValueError, TypeError, ImportError) as e:
+            logger.info(
+                "attn_implementation=%r unavailable (%s); trying next backend",
+                attn,
+                e,
+            )
+    logger.info("Loading %s with model-default attention", model_ref)
+    return AutoModelForVision2Seq.from_pretrained(model_ref, **common)
+
+
 def make_openvla_policy(
     checkpoint_path: Path,
     *,
@@ -449,7 +499,14 @@ def make_openvla_policy(
     try:
         import torch
         from PIL import Image
-        from transformers import AutoModelForVision2Seq, AutoProcessor
+
+        # Probe the heavy deps here so a missing 'openvla' extra surfaces as a
+        # friendly NotImplementedError rather than a bare ImportError deep in
+        # _load_vla_model. AutoModelForVision2Seq is loaded there, not here.
+        from transformers import (
+            AutoModelForVision2Seq,  # noqa: F401
+            AutoProcessor,
+        )
     except ImportError as e:
         raise NotImplementedError(
             "OpenVLA inference policy requires the 'openvla' extra. "
@@ -475,12 +532,7 @@ def make_openvla_policy(
         processor = AutoProcessor.from_pretrained(
             base_model_name, trust_remote_code=True
         )
-        model = AutoModelForVision2Seq.from_pretrained(
-            base_model_name,
-            torch_dtype=torch.bfloat16,
-            trust_remote_code=True,
-            low_cpu_mem_usage=True,
-        )
+        model = _load_vla_model(base_model_name)
         logger.info("Applying LoRA adapter from: %s", checkpoint_path)
         model = PeftModel.from_pretrained(model, str(checkpoint_path))
 
@@ -500,12 +552,7 @@ def make_openvla_policy(
         processor = AutoProcessor.from_pretrained(
             str(checkpoint_path), trust_remote_code=True
         )
-        model = AutoModelForVision2Seq.from_pretrained(
-            str(checkpoint_path),
-            torch_dtype=torch.bfloat16,
-            trust_remote_code=True,
-            low_cpu_mem_usage=True,
-        )
+        model = _load_vla_model(str(checkpoint_path))
 
     model = model.to(device)
 
@@ -529,11 +576,12 @@ def make_openvla_policy(
         # The HF-hosted OpenVLAForActionPrediction.predict_action() expects
         # pre-tokenized input_ids, not raw image+instruction.
         inputs = processor(task_instruction, img_array).to(device, dtype=torch.bfloat16)
-        action = model.predict_action(
-            inputs["input_ids"],
-            unnorm_key=unnorm_key,
-            do_sample=False,
-        )
+        with torch.inference_mode():
+            action = model.predict_action(
+                inputs["input_ids"],
+                unnorm_key=unnorm_key,
+                do_sample=False,
+            )
         return np.array(action, dtype=np.float64)
 
     return policy
@@ -568,7 +616,13 @@ class VLARuntime:
     ) -> None:
         try:
             import torch
-            from transformers import AutoModelForVision2Seq, AutoProcessor
+
+            # Probe the heavy deps up front (see make_openvla_policy) so a
+            # missing 'openvla' extra raises a friendly NotImplementedError.
+            from transformers import (
+                AutoModelForVision2Seq,  # noqa: F401
+                AutoProcessor,
+            )
         except ImportError as e:
             raise NotImplementedError(
                 "VLARuntime requires the 'openvla' extra. "
@@ -589,12 +643,7 @@ class VLARuntime:
             self._processor = AutoProcessor.from_pretrained(
                 base_name, trust_remote_code=True
             )
-            model = AutoModelForVision2Seq.from_pretrained(
-                base_name,
-                torch_dtype=torch.bfloat16,
-                trust_remote_code=True,
-                low_cpu_mem_usage=True,
-            )
+            model = _load_vla_model(base_name)
             logger.info("VLARuntime: applying LoRA adapter from %s", self._checkpoint_path)
             model = PeftModel.from_pretrained(model, str(self._checkpoint_path))
             if hasattr(model, "merge_and_unload"):
@@ -607,12 +656,7 @@ class VLARuntime:
             self._processor = AutoProcessor.from_pretrained(
                 str(self._checkpoint_path), trust_remote_code=True
             )
-            model = AutoModelForVision2Seq.from_pretrained(
-                str(self._checkpoint_path),
-                torch_dtype=torch.bfloat16,
-                trust_remote_code=True,
-                low_cpu_mem_usage=True,
-            )
+            model = _load_vla_model(str(self._checkpoint_path))
 
         self._model = model.to(self._device)
         logger.info("VLARuntime ready on %s", self._device)
@@ -634,9 +678,10 @@ class VLARuntime:
         inputs = self._processor(instruction, image).to(
             self._device, dtype=torch.bfloat16
         )
-        action = self._model.predict_action(
-            inputs["input_ids"],
-            unnorm_key=self._unnorm_key,
-            do_sample=False,
-        )
+        with torch.inference_mode():
+            action = self._model.predict_action(
+                inputs["input_ids"],
+                unnorm_key=self._unnorm_key,
+                do_sample=False,
+            )
         return np.array(action, dtype=np.float64)

--- a/tests/manual/bench_openvla_latency.py
+++ b/tests/manual/bench_openvla_latency.py
@@ -47,8 +47,11 @@ def main() -> None:
     runtime = VLARuntime(args.checkpoint, unnorm_key=args.unnorm_key)
     device = runtime._device  # read-only private access, benchmark only
     is_cuda = device.startswith("cuda")
+    # Ground truth of the attention backend transformers actually wired — this
+    # is what tells us whether the FlashAttn/SDPA change took effect at all.
+    attn = getattr(runtime._model.config, "_attn_implementation", "unknown")
     print(f"device={device}  iters={args.iters}  warmup={args.warmup}")
-    print("(check the load log above for the actual attn_implementation used)")
+    print(f"attn_implementation (resolved): {attn}")
 
     # Fixed synthetic frame — content is irrelevant for latency, only shape/dtype.
     rng = np.random.default_rng(0)

--- a/tests/manual/bench_openvla_latency.py
+++ b/tests/manual/bench_openvla_latency.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Micro-benchmark for OpenVLA Pilot inference latency.
+
+Isolates VLARuntime.act() from sim/env overhead so you can A/B the same
+checkpoint on two branches (e.g. develop vs feat/openvla-inference-latency)
+and see whether the FlashAttention/SDPA + inference_mode change moved the
+per-step latency.
+
+Run on the GPU VM (latency is hardware-specific), same checkpoint both times:
+
+    # baseline
+    git checkout develop
+    python bench_openvla_latency.py --checkpoint /path/to/ckpt
+
+    # candidate
+    git checkout feat/openvla-inference-latency
+    python bench_openvla_latency.py --checkpoint /path/to/ckpt
+
+Compare the reported median ms/action. This script is a throwaway harness —
+not committed to the PR unless you decide it's worth keeping.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import numpy as np
+
+from odyssey.runners.models.openvla import VLARuntime
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True, help="LoRA adapter or merged model dir")
+    p.add_argument("--unnorm-key", default="bridge_orig")
+    p.add_argument("--warmup", type=int, default=10, help="calls to discard first")
+    p.add_argument("--iters", type=int, default=100, help="timed calls")
+    p.add_argument("--height", type=int, default=256)
+    p.add_argument("--width", type=int, default=256)
+    p.add_argument("--instruction", default="pick up the object")
+    args = p.parse_args()
+
+    import torch
+
+    runtime = VLARuntime(args.checkpoint, unnorm_key=args.unnorm_key)
+    device = runtime._device  # read-only private access, benchmark only
+    is_cuda = device.startswith("cuda")
+    print(f"device={device}  iters={args.iters}  warmup={args.warmup}")
+    print("(check the load log above for the actual attn_implementation used)")
+
+    # Fixed synthetic frame — content is irrelevant for latency, only shape/dtype.
+    rng = np.random.default_rng(0)
+    image = rng.integers(0, 256, size=(args.height, args.width, 3), dtype=np.uint8)
+
+    def sync() -> None:
+        if is_cuda:
+            torch.cuda.synchronize()
+
+    # Warm-up: absorbs lazy CUDA init, kernel autotuning, caches.
+    for _ in range(args.warmup):
+        runtime.act(image, args.instruction)
+    sync()
+
+    # Timed loop — synchronize inside each iteration so we measure real
+    # GPU execution, not async kernel launches.
+    samples_ms: list[float] = []
+    for _ in range(args.iters):
+        t0 = time.perf_counter()
+        runtime.act(image, args.instruction)
+        sync()
+        samples_ms.append((time.perf_counter() - t0) * 1000.0)
+
+    samples_ms.sort()
+    median = statistics.median(samples_ms)
+    p90 = samples_ms[int(0.9 * len(samples_ms)) - 1]
+    mean = statistics.fmean(samples_ms)
+    print("\n--- per-action latency (ms) ---")
+    print(f"median : {median:7.2f}")
+    print(f"p90    : {p90:7.2f}")
+    print(f"mean   : {mean:7.2f}")
+    print(f"min    : {samples_ms[0]:7.2f}")
+    print(f"max    : {samples_ms[-1]:7.2f}")
+    print(f"\nthroughput (median): {1000.0 / median:6.2f} actions/s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Two low-risk, **in-process** latency optimizations to the OpenVLA Pilot forward pass, which is the dominant cost in eval (it's called once per step → 50+ times per episode). No migration to a serving stack (vLLM/SGLang) and no architectural changes.

- **Faster attention at load time**: `_load_vla_model` (a helper shared by `make_openvla_policy` and `VLARuntime`) tries `flash_attention_2` if `flash_attn` is installed, otherwise `sdpa`, instead of the transformers `eager` default. **Safe fallback**: if OpenVLA's remote code (pinned transformers) rejects `attn_implementation`, it retries without the kwarg → unchanged behavior on unsupported stacks.
- **`torch.inference_mode()`** around both `predict_action` call sites to drop autograd tracking during rollouts.

No changes to: bf16, greedy decode (`do_sample=False`), single weight load. The dependency probe (`AutoModelForVision2Seq`) is kept in the import guards so that a missing `openvla` extra still raises the friendly `NotImplementedError`.

## Why

In the eval loop the Specialist is invoked once per episode but the Pilot 50+ times, so every ms shaved off the Pilot forward pass is multiplied. These are the lowest-risk levers under the "cheapen the forward pass" goal — the structural ones (episode batching, TensorRT) are deferred and depend on the OpenVLA-7B vs GR00T-3B decision.

## Scope / isolation

GR00T is a **separate** runner (`gr00t.py` / `gr00t_isaac_eval.py`) and does **not** go through this path. It only shares two utility helpers (`_flatten_config`, `_resolve_and_fetch_hf_model`) which are untouched.

## Verification

- `ruff check` clean
- `mypy` clean (strict)
- 54 GR00T + OpenVLA tests pass (including `test_gr00t*` and `test_openvla_policy`)

⚠️ **Pending GPU validation**: the real it/s impact (and confirming that `flash_attention_2` is accepted by OpenVLA's remote code with the pinned transformers version) must be measured on the L4 VM with a before/after benchmark. The fallback guarantees that, if it's not accepted, nothing breaks — it just doesn't speed things up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
