### PR TITLE
fix(gr00t): setup.sh py3.12 for the GR00T venv + survives read-only checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,25 +89,22 @@ cube-lift environment.
 
 **Prerequisites:**
 
-> **One-command setup** of the three eval environments (Odyssey core, GR00T
-> server, Isaac Lab) with uv: `bash examples/quickstart-gr00t/setup.sh`. See
-> [`examples/quickstart-gr00t/README.md`](examples/quickstart-gr00t/README.md) for
-> why they're separate venvs by design + the Isaac Sim provisioning. The manual
-> steps below are the step-by-step equivalent.
+> **Run `bash examples/quickstart-gr00t/setup.sh`** — it builds the three eval
+> venvs (Odyssey core, GR00T server, Isaac Lab client transport) with uv. See
+> [`examples/quickstart-gr00t/README.md`](examples/quickstart-gr00t/README.md)
+> for the full walkthrough and why they're separate venvs by design.
 
-1. Install the upstream Isaac-GR00T package — it carries the training entry
-   point (`gr00t.experiment.launch_finetune`) and the demo dataset. Accept
-   NVIDIA's weight license:
-   ```bash
-   git clone https://github.com/NVIDIA/Isaac-GR00T.git /srv/Isaac-GR00T
-   pip install -e /srv/Isaac-GR00T
-   export ISAAC_GR00T_REPO_PATH=/srv/Isaac-GR00T   # resolves the demo dataset
-   ```
-2. For the Isaac Lab evaluation, install Isaac Lab and point Odyssey at its
-   launcher:
-   ```bash
-   export ISAACLAB_PATH=/srv/IsaacLab              # provides isaaclab.sh
-   ```
+**Isaac Sim + Isaac Lab are a separate, heavy precondition** — a large NVIDIA
+Omniverse binary installed by NVIDIA's own tooling, **not** by `setup.sh` (the
+script wires the eval client into it, and skips with a note if it's absent).
+Provision them once following the
+[quickstart-gr00t README](examples/quickstart-gr00t/README.md), then point
+Odyssey at your checkouts:
+
+```bash
+export ISAAC_GR00T_REPO_PATH=/srv/Isaac-GR00T   # GR00T checkout + demo dataset
+export ISAACLAB_PATH=$HOME/IsaacLab             # provides isaaclab.sh
+```
 
 **Run:**
 

--- a/constraints/gr00t-server-known-good.txt
+++ b/constraints/gr00t-server-known-good.txt
@@ -5,14 +5,16 @@
 # GR00T_VENV_PYTHON. NEVER co-install these into the odyssey core env or the
 # Isaac env (torch/transformers/numpy ABIs all clash). See examples/quickstart-gr00t/README.md.
 #
-# Built (py3.10, CUDA 12.8, x86_64) by examples/quickstart-gr00t/setup.sh, equivalent to:
+# Built (py3.12, CUDA 12.8, x86_64) by examples/quickstart-gr00t/setup.sh, equivalent to:
 #   cd "$ISAAC_GR00T_DIR"
-#   uv venv --python 3.10 .venv
+#   uv venv --python 3.12 .venv
 #   uv pip install --python .venv/bin/python \
 #       --extra-index-url https://download.pytorch.org/whl/cu128 \
 #       -c constraints/gr00t-server-known-good.txt -e .
 #
-# Verified live on the team H100 VM (Isaac-GR00T/.venv).
+# Isaac-GR00T now requires py3.12 (requires-python ==3.12.*). The pins below were
+# resolved on py3.10 but every version here ships a cp312 wheel; re-verify live on
+# the eval VM and refresh this file from `uv pip freeze` if anything drifts.
 
 torch==2.7.1+cu128
 torchvision==0.22.1+cu128

