### PR TITLE
[MA]feat(evals): closed-loop completion-gated phase transitions for multi-agent eval

### DIFF
--- a/examples/franka-libero/mission-multiagent.yaml
+++ b/examples/franka-libero/mission-multiagent.yaml
@@ -63,8 +63,18 @@ tasks:
       checkpoint: openvla/openvla-7b-finetuned-libero-object   # HF repo id (eval-only)
       unnorm_key: libero_object
       task_id: 0
-      steps_per_phase: 50          # PlannedEvalRuntime: advance phase every N steps
       capture_video: true
+      # Phase advancement (PlannedEvalRuntime). Default is open-loop fixed_steps:
+      #   phase_strategy: fixed_steps   # (default) advance every steps_per_phase steps
+      #   steps_per_phase: 50
+      # Opt into CLOSED-LOOP: the SPECIALIST is re-asked "is this sub-instruction
+      # done?" from the current frame every phase_check_every steps and the phase
+      # advances only when it says yes — with phase_max_steps as a safety cap. Reuses
+      # the same loaded Gemma (no extra VRAM); adds ~1-2s per check, so keep the
+      # cadence >= 10. Meant to fix "grasped but switched to the next step too early".
+      phase_strategy: completion_gated
+      phase_check_every: 10
+      phase_max_steps: 100
       # OPTIONAL alignment contract (see mission.yaml). The declared instruction is
       # cross-checked against the benchmark's task.language; the SPECIALIST plans
       # from that same authoritative instruction. Fill from the first run's log.