--- a/constraints/gr00t-server-known-good.txt
+++ b/constraints/gr00t-server-known-good.txt
@@ -1,7 +1,7 @@
 # Known-good pins for the GR00T policy SERVER venv.
 #
 # This is a SEPARATE environment from odyssey core and from Isaac Lab — it hosts
-# the GR00T model (torch 2.7.1 + flash-attn) and is reached over ZMQ via
+# the GR00T model (torch 2.9.0 + flash-attn) and is reached over ZMQ via
 # GR00T_VENV_PYTHON. NEVER co-install these into the odyssey core env or the
 # Isaac env (torch/transformers/numpy ABIs all clash). See examples/quickstart-gr00t/README.md.
 #
@@ -10,30 +10,32 @@
 #   uv venv --python 3.12 .venv
 #   uv pip install --python .venv/bin/python \
 #       --extra-index-url https://download.pytorch.org/whl/cu128 \
+#       --index-strategy unsafe-best-match \
 #       -c constraints/gr00t-server-known-good.txt -e .
 #
-# Isaac-GR00T now requires py3.12 (requires-python ==3.12.*). The pins below were
-# resolved on py3.10 but every version here ships a cp312 wheel; re-verify live on
-# the eval VM and refresh this file from `uv pip freeze` if anything drifts.
+# --index-strategy unsafe-best-match is REQUIRED: the pytorch cu128 index carries a
+# stale `requests`, but gr00t's `datasets==3.6.0` needs a newer one from PyPI.
+#
+# Resolved live on py3.12 (Isaac-GR00T 0.1.0, torch 2.9.0+cu128) on the eval VM.
 
-torch==2.7.1+cu128
-torchvision==0.22.1+cu128
-torchcodec==0.4.0
+torch==2.9.0+cu128
+torchvision==0.24.0+cu128
+torchcodec==0.8.0+cu128
 transformers==4.57.3
-accelerate==1.13.0
+accelerate==1.14.0
 diffusers==0.35.1
 peft==0.17.1
 numpy==1.26.4
 albumentations==1.4.18
 opencv-python-headless==4.11.0.86
-pillow==12.2.0
+pillow==12.3.0
 einops==0.8.1
-safetensors==0.7.0
+safetensors==0.8.0
 pyzmq==27.0.1
 msgpack==1.1.0
 msgpack-numpy==0.4.8
 
-# flash-attn: CUDA-only compiled wheel, GPU/arch-specific. Install per
-# Isaac-GR00T's pyproject (cu128 x86_64; Blackwell needs the cu13 path) AFTER
-# torch is present — do not pin a wheel URL here cross-platform.
+# flash-attn: pinned by Isaac-GR00T's pyproject to a prebuilt cu12/torch2.9 cp312
+# wheel (v2.8.3), so it installs automatically with `-e` — no separate build step
+# on this stack. (Blackwell / other arches may need the cu13 wheel path.)
 # gr00t itself is installed editable from the checkout: `uv pip install -e $ISAAC_GR00T_DIR`.

--- a/examples/quickstart-gr00t/README.md
+++ b/examples/quickstart-gr00t/README.md
@@ -22,7 +22,7 @@ pins, and an interpreter selected by an env var.** We manage all of it with
 | Env | Interpreter (env var) | Python | Holds | Managed by |
 |---|---|---|---|---|
 | **Odyssey core** | `.venv` (this repo) | 3.10–3.12 | mission engine, CLI, training runner | `uv venv` + `.[dev,huggingface]` |
-| **GR00T server** | `GR00T_VENV_PYTHON` | 3.10 | GR00T model, `torch 2.7.1+cu128`, flash-attn | `uv venv` in `$ISAAC_GR00T_DIR`, `constraints/gr00t-server-known-good.txt` |
+| **GR00T server** | `GR00T_VENV_PYTHON` | 3.12 | GR00T model, `torch 2.7.1+cu128`, flash-attn | `uv venv` in `$ISAAC_GR00T_DIR`, `constraints/gr00t-server-known-good.txt` |
 | **Isaac Lab eval** | `ISAAC_PYTHON` | 3.11 | Isaac Sim 5.1.0, `isaaclab`, the GR00T **client** transport | Isaac's python + `constraints/isaac-eval-known-good.txt` (additive) |
 
 They talk over **ZMQ**: `IsaacLabRunner` (Odyssey core) spawns the eval recipe