--- a/src/odyssey/runners/agents/planned.py
+++ b/src/odyssey/runners/agents/planned.py
@@ -26,7 +26,11 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
-from odyssey.runners.agents.runtime import PilotRuntime, PlannerRuntime
+from odyssey.runners.agents.runtime import (
+    CompletionDetector,
+    PilotRuntime,
+    PlannerRuntime,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +38,7 @@ logger = logging.getLogger(__name__)
 class PhaseStrategy(str, Enum):
     FIXED_STEPS = "fixed_steps"
     TIMEOUT = "timeout"
+    COMPLETION_GATED = "completion_gated"
 
 
 @dataclass
@@ -43,6 +48,37 @@ class PhaseConfig:
     strategy: PhaseStrategy = PhaseStrategy.FIXED_STEPS
     steps_per_phase: int = 50
     timeout_seconds: float = 10.0
+    # COMPLETION_GATED only: poll the detector every ``check_every`` steps
+    # (never every step — a VLM round-trip costs ~1-2s), and force-advance
+    # after ``max_steps_per_phase`` as a safety cap so a phase never wedges.
+    check_every: int = 10
+    max_steps_per_phase: int = 100
+
+    @classmethod
+    def from_config(cls, cfg: dict[str, Any]) -> PhaseConfig:
+        """Build a PhaseConfig from a mission ``config:`` dict (opt-in).
+
+        Recognised keys: ``phase_strategy`` (``fixed_steps`` | ``timeout`` |
+        ``completion_gated``, default ``fixed_steps``), ``steps_per_phase``,
+        ``timeout_seconds``, ``phase_check_every``, ``phase_max_steps``. An
+        unknown ``phase_strategy`` raises ``ValueError`` (runners own config
+        validation — the spec's ``config`` is free-form).
+        """
+        raw = cfg.get("phase_strategy", PhaseStrategy.FIXED_STEPS.value)
+        try:
+            strategy = PhaseStrategy(str(raw))
+        except ValueError as exc:
+            allowed = ", ".join(s.value for s in PhaseStrategy)
+            raise ValueError(
+                f"unknown phase_strategy {raw!r}; allowed: {allowed}"
+            ) from exc
+        return cls(
+            strategy=strategy,
+            steps_per_phase=int(cfg.get("steps_per_phase", 50)),
+            timeout_seconds=float(cfg.get("timeout_seconds", 10.0)),
+            check_every=int(cfg.get("phase_check_every", 10)),
+            max_steps_per_phase=int(cfg.get("phase_max_steps", 100)),
+        )
 
 
 @dataclass
@@ -84,6 +120,11 @@ class PlannedEvalRuntime:
         Controls when to advance between sub-instructions.
     fallback_instruction:
         Used if the planner is None or returns no plan.
+    detector:
+        Optional ``CompletionDetector`` for the ``COMPLETION_GATED`` strategy.
+        If omitted, the planner is auto-adopted when it exposes a ``check_done``
+        method (the out-of-process SPECIALIST answers both ``plan`` and
+        ``check_done`` from the same loaded model — zero extra VRAM).
     """
 
     def __init__(
@@ -93,12 +134,22 @@ class PlannedEvalRuntime:
         *,
         phase_config: PhaseConfig | None = None,
         fallback_instruction: str = "complete the task",
+        detector: CompletionDetector | None = None,
     ) -> None:
         self._pilot = pilot
         self._planner = planner
         self._phase_config = phase_config or PhaseConfig()
         self._fallback = fallback_instruction
+        # Reuse the planner as the completion detector when it can answer a
+        # yes/no check (RemotePlanner / a multimodal LLMPlanner). hasattr keeps
+        # a text-only planner that lacks the method perfectly valid.
+        if detector is None and hasattr(planner, "check_done"):
+            detector = planner  # type: ignore[assignment]
+        self._detector = detector
         self._state = _PhaseState()
+        # Buffered (from, to, instruction, reason) advance records. get_action
+        # is sync but telemetry is async, so the async step loop drains these.
+        self._pending_events: list[dict[str, Any]] = []
 
     @property
     def current_phase_index(self) -> int:
@@ -133,11 +184,21 @@ class PlannedEvalRuntime:
             sub_instructions=steps,
             phase_start_time=time.monotonic(),
         )
+        self._pending_events = []
         logger.info(
             "PlannedEvalRuntime: episode plan with %d phases: %s",
             len(steps),
             steps,
         )
+        if (
+            self._phase_config.strategy == PhaseStrategy.COMPLETION_GATED
+            and self._detector is None
+        ):
+            logger.warning(
+                "COMPLETION_GATED strategy but no completion detector available; "
+                "phases will only advance at the max_steps_per_phase cap (%d).",
+                self._phase_config.max_steps_per_phase,
+            )
         return steps
 
     def get_action(self, image: Any) -> NDArray[np.floating[Any]]:
@@ -152,34 +213,76 @@ class PlannedEvalRuntime:
 
         action = self._pilot.act(image, instruction)
         self._state.steps_in_phase += 1
-        self._maybe_advance_phase()
+        self._maybe_advance_phase(image)
         return action
 
-    def _maybe_advance_phase(self) -> None:
+    def _maybe_advance_phase(self, image: Any) -> None:
         if self._state.is_complete:
             return
 
         cfg = self._phase_config
         advance = False
+        reason = ""
 
         if cfg.strategy == PhaseStrategy.FIXED_STEPS:
             if self._state.steps_in_phase >= cfg.steps_per_phase:
-                advance = True
+                advance, reason = True, "fixed_steps"
         elif cfg.strategy == PhaseStrategy.TIMEOUT:
             elapsed = time.monotonic() - self._state.phase_start_time
             if elapsed >= cfg.timeout_seconds:
-                advance = True
+                advance, reason = True, "timeout"
+        elif cfg.strategy == PhaseStrategy.COMPLETION_GATED:
+            n = self._state.steps_in_phase
+            # Cap first: a stuck phase always terminates, even if the detector
+            # is unavailable or never confirms.
+            if n >= cfg.max_steps_per_phase:
+                advance, reason = True, "cap"
+            elif (
+                self._detector is not None
+                and n > 0
+                and n % cfg.check_every == 0
+                and self._detector.check_done(self._state.current_instruction, image)
+            ):
+                advance, reason = True, "completion"
 
         if advance:
             old_idx = self._state.current_index
+            old_instruction = self._state.current_instruction
             self._state.advance()
+            next_instruction = (
+                self._state.current_instruction
+                if not self._state.is_complete
+                else old_instruction
+            )
+            self._pending_events.append(
+                {
+                    "from": old_idx,
+                    "to": self._state.current_index,
+                    "instruction": next_instruction,
+                    "reason": reason,
+                }
+            )
             if not self._state.is_complete:
                 logger.debug(
-                    "Phase %d → %d: %s",
+                    "Phase %d → %d (%s): %s",
                     old_idx,
                     self._state.current_index,
+                    reason,
                     self._state.current_instruction,
                 )
+
+    def drain_phase_events(self) -> list[dict[str, Any]]:
+        """Return and clear buffered phase-advance records.
+
+        Each record is ``{"from", "to", "instruction", "reason"}`` where reason
+        is ``fixed_steps`` | ``timeout`` | ``completion`` | ``cap``. Empty (zero
+        overhead) on non-advancing steps and the single-agent path. The async
+        step loop drains this after each ``get_action`` to emit telemetry that
+        the sync runtime cannot emit itself.
+        """
+        events = self._pending_events
+        self._pending_events = []
+        return events
 
     def close(self) -> None:
         """Release runtime resources. Closes the planner if it owns any

--- a/src/odyssey/runners/agents/planner.py
+++ b/src/odyssey/runners/agents/planner.py
@@ -39,6 +39,14 @@ _SYSTEM_PROMPT_VISION = (
     "numbered list, nothing else."
 )
 
+_COMPLETION_PROMPT = (
+    "You are a robot task supervisor. You are given the current scene image and "
+    "the single sub-instruction the robot arm is currently executing. Decide "
+    "whether that sub-instruction is now FULLY completed in the image. Answer "
+    "with EXACTLY one word: YES if it is fully completed, otherwise NO. Do not "
+    "explain."
+)
+
 _NUMBERED_LINE = re.compile(r"^\s*\d+[\.\)]\s*(.+)$")
 
 
@@ -50,6 +58,19 @@ def _parse_plan(text: str) -> list[str]:
         if m:
             lines.append(m.group(1).strip())
     return lines
+
+
+def _parse_yes_no(text: str) -> bool:
+    """True only when the output's first word is an explicit yes.
+
+    Takes the first alphabetic run (ignoring surrounding markdown/punctuation
+    like ``**YES**``). Conservative by design: anything ambiguous (``no``,
+    empty, ``maybe``, a sentence not starting with yes) → False, so a phase
+    never advances on an unclear answer (the runtime's step cap still
+    guarantees progress).
+    """
+    m = re.search(r"[a-zA-Z]+", text or "")
+    return m is not None and m.group(0).lower() in ("yes", "y")
 
 
 class LLMPlanner:
@@ -98,3 +119,24 @@ class LLMPlanner:
             )
             return [task_instruction]
         return steps
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        """Return True if ``instruction`` looks completed in ``image``.
+
+        Satisfies ``CompletionDetector``. Requires a multimodal generator and a
+        frame — without either, the check is impossible, so it returns False
+        (never a false positive; the runtime's step cap still advances phases).
+        """
+        if not self._accepts_image or image is None:
+            logger.debug(
+                "check_done unavailable (accepts_image=%s, image=%s) — returning False",
+                self._accepts_image,
+                image is not None,
+            )
+            return False
+        messages = [
+            {"role": "user", "content": f"{_COMPLETION_PROMPT}\n\nSub-instruction: {instruction}"},
+        ]
+        text = self._generator.generate(messages, image=image)  # type: ignore[call-arg]
+        logger.debug("check_done(%r) raw output: %r", instruction, text)
+        return _parse_yes_no(text)

--- a/src/odyssey/runners/agents/planner_server.py
+++ b/src/odyssey/runners/agents/planner_server.py
@@ -9,6 +9,8 @@ then answers planning requests over a JSON-lines stdin/stdout protocol:
     -> {"instruction": "pick up the cube"}   (one request per line, on stdin)
     -> {"instruction": "...", "image": "<base64 PNG>"}   (multimodal request)
     <- {"plan": ["...", "..."]}              (one response per line, on stdout)
+    -> {"check": {"instruction": "...", "image": "<base64 PNG>"}}  (completion check)
+    <- {"done": true|false}                  (is the sub-instruction satisfied?)
     <- {"error": "..."}                      (on failure; the client falls back)
     -> {"shutdown": true}                    (client asks the server to exit)
 
@@ -78,6 +80,25 @@ def serve(
             continue
         if req.get("shutdown"):
             break
+        check = req.get("check")
+        if isinstance(check, dict):
+            try:
+                check_instruction = check.get("instruction")
+                if not isinstance(check_instruction, str):
+                    _emit(outstream, {"error": "check missing 'instruction' string"})
+                    continue
+                checker = getattr(planner, "check_done", None)
+                if not callable(checker):
+                    _emit(outstream, {"error": "check unsupported"})
+                    continue
+                check_image = None
+                raw_check_image = check.get("image")
+                if isinstance(raw_check_image, str):
+                    check_image = _decode_image(raw_check_image)
+                _emit(outstream, {"done": bool(checker(check_instruction, check_image))})
+            except BaseException as e:
+                _emit(outstream, {"error": f"check failed: {type(e).__name__}: {e}"})
+            continue
         instruction = req.get("instruction")
         if not isinstance(instruction, str):
             _emit(outstream, {"error": "missing 'instruction' string"})

--- a/src/odyssey/runners/agents/remote_planner.py
+++ b/src/odyssey/runners/agents/remote_planner.py
@@ -88,6 +88,10 @@ class RemotePlanner:
         model, so this is generous.
     request_timeout:
         Seconds to wait for a single plan response.
+    check_timeout:
+        Seconds to wait for a single completion-check response. Short by design
+        (the check runs on the per-step loop, every K steps): a hung check
+        falls back to ``False`` rather than freezing the episode.
     launch_args:
         Argv (after ``python_path``) that starts the server. Defaults to
         ``("-m", planner_server)``; overridable for tests.
@@ -101,6 +105,7 @@ class RemotePlanner:
         python_path: str,
         startup_timeout: float = 600.0,
         request_timeout: float = 120.0,
+        check_timeout: float = 5.0,
         launch_args: Sequence[str] = ("-m", _SERVER_MODULE),
     ) -> None:
         self._model_base = model_base
@@ -108,6 +113,7 @@ class RemotePlanner:
         self._python_path = python_path
         self._startup_timeout = startup_timeout
         self._request_timeout = request_timeout
+        self._check_timeout = check_timeout
         self._launch_args = list(launch_args)
         self._proc: subprocess.Popen[str] | None = None
         # A background thread drains stdout into this queue. We avoid