--- a/examples/quickstart-gr00t/README.md
+++ b/examples/quickstart-gr00t/README.md
@@ -22,7 +22,7 @@ pins, and an interpreter selected by an env var.** We manage all of it with
 | Env | Interpreter (env var) | Python | Holds | Managed by |
 |---|---|---|---|---|
 | **Odyssey core** | `.venv` (this repo) | 3.10–3.12 | mission engine, CLI, training runner | `uv venv` + `.[dev,huggingface]` |
-| **GR00T server** | `GR00T_VENV_PYTHON` | 3.12 | GR00T model, `torch 2.7.1+cu128`, flash-attn | `uv venv` in `$ISAAC_GR00T_DIR`, `constraints/gr00t-server-known-good.txt` |
+| **GR00T server** | `GR00T_VENV_PYTHON` | 3.12 | GR00T model, `torch 2.9.0+cu128`, flash-attn | `uv venv` in `$ISAAC_GR00T_DIR`, `constraints/gr00t-server-known-good.txt` |
 | **Isaac Lab eval** | `ISAAC_PYTHON` | 3.11 | Isaac Sim 5.1.0, `isaaclab`, the GR00T **client** transport | Isaac's python + `constraints/isaac-eval-known-good.txt` (additive) |
 
 They talk over **ZMQ**: `IsaacLabRunner` (Odyssey core) spawns the eval recipe

--- a/examples/quickstart-gr00t/setup.sh
+++ b/examples/quickstart-gr00t/setup.sh
@@ -37,7 +37,7 @@ uv pip install --python "$ODYSSEY_VENV/bin/python" -e ".[dev,huggingface]"
 # GR00T server venv location — overridable; defaults inside the checkout.
 GR00T_VENV_DIR="${GR00T_VENV_DIR:-$ISAAC_GR00T_DIR/.venv}"
 
-echo "==> [2/4] GR00T policy-server venv (uv) — py3.12, torch 2.7.1+cu128, separate ABI"
+echo "==> [2/4] GR00T policy-server venv (uv) — py3.12, torch 2.9.0+cu128, separate ABI"
 if [ -d "$ISAAC_GR00T_DIR" ]; then
   # If the venv would land inside a non-writable checkout (e.g. a root-owned
   # /srv clone) and the caller didn't override GR00T_VENV_DIR, relocate it to a
@@ -49,10 +49,14 @@ if [ -d "$ISAAC_GR00T_DIR" ]; then
   # Isaac-GR00T's pyproject requires ==3.12.* (see requires-python); uv fetches a
   # managed CPython 3.12 if the host only has 3.10.
   uv venv --python 3.12 "$GR00T_VENV_DIR"
+  # --index-strategy unsafe-best-match: the pytorch cu128 index has a stale
+  # `requests`, but gr00t's datasets needs a newer one from PyPI — let uv pick
+  # the best across both indexes (torch still comes from the cu128 index).
   uv pip install --python "$GR00T_VENV_DIR/bin/python" \
       --extra-index-url https://download.pytorch.org/whl/cu128 \
+      --index-strategy unsafe-best-match \
       -c "$C/gr00t-server-known-good.txt" -e "$ISAAC_GR00T_DIR"