@@ -216,6 +222,38 @@ class RemotePlanner:
                 task_instruction,
             )
         return [task_instruction]
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        """Ask the out-of-process SPECIALIST if ``instruction`` is completed.
+
+        Satisfies ``CompletionDetector``. Reuses the same loaded model as
+        ``plan`` over the same channel; unlike ``plan`` this runs on the
+        per-step loop (every K steps), so it uses the short ``check_timeout``.
+        Fails safe: any error, timeout, missing frame, or a server that doesn't
+        support checks (``{"error": ...}``) returns ``False`` — a phase never
+        advances on a bad check (the runtime's step cap still guarantees
+        progress).
+        """
+        if image is None:
+            return False
+        try:
+            self._ensure_started()
+            proc = self._proc
+            assert proc is not None and proc.stdin is not None
+            request = {
+                "check": {"instruction": instruction, "image": _encode_image(image)}
+            }
+            proc.stdin.write(json.dumps(request) + "\n")
+            proc.stdin.flush()
+            msg = self._read_message(self._check_timeout)
+            return bool((msg or {}).get("done"))
+        except Exception as e:
+            logger.warning(
+                "RemotePlanner.check_done failed (%s) for %r — treating as not done",
+                e,
+                instruction,
+            )
+            return False
 
     def close(self) -> None:
         """Shut down the server process. Idempotent; also runs at exit."""