-  echo "    NOTE: install flash-attn (cu128 x86_64 wheel) per Isaac-GR00T's pyproject."
+  echo "    NOTE: flash-attn comes from Isaac-GR00T's pyproject (prebuilt cu12/torch2.9 wheel)."
   "$GR00T_VENV_DIR/bin/python" -c "import gr00t; print('    gr00t OK')" 2>/dev/null || echo "    (gr00t import deferred — finish flash-attn install)"
 else
   echo "    SKIP: \$ISAAC_GR00T_DIR ($ISAAC_GR00T_DIR) not found — clone NVIDIA/Isaac-GR00T first."

--- a/examples/quickstart-gr00t/setup.sh
+++ b/examples/quickstart-gr00t/setup.sh
@@ -12,7 +12,8 @@
 # pattern as constraints/{openvla,specialist}-known-good.txt). Idempotent.
 #
 # Usage:  bash examples/quickstart-gr00t/setup.sh
-# Overridable: ODYSSEY_DIR, ISAAC_GR00T_DIR, ISAACLAB_PATH, ISAAC_PYTHON, HF_HOME
+# Overridable: ODYSSEY_DIR, ODYSSEY_VENV, ISAAC_GR00T_DIR, GR00T_VENV_DIR,
+#              ISAACLAB_PATH, ISAAC_PYTHON, HF_HOME
 set -euo pipefail
 
 # This script lives at examples/quickstart-gr00t/setup.sh -> repo root is two up.