--- a/src/odyssey/runners/agents/runtime.py
+++ b/src/odyssey/runners/agents/runtime.py
@@ -101,3 +101,24 @@ class PlannerRuntime(Protocol):
         sequentially.
         """
         ...
+
+
+@runtime_checkable
+class CompletionDetector(Protocol):
+    """Answers whether a sub-instruction is satisfied in the current frame.
+
+    Used by ``PlannedEvalRuntime``'s ``COMPLETION_GATED`` strategy to close the
+    loop: instead of advancing phases on a blind step counter, it asks a VLM
+    whether the active sub-instruction is done before moving on. The
+    out-of-process SPECIALIST satisfies both this and ``PlannerRuntime`` from
+    the same loaded model, so no second model is loaded.
+    """
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        """Return True if ``instruction`` is satisfied in ``image``.
+
+        Must be conservative and fail-safe: return False when uncertain or on
+        any error, so a phase never advances on a false positive (the runtime's
+        step cap still guarantees forward progress).
+        """
+        ...

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -312,6 +312,18 @@ class LiberoRunner(Runner):
 
                 if runtime:
                     raw_action = runtime.get_action(image)
+                    for ev in runtime.drain_phase_events():
+                        await context.emit_progress(
+                            "executing",
+                            step="phase_advance",
+                            step_index=ep,
+                            step_total=num_episodes,
+                            step_label=(
+                                f"episode {ep} phase {ev['from']}->{ev['to']} "
+                                f"({ev['reason']}): {ev['instruction']}"
+                            ),
+                            metadata=ev,
+                        )
                 else:
                     assert policy is not None
                     raw_action = policy({image_key: image})
@@ -426,7 +438,7 @@ def _build_planned_runtime(
     logger.info("SPECIALIST out-of-process: model=%s via %s", model_base, specialist_python)
     planner = RemotePlanner(model_base, quantization, python_path=specialist_python)
 
-    phase_config = PhaseConfig(steps_per_phase=int(cfg.get("steps_per_phase", 50)))
+    phase_config = PhaseConfig.from_config(cfg)
     return PlannedEvalRuntime(
         pilot=pilot,
         planner=planner,

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -313,6 +313,18 @@ class RobosuiteRunner(Runner):
                     if capture_video:
                         _capture_frame(frames, image)
                     action = runtime.get_action(image)
+                    for ev in runtime.drain_phase_events():
+                        await context.emit_progress(
+                            "executing",
+                            step="phase_advance",
+                            step_index=ep,
+                            step_total=num_episodes,
+                            step_label=(
+                                f"episode {ep} phase {ev['from']}->{ev['to']} "
+                                f"({ev['reason']}): {ev['instruction']}"
+                            ),
+                            metadata=ev,
+                        )
                 else:
                     assert policy is not None
                     if capture_video:
@@ -512,9 +524,9 @@ def _build_planned_runtime(
         python_path=specialist_python,
     )
 
-    # Phase config from mission config
-    steps_per_phase = cfg.get("steps_per_phase", 50)
-    phase_config = PhaseConfig(steps_per_phase=steps_per_phase)
+    # Phase config from mission config (opt-in completion-gating; default
+    # stays fixed_steps so existing missions are unchanged).
+    phase_config = PhaseConfig.from_config(cfg)
 
     task_instruction = _resolve_task_instruction(spec)
 

--- a/tests/integration/test_multiagent_eval.py
+++ b/tests/integration/test_multiagent_eval.py
@@ -64,6 +64,18 @@ class MockPlanner:
         return list(self._steps)
 
 
+class MockDetector:
+    """Completion detector stub — confirms done from the Nth poll onward."""
+
+    def __init__(self, done_after: int | None = None) -> None:
+        self._done_after = done_after
+        self.calls = 0
+
+    def check_done(self, instruction: str, image: object) -> bool:
+        self.calls += 1
+        return self._done_after is not None and self.calls >= self._done_after
+
+
 # ---------------------------------------------------------------------------
 # Mock runner that uses PlannedEvalRuntime for eval tasks
 # ---------------------------------------------------------------------------
@@ -355,3 +367,35 @@ async def test_mock_pilot_satisfies_protocol() -> None:
 
 async def test_mock_planner_satisfies_protocol() -> None:
     assert isinstance(MockPlanner(), PlannerRuntime)
+
+
+async def test_completion_gated_drains_phase_advance_telemetry() -> None:
+    """The runner's drain+emit pattern turns completion-gated advances into
+    phase_advance telemetry — the runtime is sync, the async loop emits."""
+    from odyssey.runners.agents.planned import PhaseStrategy
+
+    pilot = MockPilot()
+    planner = MockPlanner(["reach", "grasp"])
+    detector = MockDetector(done_after=1)  # confirms on its first poll
+    cfg = PhaseConfig(
+        strategy=PhaseStrategy.COMPLETION_GATED, check_every=2, max_steps_per_phase=50
+    )
+    runtime = PlannedEvalRuntime(pilot, planner, phase_config=cfg, detector=detector)
+    runtime.begin_episode("pick and place")
+
+    pub = CapturingPublisher()
+    img = np.zeros((64, 64, 3), dtype=np.uint8)
+    # Mirror the runner step loop: get_action, then drain -> publish. Two steps
+    # is one poll cadence (check_every=2): off-cadence step 1, then step 2 polls
+    # the detector, which confirms -> exactly one completion advance.
+    for _ in range(2):
+        runtime.get_action(img)
+        for ev in runtime.drain_phase_events():
+            await pub.publish("task.progress", {"step": "phase_advance", **ev})
+
+    advances = [p for _, p in pub.events if p.get("step") == "phase_advance"]
+    assert len(advances) == 1
+    assert advances[0]["reason"] == "completion"
+    assert advances[0]["from"] == 0
+    assert advances[0]["to"] == 1
+    assert detector.calls == 1

--- a/tests/unit/test_agent_runtimes.py
+++ b/tests/unit/test_agent_runtimes.py
@@ -20,8 +20,13 @@ from odyssey.runners.agents.planned import (
     PlannedEvalRuntime,
     _PhaseState,
 )
-from odyssey.runners.agents.planner import LLMPlanner, _parse_plan
-from odyssey.runners.agents.runtime import PilotRuntime, PlannerRuntime, TextGenerator
+from odyssey.runners.agents.planner import LLMPlanner, _parse_plan, _parse_yes_no
+from odyssey.runners.agents.runtime import (
+    CompletionDetector,
+    PilotRuntime,
+    PlannerRuntime,
+    TextGenerator,
+)
 
 # ---------------------------------------------------------------------------
 # Fakes
@@ -62,6 +67,40 @@ class FakePlanner:
         self.call_count += 1
         self.last_image = image
         return list(self._steps)
+
+
+class FakeDetector:
+    """Completion detector stub. Returns True from the Nth call onward.
+
+    ``done_after=None`` never confirms; records each (instruction, image) call.
+    """
+
+    def __init__(self, done_after: int | None = None) -> None:
+        self._done_after = done_after
+        self.calls: list[tuple[str, Any]] = []
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        self.calls.append((instruction, image))
+        return self._done_after is not None and len(self.calls) >= self._done_after
+
+
+class FakePlannerWithCheck(FakePlanner):
+    """A planner that also satisfies CompletionDetector (like RemotePlanner)."""
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        return False
+
+
+class FakeVisionGenerator:
+    """Multimodal TextGenerator stub — its generate() accepts an image."""
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.calls: list[tuple[list[dict[str, str]], Any]] = []
+
+    def generate(self, messages: list[dict[str, str]], image: Any = None) -> str:
+        self.calls.append((messages, image))
+        return self._response
 
 
 # ---------------------------------------------------------------------------
@@ -325,3 +364,157 @@ def test_llm_planner_passes_instruction_to_generator() -> None:
     planner.plan("pick up the red cube")
     assert len(calls) == 1
     assert "pick up the red cube" in calls[0][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# COMPLETION_GATED strategy
+# ---------------------------------------------------------------------------
+
+def _gated_cfg(**kw: Any) -> PhaseConfig:
+    return PhaseConfig(strategy=PhaseStrategy.COMPLETION_GATED, **kw)
+
+
+def test_completion_gated_advances_on_detector() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["phase-1", "phase-2"])
+    detector = FakeDetector(done_after=1)  # True on its first poll
+    cfg = _gated_cfg(check_every=2, max_steps_per_phase=100)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg, detector=detector)
+    rt.begin_episode("task")
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    rt.get_action(img)  # step 1: off-cadence, detector NOT polled
+    assert rt.current_phase_index == 0
+    assert detector.calls == []
+
+    rt.get_action(img)  # step 2: on-cadence, detector polled -> True -> advance
+    assert rt.current_phase_index == 1
+    assert len(detector.calls) == 1
+
+
+def test_completion_gated_advances_at_cap_when_never_done() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["phase-1", "phase-2"])
+    detector = FakeDetector(done_after=None)  # never confirms
+    cfg = _gated_cfg(check_every=2, max_steps_per_phase=6)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg, detector=detector)
+    rt.begin_episode("task")
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    for _ in range(5):
+        rt.get_action(img)
+    assert rt.current_phase_index == 0  # not yet at cap
+    rt.get_action(img)  # step 6 hits the cap
+    assert rt.current_phase_index == 1
+    # Cap is checked before the detector, so step 6 does not poll: only steps 2 & 4.
+    assert len(detector.calls) == 2
+    events = rt.drain_phase_events()
+    assert events == [
+        {"from": 0, "to": 1, "instruction": "phase-2", "reason": "cap"}
+    ]
+
+
+def test_completion_gated_no_detector_falls_back_to_cap() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["phase-1", "phase-2"])  # no check_done -> no detector
+    cfg = _gated_cfg(check_every=2, max_steps_per_phase=3)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg)
+    assert rt._detector is None
+    rt.begin_episode("task")
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    for _ in range(2):
+        rt.get_action(img)
+    assert rt.current_phase_index == 0
+    rt.get_action(img)  # step 3 == cap
+    assert rt.current_phase_index == 1
+    assert rt.drain_phase_events()[0]["reason"] == "cap"
+
+
+def test_completion_gated_detector_gets_current_frame_and_instruction() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["grasp the cube", "lift"])
+    detector = FakeDetector(done_after=None)
+    cfg = _gated_cfg(check_every=1, max_steps_per_phase=100)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg, detector=detector)
+    rt.begin_episode("task")
+
+    img = np.ones((8, 8, 3), dtype=np.uint8) * 7
+    rt.get_action(img)
+    assert detector.calls[0][0] == "grasp the cube"
+    np.testing.assert_array_equal(detector.calls[0][1], img)
+
+
+def test_detector_auto_discovered_from_planner() -> None:
+    rt = PlannedEvalRuntime(FakePilot(), FakePlannerWithCheck(["a", "b"]))
+    assert rt._detector is not None
+
+
+def test_no_detector_when_planner_lacks_check_done() -> None:
+    rt = PlannedEvalRuntime(FakePilot(), FakePlanner(["a", "b"]))
+    assert rt._detector is None
+
+
+def test_drain_phase_events_empties_the_buffer() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["a", "b"])
+    cfg = PhaseConfig(strategy=PhaseStrategy.FIXED_STEPS, steps_per_phase=1)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg)
+    rt.begin_episode("task")
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    rt.get_action(img)  # advances immediately (steps_per_phase=1)
+    first = rt.drain_phase_events()
+    assert first and first[0]["reason"] == "fixed_steps"
+    assert rt.drain_phase_events() == []  # drained
+
+
+def test_fixed_steps_emits_no_events_mid_phase() -> None:
+    pilot = FakePilot()
+    planner = FakePlanner(["a", "b"])
+    cfg = PhaseConfig(strategy=PhaseStrategy.FIXED_STEPS, steps_per_phase=5)
+    rt = PlannedEvalRuntime(pilot, planner, phase_config=cfg)
+    rt.begin_episode("task")
+    rt.get_action(np.zeros((8, 8, 3), dtype=np.uint8))
+    assert rt.drain_phase_events() == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_yes_no + LLMPlanner.check_done
+# ---------------------------------------------------------------------------
+
+def test_parse_yes_no_true_cases() -> None:
+    for text in ["YES", "yes", "Yes.", "  yes it is done", "y", "**YES**"]:
+        assert _parse_yes_no(text) is True, text
+
+
+def test_parse_yes_no_false_cases() -> None:
+    for text in ["NO", "no", "", "maybe", "not yet", "almost yes"]:
+        assert _parse_yes_no(text) is False, text
+
+
+def test_llm_planner_check_done_yes() -> None:
+    planner = LLMPlanner(FakeVisionGenerator("YES"))
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    assert planner.check_done("grasp the cube", img) is True
+
+
+def test_llm_planner_check_done_no() -> None:
+    planner = LLMPlanner(FakeVisionGenerator("NO"))
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    assert planner.check_done("grasp the cube", img) is False
+
+
+def test_llm_planner_check_done_false_without_image() -> None:
+    planner = LLMPlanner(FakeVisionGenerator("YES"))
+    assert planner.check_done("grasp", None) is False
+
+
+def test_llm_planner_check_done_false_for_text_only_generator() -> None:
+    # FakeTextGenerator.generate has no image param -> can't verify -> False.
+    planner = LLMPlanner(FakeTextGenerator("YES"))
+    assert planner.check_done("grasp", np.zeros((8, 8, 3), dtype=np.uint8)) is False
+
+
+def test_llm_planner_satisfies_completion_detector() -> None:
+    assert isinstance(LLMPlanner(FakeVisionGenerator("YES")), CompletionDetector)

--- a/tests/unit/test_remote_planner.py
+++ b/tests/unit/test_remote_planner.py
@@ -124,6 +124,59 @@ def test_serve_decodes_image_and_passes_to_planner() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# serve() — completion-check requests (additive; legacy plan path untouched)
+# --------------------------------------------------------------------------- #
+
+
+def test_serve_completion_check_returns_done() -> None:
+    # Multimodal generator -> check_done runs; "YES" -> done True.
+    planner = LLMPlanner(_FakeVLMGen("YES"))
+    out = _run_serve(
+        planner,
+        [
+            {"check": {"instruction": "grasp the cube", "image": _tiny_png_b64()}},
+            {"shutdown": True},
+        ],
+    )
+    assert out[0] == {"ready": True}
+    assert out[1] == {"done": True}
+
+
+def test_serve_completion_check_returns_not_done() -> None:
+    planner = LLMPlanner(_FakeVLMGen("NO"))
+    out = _run_serve(
+        planner,
+        [
+            {"check": {"instruction": "grasp", "image": _tiny_png_b64()}},
+            {"shutdown": True},
+        ],
+    )
+    assert out[1] == {"done": False}
+
+
+def test_serve_check_unsupported_when_planner_lacks_check_done() -> None:
+    class _PlanOnly:
+        def plan(self, instruction: str, image: object = None) -> list[str]:
+            return ["a"]
+
+    out = _run_serve(  # type: ignore[arg-type]
+        _PlanOnly(),
+        [
+            {"check": {"instruction": "x", "image": _tiny_png_b64()}},
+            {"shutdown": True},
+        ],
+    )
+    assert any(m.get("error") == "check unsupported" for m in out)
+
+
+def test_serve_legacy_plan_still_works() -> None:
+    # Back-compat: an instruction request is unaffected by the new check branch.
+    planner = LLMPlanner(_FakeGen("1. a\n2. b\n"))
+    out = _run_serve(planner, [{"instruction": "task"}, {"shutdown": True}])
+    assert out[1] == {"plan": ["a", "b"]}
+
+
+# --------------------------------------------------------------------------- #
 # RemotePlanner — the client, against a fake server subprocess
 # --------------------------------------------------------------------------- #
 
@@ -158,6 +211,24 @@ sys.stdout.write(json.dumps({"ready": True}) + "\\n"); sys.stdout.flush()
 for line in sys.stdin:
     if line.strip():
         sys.stdout.write(json.dumps({"plan": []}) + "\\n"); sys.stdout.flush()
+"""
+
+# Answers completion checks: done iff the instruction contains "done".
+_FAKE_SERVER_CHECK = """
+import json, sys
+sys.stdout.write(json.dumps({"ready": True}) + "\\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    if req.get("shutdown"):
+        break
+    if isinstance(req.get("check"), dict):
+        instr = req["check"].get("instruction", "")
+        sys.stdout.write(json.dumps({"done": "done" in instr}) + "\\n"); sys.stdout.flush()
+        continue
+    sys.stdout.write(json.dumps({"plan": ["p0", "p1"]}) + "\\n"); sys.stdout.flush()
 """
 
 # Echoes whether the request carried an "image" field (a base64 string).
@@ -289,5 +360,50 @@ def test_remote_planner_satisfies_protocol(tmp_path: Path) -> None:
     planner = _planner_for(_FAKE_SERVER_OK, tmp_path)
     try:
         assert isinstance(planner, PlannerRuntime)
+    finally:
+        planner.close()
+
+
+def test_remote_planner_satisfies_completion_detector(tmp_path: Path) -> None:
+    from odyssey.runners.agents.runtime import CompletionDetector
+
+    planner = _planner_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        assert isinstance(planner, CompletionDetector)
+    finally:
+        planner.close()
+
+
+def test_remote_planner_check_done_roundtrip(tmp_path: Path) -> None:
+    import numpy as np
+
+    planner = _planner_for(_FAKE_SERVER_CHECK, tmp_path)
+    try:
+        img = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert planner.check_done("the task is done now", img) is True
+        assert planner.check_done("still working", img) is False
+    finally:
+        planner.close()
+
+
+def test_remote_planner_check_done_false_without_image(tmp_path: Path) -> None:
+    # image=None short-circuits to False without starting the subprocess.
+    planner = _planner_for(_FAKE_SERVER_CHECK, tmp_path)
+    try:
+        assert planner.check_done("done", None) is False
+        assert planner._proc is None  # never launched
+    finally:
+        planner.close()
+
+
+def test_remote_planner_check_done_false_against_old_server(tmp_path: Path) -> None:
+    # An old server that doesn't understand {"check": ...} replies with a plan;
+    # the client fails safe to False (no "done" key).
+    import numpy as np
+
+    planner = _planner_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        img = np.zeros((2, 2, 3), dtype=np.uint8)
+        assert planner.check_done("anything", img) is False
     finally:
         planner.close()