@@ -26,23 +27,39 @@ command -v uv >/dev/null || { echo "uv not found — install from https://docs.a
 
 echo "==> [1/4] Odyssey core env (uv)"
 cd "$ODYSSEY_DIR"
-uv venv --python 3.10 .venv
+# Odyssey core venv — overridable so a shared VM (e.g. one already running an
+# OpenVLA env in .venv) can build GR00T's core elsewhere without clobbering it:
+#   ODYSSEY_VENV=.venv-gr00t bash examples/quickstart-gr00t/setup.sh
+ODYSSEY_VENV="${ODYSSEY_VENV:-.venv}"
+uv venv --python 3.10 "$ODYSSEY_VENV"
 # huggingface extra: the GR00T training runner uses odyssey's HF provider.
-uv pip install --python .venv/bin/python -e ".[dev,huggingface]"
-GR00T_VENV_PYTHON="${GR00T_VENV_PYTHON:-$ISAAC_GR00T_DIR/.venv/bin/python}"
+uv pip install --python "$ODYSSEY_VENV/bin/python" -e ".[dev,huggingface]"
+# GR00T server venv location — overridable; defaults inside the checkout.
+GR00T_VENV_DIR="${GR00T_VENV_DIR:-$ISAAC_GR00T_DIR/.venv}"
 
-echo "==> [2/4] GR00T policy-server venv (uv) — torch 2.7.1+cu128, separate ABI"
+echo "==> [2/4] GR00T policy-server venv (uv) — py3.12, torch 2.7.1+cu128, separate ABI"
 if [ -d "$ISAAC_GR00T_DIR" ]; then
-  cd "$ISAAC_GR00T_DIR"
-  uv venv --python 3.10 .venv
-  uv pip install --python .venv/bin/python \
+  # If the venv would land inside a non-writable checkout (e.g. a root-owned
+  # /srv clone) and the caller didn't override GR00T_VENV_DIR, relocate it to a
+  # writable dir. The editable install still targets the checkout in place.
+  if [ "$GR00T_VENV_DIR" = "$ISAAC_GR00T_DIR/.venv" ] && [ ! -w "$ISAAC_GR00T_DIR" ]; then
+    GR00T_VENV_DIR="$HOME/gr00t-venv"
+    echo "    NOTE: $ISAAC_GR00T_DIR is not writable — placing the venv at $GR00T_VENV_DIR instead."
+  fi
+  # Isaac-GR00T's pyproject requires ==3.12.* (see requires-python); uv fetches a
+  # managed CPython 3.12 if the host only has 3.10.
+  uv venv --python 3.12 "$GR00T_VENV_DIR"
+  uv pip install --python "$GR00T_VENV_DIR/bin/python" \
       --extra-index-url https://download.pytorch.org/whl/cu128 \
-      -c "$C/gr00t-server-known-good.txt" -e .
+      -c "$C/gr00t-server-known-good.txt" -e "$ISAAC_GR00T_DIR"
   echo "    NOTE: install flash-attn (cu128 x86_64 wheel) per Isaac-GR00T's pyproject."
-  "$GR00T_VENV_PYTHON" -c "import gr00t; print('    gr00t OK')" 2>/dev/null || echo "    (gr00t import deferred — finish flash-attn install)"
+  "$GR00T_VENV_DIR/bin/python" -c "import gr00t; print('    gr00t OK')" 2>/dev/null || echo "    (gr00t import deferred — finish flash-attn install)"
 else
   echo "    SKIP: \$ISAAC_GR00T_DIR ($ISAAC_GR00T_DIR) not found — clone NVIDIA/Isaac-GR00T first."
 fi
+# Derive the interpreter path from the (possibly relocated) venv dir, unless the
+# caller pinned GR00T_VENV_PYTHON explicitly.
+GR00T_VENV_PYTHON="${GR00T_VENV_PYTHON:-$GR00T_VENV_DIR/bin/python}"
 
 echo "==> [3/4] Isaac Lab eval env (client transport into Isaac's python)"
 if [ -x "$ISAAC_PYTHON" ]; then


### PR DESCRIPTION
## Context

Following the GR00T quickstart on a GCP VM, `examples/quickstart-gr00t/setup.sh` failed at the GR00T policy-server venv step:

- Isaac-GR00T's `pyproject.toml` now requires `requires-python = ">=3.12,<3.13"`, but `setup.sh` created the GR00T venv with `--python 3.10` → uv warned about the interpreter mismatch and the editable install failed.
- On this VM the Isaac-GR00T checkout is a **root-owned `/srv` clone**, so `uv venv .venv` *inside* it also failed with `Permission denied`.

## What this changes (`examples/quickstart-gr00t/setup.sh`)

- **GR00T-server venv → Python 3.12** (uv fetches a managed CPython 3.12 if the host only has 3.10). The **odyssey-core** venv stays 3.10.
- **`ODYSSEY_VENV` override** (default `.venv`): a VM already running an OpenVLA env in `.venv` can build GR00T's core elsewhere (e.g. `.venv-gr00t`) without clobbering it.
- **`GR00T_VENV_DIR` override** + **auto-relocate**: when the checkout dir isn't writable (root-owned `/srv` clone), the venv is placed at `~/gr00t-venv` instead. The editable install still targets the checkout in place; `GR00T_VENV_PYTHON` is derived from the resolved dir (so `odyssey-eval-env.sh` stays correct).

## Docs

- `constraints/gr00t-server-known-good.txt` — header bumped to py3.12. The pins were resolved on 3.10 but every version ships a cp312 wheel; flagged to **re-verify live** on the eval VM and refresh from `uv pip freeze` if anything drifts.
- `examples/quickstart-gr00t/README.md` — env table row GR00T server `3.10` → `3.12`.

## Still to do (follow-up in this PR)

- Simplify the **root `README.md`** GR00T section to just point at `setup.sh` (the current manual `pip install -e /srv/Isaac-GR00T` block is broken — it's what triggered this).
- Re-verify the 3.12 pins on the VM and commit the regenerated `uv pip freeze` if they drift.

## How to test (on the VM)

```bash
cd ~/odyssey && git fetch origin && git checkout fix/gr00t-setup-python312
# core venv named so it won't touch an existing OpenVLA .venv
ODYSSEY_VENV=.venv-gr00t ISAAC_GR00T_DIR=/srv/Isaac-GR00T bash examples/quickstart-gr00t/setup.sh
```
Expect `[2/4]` to build the GR00T venv on py3.12 (relocated to `~/gr00t-venv` if `/srv` is read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)