### PR DESCRIPTION
## Context

The multi-agent eval runtime advanced phases **open-loop**. The SPECIALIST (Gemma) decomposed the task into sub-instructions **once** per episode; `PlannedEvalRuntime` then switched sub-instructions **blindly** after a fixed step count (`FIXED_STEPS`, default 50) or a timeout, with **no perception feedback**. Failure mode: a grasp that takes longer than the window advances to "lift" with an empty gripper and nothing notices — a likely contributor to the LIBERO grasp-but-FAIL rollouts investigated in #46 / #61.

This PR adds the "**ask if the sub-task is finished before giving the next sub-order**" behavior.

## What this adds

A new **opt-in** `COMPLETION_GATED` phase strategy: every `phase_check_every` steps the runtime asks a VLM *"is this sub-instruction satisfied in the current frame? yes/no"* and advances **only on a confirmed yes**, with `phase_max_steps` as a safety cap so a phase never wedges.

Key design decision: the detector **reuses the already-loaded out-of-process Gemma SPECIALIST** (a new `check_done` capability over the same JSON-lines IPC) — no second model, **zero extra VRAM**. It is deliberately *not* the `cosmos_reason` path, which is coupled to GR00T's Cosmos-Reason2 backbone (wrong model for an OpenVLA pilot) and is a once-per-episode narrator, not a per-step detector.

**Core**
- `runners/agents/planned.py` — `PhaseStrategy.COMPLETION_GATED`; `PhaseConfig.{check_every, max_steps_per_phase}` + `from_config()`; current frame threaded into phase-advance; detector auto-discovery (via `hasattr(check_done)`); buffered phase-advance events + `drain_phase_events()` (the sync runtime can't `await` telemetry, so the async step loop drains + emits).
- `runners/agents/runtime.py` — `CompletionDetector` protocol.
- `runners/agents/planner.py` — `LLMPlanner.check_done()` with a strict yes/no prompt + conservative `_parse_yes_no()` (ambiguous → False, so a phase never advances on an unclear answer).
- `runners/agents/planner_server.py` / `remote_planner.py` — **additive** IPC: `{"check": {...}}` → `{"done": bool}`; short `check_timeout` (5s); fail-safe to `False`.
- `runners/evals/libero.py` / `robosuite.py` — `PhaseConfig.from_config(cfg)` + `phase_advance` telemetry (with `completion` / `cap` / `fixed_steps` reason) for Episode Review.

**Example**
- `examples/franka-libero/mission-multiagent.yaml` — documents and enables the opt-in config keys.

## Backward compatibility

- Default stays `FIXED_STEPS`; `COMPLETION_GATED` is opt-in via `phase_strategy` in the mission `config:`.
- `get_action(image)` public signature unchanged; **single-agent path untouched**.
- IPC is additive — legacy `{"instruction"}` / `{"shutdown"}` intact; an old server that doesn't understand `{"check"}` replies `{"error"}` → client returns `False` → gated mode degrades safely to cap-only.
- `drain_phase_events()` returns `[]` on non-gated / non-advancing steps (zero overhead).

## How to test

**Local (no GPU) — CI-covered:**
```bash
pip install -e ".[dev]"
ruff check src/ tests/
mypy
pytest tests/unit/test_agent_runtimes.py tests/unit/test_remote_planner.py tests/integration/test_multiagent_eval.py
```
New coverage: completion-gated advancement (poll cadence, cap fallback, no-detector fallback, frame/instruction passthrough), detector auto-discovery, `_parse_yes_no` table, `LLMPlanner.check_done`, the `{"check"}` IPC path + legacy back-compat, and the `drain_phase_events()` → `phase_advance` telemetry contract.

**Opt in from a mission** (config keys, all optional; omit for the old fixed-steps behavior):
```yaml
config:
  phase_strategy: completion_gated
  phase_check_every: 10   # poll the detector every N steps (keep >= 10: ~1-2s/check)
  phase_max_steps: 100    # safety cap; force-advance if never confirmed
```

**GPU VM (real, manual — deferred from #46):** run `examples/franka-libero/mission-multiagent.yaml` (with `ODYSSEY_SPECIALIST_PYTHON` set) on the L4 and confirm:
- `phase_advance` telemetry shows `completion`-reason transitions (not just `cap`),
- both models fit in VRAM (int4 planner + bf16 pilot — the detector reuses the loaded planner),
- `success_rate` on `libero_object` `task_0` is >= the fixed-steps baseline. This is the single-vs-multi comparison deferred from #46.

## Known trade-offs / follow-ups (v2)

- The `check_done` IPC round-trip is synchronous and blocks the async step loop ~1-2s per check (bounded by `phase_check_every` + the short `check_timeout`). v2: off-thread / awaitable check.
- Others deferred: mid-episode re-planning, detector debounce/voting, request-id IPC correlation, startup capability handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)