### PR TITLE
[MA]feat(evals): delegation-driven multi-agent eval arm (grounding)

### DIFF
--- a/examples/franka-libero/README.md
+++ b/examples/franka-libero/README.md
@@ -13,10 +13,13 @@ HuggingFace, so you do **not** need a dataset on disk (the 10.2 GB
 | Mission | Agents | What it adds |
 |---|---|---|
 | `mission.yaml` | 1 — OpenVLA **pilot** | Baseline single-agent eval on the LIBERO `object` suite. |
-| `mission-multiagent.yaml` | 2 — pilot + Gemma **specialist** | Adds an out-of-process multimodal Gemma 4 planner that decomposes the instruction into phases (`PlannedEvalRuntime`). |
+| `mission-multiagent.yaml` | 2 — pilot + Gemma **specialist** | **Planner-driven.** An out-of-process multimodal Gemma 4 planner decomposes the instruction into phases the pilot executes (`PlannedEvalRuntime`, `coordination: planning`). |
+| `mission-multiagent-delegation.yaml` | 2 — pilot + Gemma **specialist** | **Delegation-driven.** A deterministic orchestrator delegates per-phase target *grounding* to the specialist and hands control back on completion (`DelegatedEvalRuntime`, `coordination: delegation`). |
 
-> Both are eval-only — the multi-agent one is **not** a training mission, it just
-> adds a planner. See the top of each YAML for the config knobs.
+> All three are eval-only — the multi-agent ones are **not** training missions,
+> they just add a specialist. See the top of each YAML for the config knobs, and
+> [Planner vs delegation](#planner-vs-delegation-two-multi-agent-arms) below for
+> what actually differs between the two multi-agent arms.
 
 > **No `task_instruction` — that's intentional.** LIBERO is a *language-conditioned*
 > benchmark: every task in a suite ships its own natural-language instruction (keyed
@@ -78,9 +81,14 @@ export MUJOCO_GL=osmesa PYOPENGL_PLATFORM=osmesa
 odyssey validate examples/franka-libero/mission.yaml
 odyssey run      examples/franka-libero/mission.yaml
 
-# multi-agent (Gemma planner) — load the specialist venv first
-source examples/multiagent-openvla-gemma/.env       # sets ODYSSEY_SPECIALIST_PYTHON
+# multi-agent — load the specialist venv first (sets ODYSSEY_SPECIALIST_PYTHON)
+source examples/multiagent-openvla-gemma/.env
+
+# planner-driven arm: specialist authors the plan, pilot executes it
 odyssey run examples/franka-libero/mission-multiagent.yaml
+
+# delegation-driven arm: orchestrator delegates grounding to the specialist
+odyssey run examples/franka-libero/mission-multiagent-delegation.yaml
 
 # per-episode videos
 find ~/.odyssey/runs -path "*/videos/*.mp4" -exec ls -lh {} \;
@@ -96,6 +104,54 @@ Change `benchmark_name`, `config.checkpoint`, and `config.unnorm_key` **together
 | `libero_spatial` | `openvla/openvla-7b-finetuned-libero-spatial` | `libero_spatial` |
 | `libero_goal`    | `openvla/openvla-7b-finetuned-libero-goal`    | `libero_goal`    |
 | `libero_10`      | `openvla/openvla-7b-finetuned-libero-10`      | `libero_10`      |
+
+---
+
+## Planner vs delegation (two multi-agent arms)
+
+Both multi-agent missions pair the same OpenVLA **pilot** with the same Gemma 4
+**specialist** and share the same completion check — the *only* difference is the
+specialist's **role**, selected by the `coordination` key in the task `config:`.
+This is the "planner vs delegation" comparison: run both on identical suites and
+compare `success_rate`, wasted steps, and time-to-completion.
+
+| | Planner-driven (`coordination: planning`) | Delegation-driven (`coordination: delegation`) |
+|---|---|---|
+| Who owns the sequence | The **specialist** — it authors the full plan once per episode | The **orchestrator** — a generic `pick → place` skill template |
+| Specialist's job | `plan()`: decompose the task into ordered sub-instructions | `ground()`: locate the current phase's target in the scene, on demand |
+| Phase transition | Pilot marches the fixed plan; advance on completion check / step cap | Orchestrator hands control back when the specialist confirms the sub-task is done |
+| Runtime | `PlannedEvalRuntime` | `DelegatedEvalRuntime` |
+| Mission | `mission-multiagent.yaml` | `mission-multiagent-delegation.yaml` |
+
+**How delegation works per phase:** the orchestrator asks the specialist *"where
+is the object to pick up in this scene?"* (`ground`), splices the returned phrase
+into the pilot's instruction (e.g. `pick up the red mug on the left`), lets the
+pilot act, and every `phase_check_every` steps asks *"is this sub-task done?"*
+(`check_done`) — advancing to `place` only on a confirmed yes, with
+`phase_max_steps` as a safety cap. The specialist **authors no plan**; it is an
+on-demand perception tool.
+
+**Zero extra VRAM either way:** the one loaded Gemma answers `plan`, `check_done`
+*and* `ground` from the same out-of-process server. Grounding/check calls add
+~1–2 s each, so keep `phase_check_every >= 10`.
+
+**Reading the telemetry:** both arms emit `phase_advance` progress events. In the
+delegation arm each event carries a `capability` (`grounding` when a new target
+is grounded, `handback` when a phase completes) and a `reason` (`grounding` /
+`completion` / `cap`). A healthy delegation run shows `completion` hand-backs, not
+just `cap` ones — `cap`-only means the completion check never fired (check the
+specialist server logs).
+
+```bash
+# same suite, both arms — compare the reported success_rate
+odyssey run examples/franka-libero/mission-multiagent.yaml             # planning
+odyssey run examples/franka-libero/mission-multiagent-delegation.yaml  # delegation
+```
+
+> Scope: the delegation orchestrator's routing is a fixed `pick → place` template
+> and completion-gated hand-back — a deliberate skeleton. Capability advertising /
+> an LLM router that *chooses* which agent to invoke (full delegation-driven
+> regime) is not yet wired.
 
 ---
 

--- a/examples/franka-libero/mission-multiagent-delegation.yaml
+++ b/examples/franka-libero/mission-multiagent-delegation.yaml
@@ -1,0 +1,84 @@
+# LIBERO eval (MULTI-AGENT, DELEGATION-DRIVEN, EVAL-ONLY):
+#   OpenVLA-LIBERO pilot + Gemma 4 SPECIALIST as an on-demand grounding tool.
+#
+# The delegation counterpart to mission-multiagent.yaml. There, the SPECIALIST is
+# the *planner*: it authors the full task decomposition up front and the pilot
+# marches through that fixed list (PlannedEvalRuntime, coordination: planning).
+#
+# HERE, no agent owns the sequence. A deterministic orchestrator runs a generic
+# pick -> place skill template and, per phase, DELEGATES target grounding to the
+# SPECIALIST ("where is the object to pick up in this scene?"); the returned
+# scene-grounded phrase conditions the pilot's instruction. The phase HANDS
+# CONTROL BACK when the SPECIALIST confirms the sub-task is done (reusing the same
+# completion check as the planner arm). The SPECIALIST authors no plan — it is a
+# perception tool the orchestrator invokes (the open-weight analogue of GR-ER's
+# spatial grounding). This is the "delegation" arm of the planner-vs-delegation
+# comparison; run it against mission-multiagent.yaml on identical tasks/metrics.
+#
+# Prereqs (two venvs): identical to mission-multiagent.yaml —
+#   examples/multiagent-openvla-gemma/setup.sh
+#   source examples/multiagent-openvla-gemma/.env   # sets ODYSSEY_SPECIALIST_PYTHON
+# Plus the `libero` package in env_pilot (examples/franka-libero/setup.sh).
+# Hardware: 24 GB GPU — int4 E2B-it SPECIALIST (~5 GB) + ~14 GB bf16 pilot ≈ 19 GB
+# peak (grounding + completion checks reuse the one loaded Gemma; no extra VRAM).
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: franka-libero-object-multiagent-delegation
+  description: Eval-only delegation-driven — OpenVLA LIBERO-object pilot + Gemma 4 grounding SPECIALIST on the LIBERO object suite.
+  tags: [openvla, gemma, multiagent, delegation, libero, franka, eval-only]
+
+objective: |
+  Evaluate the published OpenVLA-7B LIBERO-object checkpoint under a
+  delegation-driven orchestrator that delegates per-phase target grounding to an
+  out-of-process multimodal Gemma 4 SPECIALIST, on the LIBERO object suite.
+
+acceptance_criteria: |
+  Non-trivial success_rate across the evaluation episodes, with phase_advance
+  telemetry showing per-phase grounding delegations and completion-driven
+  hand-backs (not just cap hand-backs).
+
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: openvla/openvla-7b-finetuned-libero-object
+
+    - id: specialist
+      role: SPECIALIST
+      model:
+        source: huggingface
+        # Vision-language SPECIALIST, runs out-of-process in env_specialist. Gemma
+        # 4 E2B-it is multimodal and ungated; here it is invoked as a grounding
+        # tool (and completion detector), not as a planner.
+        base: google/gemma-4-E2B-it
+        quantization: int4
+        modality: multimodal
+
+tasks:
+  - name: eval-libero-object-delegation
+    kind: evaluation
+    evaluation_type: libero
+    description: Pick-and-place of the task_id=0 object into the basket (LIBERO object suite).
+    benchmark_name: libero_object
+    num_episodes: 10
+    config:
+      checkpoint: openvla/openvla-7b-finetuned-libero-object   # HF repo id (eval-only)
+      unnorm_key: libero_object
+      task_id: 0
+      capture_video: true
+      # Select the delegation-driven arm. Default is `planning` (PlannedEvalRuntime,
+      # the SPECIALIST authors the plan). `delegation` runs the orchestrator that
+      # delegates grounding per phase and hands back on completion.
+      coordination: delegation
+      # Hand-back cadence (shared with the planner arm's completion gating): every
+      # phase_check_every steps the SPECIALIST is asked "is this sub-task done?" and
+      # the phase hands back only on yes; phase_max_steps is the safety cap. Each
+      # check/grounding call adds ~1-2s, so keep the cadence >= 10.
+      phase_check_every: 10
+      phase_max_steps: 100

--- a/src/odyssey/runners/agents/delegated.py
+++ b/src/odyssey/runners/agents/delegated.py
@@ -1,0 +1,330 @@
+"""DelegatedEvalRuntime — delegation-driven multi-agent eval orchestrator.
+
+The *delegation* counterpart to ``PlannedEvalRuntime``. Where the planner-driven
+runtime has the SPECIALIST author the full task decomposition up front and the
+PILOT march through that fixed list, here **no agent owns the sequence**:
+
+  * The **orchestrator** holds a generic, task-agnostic manipulation template
+    (default pick -> place — an embodiment-level skill skeleton, *not* a
+    task-specific plan).
+  * For each phase it **delegates grounding** to the SPECIALIST — "where is the
+    object to pick up in *this* scene?" — turning a generic query into a
+    scene-grounded phrase that conditions the PILOT's instruction.
+  * It then **delegates execution** to the PILOT, and the phase **hands control
+    back** when the SPECIALIST's completion detector confirms the sub-task is
+    done (semantic hand-back), with a step cap as a safety net.
+
+The distinction from ``PlannedEvalRuntime`` is the SPECIALIST's *role*: there it
+is the sequence author (``plan``); here it is an on-demand perception tool
+(``ground``) that never decomposes the task. Everything else — the model, the
+PILOT, the completion detector, the environments, the metrics — is held equal,
+so the two runtimes isolate exactly that variable.
+
+Scope (v0.1 skeleton): the orchestrator's routing is a fixed template and its
+hand-back is completion-gated. Capability advertising / A2A-style task lifecycle
+/ an LLM router that *chooses* which capability to invoke are deferred (that is
+the full delegation-driven regime). See ``PlannedEvalRuntime`` for the
+planner-driven arm this is compared against.
+
+Public surface mirrors ``PlannedEvalRuntime`` (``begin_episode`` / ``get_action``
+/ ``drain_phase_events`` / ``close`` + the phase properties) so the eval runners
+drive both runtimes through one code path.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from odyssey.runners.agents.runtime import (
+    CompletionDetector,
+    GroundingProvider,
+    PilotRuntime,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DelegationSkill:
+    """One phase of the orchestrator's generic manipulation template.
+
+    ``target_query`` is what the orchestrator delegates to the grounder (it may
+    reference ``{task}``); the returned phrase is spliced into ``instruction``
+    via ``{target}`` to produce the PILOT's grounded sub-instruction.
+    """
+
+    name: str
+    target_query: str
+    instruction: str
+
+
+# Default template: the canonical pick-and-place skeleton. Task-agnostic — the
+# scene-specific intelligence comes entirely from the delegated grounding, not
+# from this list. Override via ``DelegationConfig.from_config`` (skills key) for
+# other manipulation shapes.
+PICK_PLACE_TEMPLATE: tuple[DelegationSkill, ...] = (
+    DelegationSkill(
+        name="pick",
+        target_query="the object that must be picked up to accomplish the task: {task}",
+        instruction="pick up {target}",
+    ),
+    DelegationSkill(
+        name="place",
+        target_query=(
+            "the location or container where the held object must be placed "
+            "to accomplish the task: {task}"
+        ),
+        instruction="place it at {target}",
+    ),
+)
+
+
+@dataclass
+class DelegationConfig:
+    """Configuration for the delegation-driven orchestrator.
+
+    Parameters
+    ----------
+    skills:
+        The manipulation template (ordered phases). Defaults to pick -> place.
+    check_every:
+        Poll the completion detector every N steps for hand-back (never every
+        step — a VLM round-trip costs ~1-2s).
+    max_steps_per_phase:
+        Safety cap: force a hand-back after this many steps so a phase never
+        wedges if the detector never confirms (or is unavailable).
+    """
+
+    skills: tuple[DelegationSkill, ...] = PICK_PLACE_TEMPLATE
+    check_every: int = 10
+    max_steps_per_phase: int = 100
+
+    @classmethod
+    def from_config(cls, cfg: dict[str, Any]) -> DelegationConfig:
+        """Build a DelegationConfig from a mission ``config:`` dict (opt-in).
+
+        Recognised keys: ``phase_check_every``, ``phase_max_steps`` (shared with
+        the planner arm for parity). The template is the default pick -> place;
+        a custom template is not yet mission-configurable (skeleton scope).
+        """
+        return cls(
+            check_every=int(cfg.get("phase_check_every", 10)),
+            max_steps_per_phase=int(cfg.get("phase_max_steps", 100)),
+        )
+
+
+@dataclass
+class _DelegationState:
+    """Mutable per-episode orchestrator state."""
+
+    task: str = ""
+    skill_index: int = 0
+    # The current PILOT instruction (grounded). None means the next phase still
+    # needs grounding — the orchestrator delegates it lazily on the next step,
+    # using the frame it is about to act on.
+    pilot_instruction: str | None = None
+    steps_in_phase: int = 0
+
+
+class DelegatedEvalRuntime:
+    """Delegation-driven multi-agent eval runtime (orchestrator + PILOT + SPECIALIST).
+
+    Parameters
+    ----------
+    pilot:
+        A ``PilotRuntime`` (e.g. ``VLARuntime``) for action generation.
+    grounder:
+        A ``GroundingProvider`` (e.g. the out-of-process ``RemotePlanner``) the
+        orchestrator delegates per-phase target grounding to.
+    config:
+        Template + hand-back cadence/cap. Defaults to pick -> place.
+    detector:
+        Optional ``CompletionDetector`` for semantic hand-back. If omitted, the
+        grounder is auto-adopted when it exposes ``check_done`` (the SPECIALIST
+        answers both from the same loaded model — zero extra VRAM). Without a
+        detector, phases hand back only at the step cap.
+    task_fallback:
+        Instruction used if grounding yields nothing and no task is set.
+    """
+
+    def __init__(
+        self,
+        pilot: PilotRuntime,
+        grounder: GroundingProvider,
+        *,
+        config: DelegationConfig | None = None,
+        detector: CompletionDetector | None = None,
+        task_fallback: str = "complete the task",
+    ) -> None:
+        self._pilot = pilot
+        self._grounder = grounder
+        self._config = config or DelegationConfig()
+        # Reuse the grounder as the completion detector when it can answer a
+        # yes/no check (the SPECIALIST does both). hasattr keeps a grounder that
+        # lacks the method valid — hand-back then falls back to the step cap.
+        if detector is None and hasattr(grounder, "check_done"):
+            detector = grounder  # type: ignore[assignment]
+        self._detector = detector
+        self._fallback = task_fallback
+        self._state = _DelegationState()
+        # Buffered (from, to, instruction, reason, capability) records. get_action
+        # is sync but telemetry is async, so the async step loop drains these.
+        self._pending_events: list[dict[str, Any]] = []
+
+    @property
+    def current_phase_index(self) -> int:
+        return self._state.skill_index
+
+    @property
+    def total_phases(self) -> int:
+        return len(self._config.skills)
+
+    @property
+    def current_instruction(self) -> str:
+        return self._state.pilot_instruction or ""
+
+    @property
+    def _is_complete(self) -> bool:
+        return self._state.skill_index >= len(self._config.skills)
+
+    def begin_episode(
+        self, task_instruction: str, image: Any | None = None
+    ) -> list[str]:
+        """Call at the start of each episode. Returns the phase labels.
+
+        Unlike the planner arm, there is no plan to compute here: grounding is
+        delegated lazily on the first step of each phase (using the frame the
+        PILOT is about to act on). The returned list is the template's phase
+        names, purely for telemetry/logging parity with ``PlannedEvalRuntime``.
+        ``image`` is accepted for signature parity and currently unused.
+        """
+        self._state = _DelegationState(task=task_instruction)
+        self._pending_events = []
+        labels = [s.name for s in self._config.skills]
+        logger.info(
+            "DelegatedEvalRuntime: episode with %d delegated phase(s): %s",
+            len(labels),
+            labels,
+        )
+        if self._detector is None:
+            logger.warning(
+                "No completion detector available; delegated phases will only "
+                "hand back at the max_steps_per_phase cap (%d).",
+                self._config.max_steps_per_phase,
+            )
+        return labels
+
+    def get_action(self, image: Any) -> NDArray[np.floating[Any]]:
+        """Delegate grounding (if needed), then delegate execution to the PILOT.
+
+        Handles semantic hand-back between phases based on the completion
+        detector, with the step cap as a safety net.
+        """
+        if self._is_complete:
+            # All phases handed back: hold the last grounded instruction.
+            instruction = self._state.pilot_instruction or self._state.task or self._fallback
+            return self._pilot.act(image, instruction)
+
+        if self._state.pilot_instruction is None:
+            self._delegate_grounding(image)
+
+        assert self._state.pilot_instruction is not None
+        action = self._pilot.act(image, self._state.pilot_instruction)
+        self._state.steps_in_phase += 1
+        self._maybe_hand_back(image)
+        return action
+
+    def _delegate_grounding(self, image: Any) -> None:
+        """Delegate target grounding for the current phase to the SPECIALIST."""
+        skill = self._config.skills[self._state.skill_index]
+        query = skill.target_query.format(task=self._state.task)
+        try:
+            target = self._grounder.ground(query, image)
+        except Exception as e:  # grounder is fail-safe, but never let it crash the loop
+            logger.warning("grounding delegation failed (%s) — using query", e)
+            target = query
+        target = (target or "").strip() or self._state.task or self._fallback
+        self._state.pilot_instruction = skill.instruction.format(target=target)
+        logger.debug(
+            "Delegated grounding for phase %d (%s): %r -> %r",
+            self._state.skill_index,
+            skill.name,
+            query,
+            self._state.pilot_instruction,
+        )
+        self._pending_events.append(
+            {
+                "from": self._state.skill_index,
+                "to": self._state.skill_index,
+                "instruction": self._state.pilot_instruction,
+                "reason": "grounding",
+                "capability": "grounding",
+                "skill": skill.name,
+            }
+        )
+
+    def _maybe_hand_back(self, image: Any) -> None:
+        cfg = self._config
+        hand_back = False
+        reason = ""
+
+        n = self._state.steps_in_phase
+        # Cap first: a stuck phase always hands back, even without a detector.
+        if n >= cfg.max_steps_per_phase:
+            hand_back, reason = True, "cap"
+        elif (
+            self._detector is not None
+            and self._state.pilot_instruction is not None
+            and n > 0
+            and n % cfg.check_every == 0
+            and self._detector.check_done(self._state.pilot_instruction, image)
+        ):
+            hand_back, reason = True, "completion"
+
+        if not hand_back:
+            return
+
+        old_idx = self._state.skill_index
+        old_instruction = self._state.pilot_instruction
+        self._state.skill_index += 1
+        self._state.steps_in_phase = 0
+        # Next phase re-grounds lazily on its first step.
+        self._state.pilot_instruction = None
+        self._pending_events.append(
+            {
+                "from": old_idx,
+                "to": self._state.skill_index,
+                "instruction": old_instruction,
+                "reason": reason,
+                "capability": "handback",
+            }
+        )
+        logger.debug(
+            "Phase %d -> %d hand-back (%s)", old_idx, self._state.skill_index, reason
+        )
+
+    def drain_phase_events(self) -> list[dict[str, Any]]:
+        """Return and clear buffered delegation/hand-back records.
+
+        Each record is ``{"from", "to", "instruction", "reason", "capability"}``
+        where reason is ``grounding`` (a new target was delegated) |
+        ``completion`` (semantic hand-back) | ``cap`` (safety-cap hand-back).
+        Empty (zero overhead) on non-eventful steps. Mirrors
+        ``PlannedEvalRuntime.drain_phase_events`` so the async step loop drains
+        both runtimes identically.
+        """
+        events = self._pending_events
+        self._pending_events = []
+        return events
+
+    def close(self) -> None:
+        """Release runtime resources. Closes the grounder if it owns any (e.g.
+        an out-of-process ``RemotePlanner`` subprocess). Safe to call twice."""
+        closer = getattr(self._grounder, "close", None)
+        if callable(closer):
+            closer()

--- a/src/odyssey/runners/agents/planner.py
+++ b/src/odyssey/runners/agents/planner.py
@@ -47,6 +47,16 @@ _COMPLETION_PROMPT = (
     "explain."
 )
 
+_GROUNDING_PROMPT = (
+    "You are a robot perception module. You are given the current scene image "
+    "and a description of a target the robot must act on. Look at the image and "
+    "identify the single concrete object or location that best matches the "
+    "description. Answer with a SHORT noun phrase naming it and, if helpful, its "
+    "distinguishing visual feature or position (e.g. 'the red mug on the left', "
+    "'the top drawer', 'the black bowl'). Output ONLY that phrase — no full "
+    "sentence, no explanation, no quotes."
+)
+
 _NUMBERED_LINE = re.compile(r"^\s*\d+[\.\)]\s*(.+)$")
 
 
@@ -71,6 +81,22 @@ def _parse_yes_no(text: str) -> bool:
     """
     m = re.search(r"[a-zA-Z]+", text or "")
     return m is not None and m.group(0).lower() in ("yes", "y")
+
+
+def _parse_grounding(text: str) -> str:
+    """Extract a single grounded phrase from the VLM output.
+
+    Takes the first non-empty line and strips surrounding markdown/quotes/
+    trailing punctuation, keeping a compact noun phrase. Returns "" when the
+    output has nothing usable, so ``ground`` can fall back to the raw query.
+    """
+    for line in (text or "").strip().splitlines():
+        # Drop a leading list marker ("- ", "1. ") the model may add.
+        cleaned = re.sub(r"^\s*(?:[-*]|\d+[.)])\s*", "", line).strip()
+        cleaned = cleaned.strip("\"'`*.").strip()
+        if cleaned:
+            return cleaned
+    return ""
 
 
 class LLMPlanner:
@@ -140,3 +166,25 @@ class LLMPlanner:
         text = self._generator.generate(messages, image=image)  # type: ignore[call-arg]
         logger.debug("check_done(%r) raw output: %r", instruction, text)
         return _parse_yes_no(text)
+
+    def ground(self, target_query: str, image: Any) -> str:
+        """Return a scene-grounded phrase for ``target_query`` in ``image``.
+
+        Satisfies ``GroundingProvider``. Requires a multimodal generator and a
+        frame; without either, grounding is impossible, so it returns
+        ``target_query`` unchanged (fail-safe — the pilot still gets an
+        actionable instruction, it just isn't scene-specialised).
+        """
+        if not self._accepts_image or image is None:
+            logger.debug(
+                "ground unavailable (accepts_image=%s, image=%s) — echoing query",
+                self._accepts_image,
+                image is not None,
+            )
+            return target_query
+        messages = [
+            {"role": "user", "content": f"{_GROUNDING_PROMPT}\n\nTarget: {target_query}"},
+        ]
+        text = self._generator.generate(messages, image=image)  # type: ignore[call-arg]
+        logger.debug("ground(%r) raw output: %r", target_query, text)
+        return _parse_grounding(text) or target_query

--- a/src/odyssey/runners/agents/planner_server.py
+++ b/src/odyssey/runners/agents/planner_server.py
@@ -11,6 +11,8 @@ then answers planning requests over a JSON-lines stdin/stdout protocol:
     <- {"plan": ["...", "..."]}              (one response per line, on stdout)
     -> {"check": {"instruction": "...", "image": "<base64 PNG>"}}  (completion check)
     <- {"done": true|false}                  (is the sub-instruction satisfied?)
+    -> {"ground": {"query": "...", "image": "<base64 PNG>"}}  (target grounding)
+    <- {"target": "..."}                     (scene-grounded phrase for the query)
     <- {"error": "..."}                      (on failure; the client falls back)
     -> {"shutdown": true}                    (client asks the server to exit)
 
@@ -98,6 +100,25 @@ def serve(
                 _emit(outstream, {"done": bool(checker(check_instruction, check_image))})
             except BaseException as e:
                 _emit(outstream, {"error": f"check failed: {type(e).__name__}: {e}"})
+            continue
+        grounding = req.get("ground")
+        if isinstance(grounding, dict):
+            try:
+                query = grounding.get("query")
+                if not isinstance(query, str):
+                    _emit(outstream, {"error": "ground missing 'query' string"})
+                    continue
+                grounder = getattr(planner, "ground", None)
+                if not callable(grounder):
+                    _emit(outstream, {"error": "ground unsupported"})
+                    continue
+                ground_image = None
+                raw_ground_image = grounding.get("image")
+                if isinstance(raw_ground_image, str):
+                    ground_image = _decode_image(raw_ground_image)
+                _emit(outstream, {"target": str(grounder(query, ground_image))})
+            except BaseException as e:
+                _emit(outstream, {"error": f"ground failed: {type(e).__name__}: {e}"})
             continue
         instruction = req.get("instruction")
         if not isinstance(instruction, str):

--- a/src/odyssey/runners/agents/remote_planner.py
+++ b/src/odyssey/runners/agents/remote_planner.py
@@ -92,6 +92,11 @@ class RemotePlanner:
         Seconds to wait for a single completion-check response. Short by design
         (the check runs on the per-step loop, every K steps): a hung check
         falls back to ``False`` rather than freezing the episode.
+    ground_timeout:
+        Seconds to wait for a single grounding response. Grounding runs only at
+        phase boundaries (not every step), so it can afford a longer budget than
+        the completion check; a hung grounding call falls back to echoing the
+        query rather than freezing the episode.
     launch_args:
         Argv (after ``python_path``) that starts the server. Defaults to
         ``("-m", planner_server)``; overridable for tests.
@@ -106,6 +111,7 @@ class RemotePlanner:
         startup_timeout: float = 600.0,
         request_timeout: float = 120.0,
         check_timeout: float = 5.0,
+        ground_timeout: float = 15.0,
         launch_args: Sequence[str] = ("-m", _SERVER_MODULE),
     ) -> None:
         self._model_base = model_base
@@ -114,6 +120,7 @@ class RemotePlanner:
         self._startup_timeout = startup_timeout
         self._request_timeout = request_timeout
         self._check_timeout = check_timeout
+        self._ground_timeout = ground_timeout
         self._launch_args = list(launch_args)
         self._proc: subprocess.Popen[str] | None = None
         # A background thread drains stdout into this queue. We avoid
@@ -254,6 +261,42 @@ class RemotePlanner:
                 instruction,
             )
             return False
+
+    def ground(self, target_query: str, image: Any) -> str:
+        """Ask the out-of-process SPECIALIST to ground ``target_query`` in ``image``.
+
+        Satisfies ``GroundingProvider``. Reuses the same loaded model as ``plan``
+        over the same channel. Runs only at phase boundaries (not every step),
+        so it uses the moderate ``ground_timeout``. Fails safe: any error,
+        timeout, missing frame, or a server that doesn't support grounding
+        (``{"error": ...}``) returns ``target_query`` unchanged — the pilot
+        always receives an actionable instruction.
+        """
+        if image is None:
+            return target_query
+        try:
+            self._ensure_started()
+            proc = self._proc
+            assert proc is not None and proc.stdin is not None
+            request = {"ground": {"query": target_query, "image": _encode_image(image)}}
+            proc.stdin.write(json.dumps(request) + "\n")
+            proc.stdin.flush()
+            msg = self._read_message(self._ground_timeout)
+            target = (msg or {}).get("target")
+            if isinstance(target, str) and target.strip():
+                return target.strip()
+            logger.warning(
+                "RemotePlanner: bad/empty grounding %r for %r — echoing query",
+                msg,
+                target_query,
+            )
+        except Exception as e:
+            logger.warning(
+                "RemotePlanner.ground failed (%s) for %r — echoing query",
+                e,
+                target_query,
+            )
+        return target_query
 
     def close(self) -> None:
         """Shut down the server process. Idempotent; also runs at exit."""

--- a/src/odyssey/runners/agents/runtime.py
+++ b/src/odyssey/runners/agents/runtime.py
@@ -122,3 +122,40 @@ class CompletionDetector(Protocol):
         step cap still guarantees forward progress).
         """
         ...
+
+
+@runtime_checkable
+class GroundingProvider(Protocol):
+    """Locates the scene target a delegated sub-task should act on.
+
+    This is the delegated capability in the *delegation-driven* runtime
+    (``DelegatedEvalRuntime``). Unlike ``PlannerRuntime`` — which authors the
+    whole task decomposition up front — a grounder owns no sequence: the
+    orchestrator invokes it on demand, once per phase, to turn a generic query
+    ("the object to pick up") into a scene-grounded phrase ("the red mug on the
+    left") that conditions the pilot's instruction. It is the open-weight
+    analogue of GR-ER's 2D pointing / spatial grounding.
+
+    The out-of-process SPECIALIST satisfies this alongside ``PlannerRuntime``
+    and ``CompletionDetector`` from the same loaded model — no extra VRAM.
+    """
+
+    def ground(self, target_query: str, image: Any) -> str:
+        """Return a scene-grounded phrase for ``target_query`` in ``image``.
+
+        Parameters
+        ----------
+        target_query:
+            A generic description of what to locate (e.g. "the object that must
+            be picked up").
+        image:
+            RGB frame (PIL Image or HWC uint8 ndarray) of the current scene.
+
+        Returns
+        -------
+        A short natural-language phrase naming the located target, suitable for
+        splicing into a pilot instruction. Must fail safe: return the query
+        unchanged (never empty) when uncertain or on any error, so the pilot
+        always receives an actionable instruction.
+        """
+        ...

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -245,11 +245,22 @@ class LiberoRunner(Runner):
         # Single-agent (OpenVLA policy) vs multi-agent (PlannedEvalRuntime + Gemma).
         use_planned = _has_specialist(context)
         if use_planned:
-            runtime = _build_planned_runtime(context, checkpoint, cfg, instruction)
+            coordination = str(cfg.get("coordination", "planning")).lower()
+            if coordination == "delegation":
+                runtime = _build_delegated_runtime(context, checkpoint, cfg, instruction)
+                step_label = "DelegatedEvalRuntime (PILOT + SPECIALIST)"
+            elif coordination == "planning":
+                runtime = _build_planned_runtime(context, checkpoint, cfg, instruction)
+                step_label = "PlannedEvalRuntime (PILOT + SPECIALIST)"
+            else:
+                raise ValueError(
+                    f"unknown coordination {coordination!r}; "
+                    "allowed: planning, delegation"
+                )
             await context.emit_progress(
                 "model_loading",
                 step="load_specialist",
-                step_label="PlannedEvalRuntime (PILOT + SPECIALIST)",
+                step_label=step_label,
             )
             policy = None
         else:
@@ -413,14 +424,15 @@ def _find_specialist_model(context: TaskContext) -> tuple[str, str | None]:
     raise ValueError("No SPECIALIST agent found in the loadout")
 
 
-def _build_planned_runtime(
-    context: TaskContext,
-    checkpoint: Path,
-    cfg: dict[str, Any],
-    instruction: str,
-) -> Any:
-    """Compose the PILOT (OpenVLA) + out-of-process SPECIALIST (Gemma) planner."""
-    from odyssey.runners.agents.planned import PhaseConfig, PlannedEvalRuntime
+def _build_pilot_and_specialist(
+    context: TaskContext, checkpoint: Path, cfg: dict[str, Any]
+) -> tuple[Any, Any]:
+    """Build the PILOT (OpenVLA) + out-of-process SPECIALIST (Gemma).
+
+    Shared by the planner-driven and delegation-driven builders. The returned
+    ``RemotePlanner`` satisfies ``PlannerRuntime``, ``CompletionDetector`` and
+    ``GroundingProvider`` from one loaded model, so both runtimes reuse it.
+    """
     from odyssey.runners.agents.remote_planner import RemotePlanner
     from odyssey.runners.models.openvla import VLARuntime
 
@@ -436,12 +448,48 @@ def _build_planned_runtime(
             "Gemma 4 planner cannot load in the OpenVLA-pinned env)."
         )
     logger.info("SPECIALIST out-of-process: model=%s via %s", model_base, specialist_python)
-    planner = RemotePlanner(model_base, quantization, python_path=specialist_python)
+    specialist = RemotePlanner(model_base, quantization, python_path=specialist_python)
+    return pilot, specialist
 
+
+def _build_planned_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    cfg: dict[str, Any],
+    instruction: str,
+) -> Any:
+    """Planner-driven arm: SPECIALIST authors the plan, PILOT executes it."""
+    from odyssey.runners.agents.planned import PhaseConfig, PlannedEvalRuntime
+
+    pilot, specialist = _build_pilot_and_specialist(context, checkpoint, cfg)
     phase_config = PhaseConfig.from_config(cfg)
     return PlannedEvalRuntime(
         pilot=pilot,
-        planner=planner,
+        planner=specialist,
         phase_config=phase_config,
         fallback_instruction=instruction,
+    )
+
+
+def _build_delegated_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    cfg: dict[str, Any],
+    instruction: str,
+) -> Any:
+    """Delegation-driven arm: orchestrator delegates grounding to the SPECIALIST.
+
+    The SPECIALIST authors no plan; the orchestrator runs a generic pick -> place
+    template and delegates per-phase target grounding (``ground``) to it, with
+    completion-gated hand-back (``check_done``). Contrast with
+    ``_build_planned_runtime``.
+    """
+    from odyssey.runners.agents.delegated import DelegatedEvalRuntime, DelegationConfig
+
+    pilot, specialist = _build_pilot_and_specialist(context, checkpoint, cfg)
+    return DelegatedEvalRuntime(
+        pilot=pilot,
+        grounder=specialist,
+        config=DelegationConfig.from_config(cfg),
+        task_fallback=instruction,
     )

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -218,11 +218,22 @@ class RobosuiteRunner(Runner):
         )
 
         if use_planned:
-            runtime = _build_planned_runtime(context, checkpoint, spec)
+            coordination = str((spec.config or {}).get("coordination", "planning")).lower()
+            if coordination == "delegation":
+                runtime = _build_delegated_runtime(context, checkpoint, spec)
+                step_label = "DelegatedEvalRuntime (PILOT + SPECIALIST)"
+            elif coordination == "planning":
+                runtime = _build_planned_runtime(context, checkpoint, spec)
+                step_label = "PlannedEvalRuntime (PILOT + SPECIALIST)"
+            else:
+                raise ValueError(
+                    f"unknown coordination {coordination!r}; "
+                    "allowed: planning, delegation"
+                )
             await context.emit_progress(
                 "model_loading",
                 step="load_specialist",
-                step_label="PlannedEvalRuntime (PILOT + SPECIALIST)",
+                step_label=step_label,
             )
             policy = None
         elif self._policy_factory is _default_policy_factory:
@@ -478,21 +489,22 @@ def _resolve_task_instruction(spec: EvaluationTask) -> str:
     )
 
 
-def _build_planned_runtime(
+def _build_pilot_and_specialist(
     context: TaskContext,
     checkpoint: Path,
     spec: EvaluationTask,
-) -> Any:
-    """Build a PlannedEvalRuntime from the mission's PILOT + SPECIALIST.
+) -> tuple[Any, Any]:
+    """Build the PILOT (OpenVLA) + out-of-process SPECIALIST (Gemma).
 
-    The SPECIALIST is a multimodal Gemma 4 task planner that runs **out of
-    process**: ``ODYSSEY_SPECIALIST_PYTHON`` must point at a separate venv's
-    python whose modern ``transformers`` + ``torchvision`` can host Gemma 4,
-    free of OpenVLA's pinned ``transformers==4.40.1`` in this venv. The
-    SPECIALIST is inference-only (it runs its base checkpoint to plan); only the
-    PILOT is trained.
+    Shared by the planner-driven and delegation-driven builders. The SPECIALIST
+    is a multimodal Gemma 4 model that runs **out of process**:
+    ``ODYSSEY_SPECIALIST_PYTHON`` must point at a separate venv's python whose
+    modern ``transformers`` + ``torchvision`` can host Gemma 4, free of OpenVLA's
+    pinned ``transformers==4.40.1`` in this venv. It is inference-only (runs its
+    base checkpoint); only the PILOT is trained. The returned ``RemotePlanner``
+    satisfies ``PlannerRuntime``, ``CompletionDetector`` and ``GroundingProvider``
+    from one loaded model, so both runtimes reuse it.
     """
-    from odyssey.runners.agents.planned import PhaseConfig, PlannedEvalRuntime
     from odyssey.runners.agents.remote_planner import RemotePlanner
     from odyssey.runners.models.openvla import VLARuntime
 
@@ -502,7 +514,7 @@ def _build_planned_runtime(
     # Load the PILOT as a VLARuntime (per-call instruction)
     pilot = VLARuntime(checkpoint, unnorm_key=unnorm_key)
 
-    # The SPECIALIST planner runs out-of-process: Gemma 4 needs a modern
+    # The SPECIALIST runs out-of-process: Gemma 4 needs a modern
     # transformers/torchvision incompatible with OpenVLA's pin in this venv.
     model_base, quantization = _find_specialist_model(context)
     specialist_python = os.getenv("ODYSSEY_SPECIALIST_PYTHON")
@@ -511,28 +523,59 @@ def _build_planned_runtime(
             "Multi-agent eval requires the out-of-process SPECIALIST: set "
             "ODYSSEY_SPECIALIST_PYTHON to the specialist venv's python (see the "
             "README 'Multi-agent evaluation' section). The multimodal Gemma 4 "
-            "planner cannot load in this venv, which pins transformers==4.40.1 "
+            "model cannot load in this venv, which pins transformers==4.40.1 "
             "for OpenVLA."
         )
 
     logger.info(
         "SPECIALIST out-of-process: model=%s via %s", model_base, specialist_python
     )
-    planner = RemotePlanner(
+    specialist = RemotePlanner(
         model_base,
         quantization,
         python_path=specialist_python,
     )
+    return pilot, specialist
 
+
+def _build_planned_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    spec: EvaluationTask,
+) -> Any:
+    """Planner-driven arm: SPECIALIST authors the plan, PILOT executes it."""
+    from odyssey.runners.agents.planned import PhaseConfig, PlannedEvalRuntime
+
+    pilot, specialist = _build_pilot_and_specialist(context, checkpoint, spec)
     # Phase config from mission config (opt-in completion-gating; default
     # stays fixed_steps so existing missions are unchanged).
-    phase_config = PhaseConfig.from_config(cfg)
-
-    task_instruction = _resolve_task_instruction(spec)
-
+    phase_config = PhaseConfig.from_config(spec.config or {})
     return PlannedEvalRuntime(
         pilot=pilot,
-        planner=planner,
+        planner=specialist,
         phase_config=phase_config,
-        fallback_instruction=task_instruction,
+        fallback_instruction=_resolve_task_instruction(spec),
+    )
+
+
+def _build_delegated_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    spec: EvaluationTask,
+) -> Any:
+    """Delegation-driven arm: orchestrator delegates grounding to the SPECIALIST.
+
+    The SPECIALIST authors no plan; the orchestrator runs a generic pick -> place
+    template and delegates per-phase target grounding (``ground``) to it, with
+    completion-gated hand-back (``check_done``). Contrast with
+    ``_build_planned_runtime``.
+    """
+    from odyssey.runners.agents.delegated import DelegatedEvalRuntime, DelegationConfig
+
+    pilot, specialist = _build_pilot_and_specialist(context, checkpoint, spec)
+    return DelegatedEvalRuntime(
+        pilot=pilot,
+        grounder=specialist,
+        config=DelegationConfig.from_config(spec.config or {}),
+        task_fallback=_resolve_task_instruction(spec),
     )

--- a/tests/integration/test_multiagent_eval.py
+++ b/tests/integration/test_multiagent_eval.py
@@ -399,3 +399,59 @@ async def test_completion_gated_drains_phase_advance_telemetry() -> None:
     assert advances[0]["from"] == 0
     assert advances[0]["to"] == 1
     assert detector.calls == 1
+
+
+class MockGrounder:
+    """Grounding provider + completion detector stub (like RemotePlanner).
+
+    ``ground`` returns a fixed target; ``check_done`` confirms from the Nth poll.
+    """
+
+    def __init__(self, target: str = "the red cube", *, done_after: int | None = None) -> None:
+        self._target = target
+        self._done_after = done_after
+        self.ground_calls = 0
+        self.check_calls = 0
+
+    def ground(self, target_query: str, image: object) -> str:
+        self.ground_calls += 1
+        return self._target
+
+    def check_done(self, instruction: str, image: object) -> bool:
+        self.check_calls += 1
+        return self._done_after is not None and self.check_calls >= self._done_after
+
+
+async def test_delegated_runtime_drains_delegation_telemetry() -> None:
+    """The DelegatedEvalRuntime emits grounding + hand-back records through the
+    same sync-runtime / async-drain pattern the eval runners use."""
+    from odyssey.runners.agents.delegated import DelegatedEvalRuntime, DelegationConfig
+
+    pilot = MockPilot()
+    grounder = MockGrounder(target="the mug", done_after=1)  # confirms on first poll
+    runtime = DelegatedEvalRuntime(
+        pilot,
+        grounder,
+        config=DelegationConfig(check_every=1, max_steps_per_phase=50),
+    )
+    runtime.begin_episode("put the mug on the plate")
+
+    pub = CapturingPublisher()
+    img = np.zeros((64, 64, 3), dtype=np.uint8)
+    for _ in range(2):
+        runtime.get_action(img)
+        for ev in runtime.drain_phase_events():
+            await pub.publish("task.progress", {"step": "phase_advance", **ev})
+
+    records = [p for _, p in pub.events if p.get("step") == "phase_advance"]
+    reasons = [r["reason"] for r in records]
+    # Step 1: ground pick -> completion hand-back. Step 2: ground place ->
+    # completion hand-back (detector confirms on every poll here).
+    assert reasons == ["grounding", "completion", "grounding", "completion"]
+    assert records[0]["capability"] == "grounding"
+    assert records[0]["instruction"] == "pick up the mug"
+    assert records[1]["capability"] == "handback"
+    assert records[1]["from"] == 0 and records[1]["to"] == 1
+    assert records[2]["capability"] == "grounding"
+    assert records[2]["instruction"] == "place it at the mug"
+    assert grounder.ground_calls == 2  # one grounding per phase

--- a/tests/unit/test_agent_runtimes.py
+++ b/tests/unit/test_agent_runtimes.py
@@ -14,15 +14,26 @@ from numpy.typing import NDArray
 
 # Import engine first to avoid circular import (same pattern as test_engine.py).
 import odyssey.engine  # noqa: F401
+from odyssey.runners.agents.delegated import (
+    PICK_PLACE_TEMPLATE,
+    DelegatedEvalRuntime,
+    DelegationConfig,
+)
 from odyssey.runners.agents.planned import (
     PhaseConfig,
     PhaseStrategy,
     PlannedEvalRuntime,
     _PhaseState,
 )
-from odyssey.runners.agents.planner import LLMPlanner, _parse_plan, _parse_yes_no
+from odyssey.runners.agents.planner import (
+    LLMPlanner,
+    _parse_grounding,
+    _parse_plan,
+    _parse_yes_no,
+)
 from odyssey.runners.agents.runtime import (
     CompletionDetector,
+    GroundingProvider,
     PilotRuntime,
     PlannerRuntime,
     TextGenerator,
@@ -518,3 +529,238 @@ def test_llm_planner_check_done_false_for_text_only_generator() -> None:
 
 def test_llm_planner_satisfies_completion_detector() -> None:
     assert isinstance(LLMPlanner(FakeVisionGenerator("YES")), CompletionDetector)
+
+
+# ---------------------------------------------------------------------------
+# Grounding — LLMPlanner.ground() + _parse_grounding
+# ---------------------------------------------------------------------------
+
+def test_parse_grounding_first_nonempty_line() -> None:
+    assert _parse_grounding("the red mug on the left") == "the red mug on the left"
+
+
+def test_parse_grounding_strips_markers_and_quotes() -> None:
+    assert _parse_grounding('- "the top drawer".') == "the top drawer"
+    assert _parse_grounding("1. **the black bowl**") == "the black bowl"
+
+
+def test_parse_grounding_skips_blank_lines() -> None:
+    assert _parse_grounding("\n\n  the blue plate\nextra") == "the blue plate"
+
+
+def test_parse_grounding_empty() -> None:
+    assert _parse_grounding("") == ""
+    assert _parse_grounding("   \n  ") == ""
+
+
+def test_llm_planner_ground_returns_parsed_phrase() -> None:
+    gen = FakeVisionGenerator("the red cube near the plate")
+    planner = LLMPlanner(gen)
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    assert planner.ground("the object to pick up", img) == "the red cube near the plate"
+    # The scene image is forwarded to the multimodal generator.
+    assert gen.calls[-1][1] is img
+
+
+def test_llm_planner_ground_echoes_query_without_image() -> None:
+    planner = LLMPlanner(FakeVisionGenerator("ignored"))
+    assert planner.ground("the target", None) == "the target"
+
+
+def test_llm_planner_ground_echoes_query_for_text_only_generator() -> None:
+    planner = LLMPlanner(FakeTextGenerator("ignored"))
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    assert planner.ground("the target", img) == "the target"
+
+
+def test_llm_planner_ground_echoes_query_on_empty_output() -> None:
+    planner = LLMPlanner(FakeVisionGenerator("   "))
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+    assert planner.ground("the target", img) == "the target"
+
+
+def test_llm_planner_satisfies_grounding_provider() -> None:
+    assert isinstance(LLMPlanner(FakeVisionGenerator("x")), GroundingProvider)
+
+
+# ---------------------------------------------------------------------------
+# DelegatedEvalRuntime — delegation-driven orchestrator
+# ---------------------------------------------------------------------------
+
+class FakeGrounder:
+    """Grounding provider stub. Records queries; returns a fixed target.
+
+    No ``check_done`` — models a grounder that only grounds (hand-back then
+    falls back to the step cap).
+    """
+
+    def __init__(self, target: str = "the red cube", *, raises: bool = False) -> None:
+        self.target = target
+        self.ground_calls: list[tuple[str, Any]] = []
+        self._raises = raises
+
+    def ground(self, target_query: str, image: Any) -> str:
+        self.ground_calls.append((target_query, image))
+        if self._raises:
+            raise RuntimeError("grounding boom")
+        return self.target
+
+
+class FakeGrounderWithCheck(FakeGrounder):
+    """Grounder that also satisfies CompletionDetector (like RemotePlanner).
+
+    ``check_done`` returns True from the ``done_after``-th call onward.
+    """
+
+    def __init__(
+        self, target: str = "the red cube", *, done_after: int | None = None
+    ) -> None:
+        super().__init__(target)
+        self._done_after = done_after
+        self.check_calls: list[tuple[str, Any]] = []
+
+    def check_done(self, instruction: str, image: Any) -> bool:
+        self.check_calls.append((instruction, image))
+        return self._done_after is not None and len(self.check_calls) >= self._done_after
+
+
+_IMG = np.zeros((4, 4, 3), dtype=np.uint8)
+
+
+def test_fake_grounder_satisfies_protocol() -> None:
+    assert isinstance(FakeGrounder(), GroundingProvider)
+
+
+def test_delegated_begin_episode_returns_phase_labels() -> None:
+    rt = DelegatedEvalRuntime(FakePilot(), FakeGrounder())
+    assert rt.begin_episode("task") == ["pick", "place"]
+    assert rt.total_phases == 2
+    assert rt.current_phase_index == 0
+
+
+def test_delegated_grounds_and_composes_pick_instruction() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounder(target="the blue mug")
+    rt = DelegatedEvalRuntime(pilot, grounder)
+    rt.begin_episode("put the mug on the plate")
+    rt.get_action(_IMG)
+    # First phase (pick) grounded once, spliced into the pilot instruction.
+    assert len(grounder.ground_calls) == 1
+    assert pilot.calls[0][1] == "pick up the blue mug"
+
+
+def test_delegated_hand_back_on_completion_and_regrounds() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounderWithCheck(target="the mug", done_after=1)
+    rt = DelegatedEvalRuntime(
+        pilot, grounder, config=DelegationConfig(check_every=2, max_steps_per_phase=100)
+    )
+    rt.begin_episode("put the mug on the plate")
+
+    rt.get_action(_IMG)  # step 1: ground pick, act; no check yet (n=1)
+    assert rt.current_phase_index == 0
+    rt.get_action(_IMG)  # step 2: n=2 -> check fires -> hand-back to place
+    assert rt.current_phase_index == 1
+    rt.get_action(_IMG)  # step 3: re-ground place, act
+    assert pilot.calls[-1][1] == "place it at the mug"
+    assert len(grounder.ground_calls) == 2  # exactly one grounding per phase
+
+
+def test_delegated_cap_hand_back_without_detector() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounder(target="the cube")  # no check_done
+    rt = DelegatedEvalRuntime(
+        pilot, grounder, config=DelegationConfig(check_every=10, max_steps_per_phase=3)
+    )
+    rt.begin_episode("task")
+    for _ in range(3):
+        rt.get_action(_IMG)
+    # Cap reached at step 3 -> hand-back even without a detector.
+    assert rt.current_phase_index == 1
+
+
+def test_delegated_auto_adopts_grounder_as_detector() -> None:
+    # No detector passed; the grounder exposes check_done -> semantic hand-back
+    # works (proves auto-adoption).
+    pilot = FakePilot()
+    grounder = FakeGrounderWithCheck(target="x", done_after=1)
+    rt = DelegatedEvalRuntime(
+        pilot, grounder, config=DelegationConfig(check_every=1, max_steps_per_phase=100)
+    )
+    rt.begin_episode("task")
+    rt.get_action(_IMG)  # n=1 -> check -> hand-back
+    assert rt.current_phase_index == 1
+    assert grounder.check_calls  # detector was consulted
+
+
+def test_delegated_phase_events_schema() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounderWithCheck(target="the cube", done_after=1)
+    rt = DelegatedEvalRuntime(
+        pilot, grounder, config=DelegationConfig(check_every=1, max_steps_per_phase=100)
+    )
+    rt.begin_episode("task")
+    rt.get_action(_IMG)  # grounding event, then completion hand-back event
+    events = rt.drain_phase_events()
+
+    assert [e["reason"] for e in events] == ["grounding", "completion"]
+    assert events[0]["capability"] == "grounding"
+    assert events[0]["instruction"] == "pick up the cube"
+    assert events[0]["skill"] == "pick"
+    assert events[1]["capability"] == "handback"
+    assert events[1]["from"] == 0 and events[1]["to"] == 1
+    # Drain clears the buffer.
+    assert rt.drain_phase_events() == []
+
+
+def test_delegated_grounding_failure_falls_back_to_query() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounder(raises=True)
+    rt = DelegatedEvalRuntime(pilot, grounder, task_fallback="do it")
+    rt.begin_episode("stack the blocks")
+    rt.get_action(_IMG)  # grounder raises -> falls back to the query, never crashes
+    instr = pilot.calls[0][1]
+    assert instr.startswith("pick up ")
+    assert "stack the blocks" in instr
+
+
+def test_delegated_holds_after_all_phases() -> None:
+    pilot = FakePilot()
+    grounder = FakeGrounderWithCheck(target="the cube", done_after=1)
+    rt = DelegatedEvalRuntime(
+        pilot, grounder, config=DelegationConfig(check_every=1, max_steps_per_phase=100)
+    )
+    rt.begin_episode("task")
+    for _ in range(5):
+        action = rt.get_action(_IMG)
+    # Both phases handed back; runtime keeps returning valid actions.
+    assert rt.current_phase_index >= rt.total_phases
+    assert action.shape == (7,)
+
+
+def test_delegation_config_from_config_reads_keys() -> None:
+    cfg = DelegationConfig.from_config({"phase_check_every": 5, "phase_max_steps": 20})
+    assert cfg.check_every == 5
+    assert cfg.max_steps_per_phase == 20
+    assert cfg.skills == PICK_PLACE_TEMPLATE
+
+
+def test_delegation_config_defaults() -> None:
+    cfg = DelegationConfig.from_config({})
+    assert cfg.check_every == 10
+    assert cfg.max_steps_per_phase == 100
+
+
+def test_delegated_close_calls_grounder_close() -> None:
+    class ClosableGrounder(FakeGrounder):
+        def __init__(self) -> None:
+            super().__init__()
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    grounder = ClosableGrounder()
+    rt = DelegatedEvalRuntime(FakePilot(), grounder)
+    rt.close()
+    assert grounder.closed is True

--- a/tests/unit/test_remote_planner.py
+++ b/tests/unit/test_remote_planner.py
@@ -177,6 +177,42 @@ def test_serve_legacy_plan_still_works() -> None:
 
 
 # --------------------------------------------------------------------------- #
+# serve() — grounding requests (additive; legacy plan/check paths untouched)
+# --------------------------------------------------------------------------- #
+
+
+def test_serve_ground_returns_target() -> None:
+    planner = LLMPlanner(_FakeVLMGen("the red mug on the left"))
+    out = _run_serve(
+        planner,
+        [
+            {"ground": {"query": "the object to pick up", "image": _tiny_png_b64()}},
+            {"shutdown": True},
+        ],
+    )
+    assert out[0] == {"ready": True}
+    assert out[1] == {"target": "the red mug on the left"}
+
+
+def test_serve_ground_missing_query() -> None:
+    planner = LLMPlanner(_FakeVLMGen("x"))
+    out = _run_serve(planner, [{"ground": {"image": _tiny_png_b64()}}, {"shutdown": True}])
+    assert any(m.get("error") == "ground missing 'query' string" for m in out)
+
+
+def test_serve_ground_unsupported_when_planner_lacks_ground() -> None:
+    class _PlanOnly:
+        def plan(self, instruction: str, image: object = None) -> list[str]:
+            return ["a"]
+
+    out = _run_serve(  # type: ignore[arg-type]
+        _PlanOnly(),
+        [{"ground": {"query": "x", "image": _tiny_png_b64()}}, {"shutdown": True}],
+    )
+    assert any(m.get("error") == "ground unsupported" for m in out)
+
+
+# --------------------------------------------------------------------------- #
 # RemotePlanner — the client, against a fake server subprocess
 # --------------------------------------------------------------------------- #
 
@@ -227,6 +263,24 @@ for line in sys.stdin:
     if isinstance(req.get("check"), dict):
         instr = req["check"].get("instruction", "")
         sys.stdout.write(json.dumps({"done": "done" in instr}) + "\\n"); sys.stdout.flush()
+        continue
+    sys.stdout.write(json.dumps({"plan": ["p0", "p1"]}) + "\\n"); sys.stdout.flush()
+"""
+
+# Answers grounding requests: echoes back "grounded: <query>".
+_FAKE_SERVER_GROUND = """
+import json, sys
+sys.stdout.write(json.dumps({"ready": True}) + "\\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    if req.get("shutdown"):
+        break
+    if isinstance(req.get("ground"), dict):
+        q = req["ground"].get("query", "")
+        sys.stdout.write(json.dumps({"target": "grounded: " + q}) + "\\n"); sys.stdout.flush()
         continue
     sys.stdout.write(json.dumps({"plan": ["p0", "p1"]}) + "\\n"); sys.stdout.flush()
 """
@@ -405,5 +459,49 @@ def test_remote_planner_check_done_false_against_old_server(tmp_path: Path) -> N
     try:
         img = np.zeros((2, 2, 3), dtype=np.uint8)
         assert planner.check_done("anything", img) is False
+    finally:
+        planner.close()
+
+
+def test_remote_planner_satisfies_grounding_provider(tmp_path: Path) -> None:
+    from odyssey.runners.agents.runtime import GroundingProvider
+
+    planner = _planner_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        assert isinstance(planner, GroundingProvider)
+    finally:
+        planner.close()
+
+
+def test_remote_planner_ground_roundtrip(tmp_path: Path) -> None:
+    import numpy as np
+
+    planner = _planner_for(_FAKE_SERVER_GROUND, tmp_path)
+    try:
+        img = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert planner.ground("the object to pick up", img) == "grounded: the object to pick up"
+    finally:
+        planner.close()
+
+
+def test_remote_planner_ground_echoes_query_without_image(tmp_path: Path) -> None:
+    # image=None short-circuits to the query without starting the subprocess.
+    planner = _planner_for(_FAKE_SERVER_GROUND, tmp_path)
+    try:
+        assert planner.ground("the target", None) == "the target"
+        assert planner._proc is None  # never launched
+    finally:
+        planner.close()
+
+
+def test_remote_planner_ground_echoes_query_against_old_server(tmp_path: Path) -> None:
+    # An old server that doesn't understand {"ground": ...} replies with a plan;
+    # the client fails safe to echoing the query (no "target" key).
+    import numpy as np
+
+    planner = _planner_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        img = np.zeros((2, 2, 3), dtype=np.uint8)
+        assert planner.ground("the mug", img) == "the mug"
     finally:
         planner.close()


### PR DESCRIPTION
## Context

Stacked on #64. That PR gives the multi-agent eval a **closed-loop completion check** (`check_done`); this PR reuses it to add the **delegation-driven** counterpart to the planner-driven `PlannedEvalRuntime`.

Framing (research landscape §4.4 coordination regimes): #64 ≈ *planner-driven + semantic transitions*. This PR sits between the closed-loop-no-plan and full-delegation regimes: a deterministic orchestrator + the SPECIALIST as an on-demand **grounding tool** (not a sequence author) + completion-gated hand-back. It isolates one variable — **is the SPECIALIST better as sequence-author (planner) or as an on-demand grounding tool (delegation)?** — for a fair comparison on identical LIBERO tasks/metrics.

> Base is `feat/multiagent-inference-integration` so the diff shows **only** the delegation arm. Re-target to `develop` once #64 merges.

## What this adds

A new **opt-in** `coordination: delegation` regime. Instead of the SPECIALIST authoring a full plan up front, an orchestrator runs a generic `pick → place` skill template and, per phase:
1. **delegates grounding** to the SPECIALIST — *"where is the object to pick up in this scene?"* (`ground`) — and splices the returned phrase into the pilot instruction (`pick up the red mug on the left`);
2. **delegates execution** to the pilot;
3. **hands control back** when the completion check confirms the sub-task is done (`check_done`), with a step cap as a safety net.

The SPECIALIST **authors no plan** — it is a perception tool (open-weight analogue of GR-ER's spatial grounding). Default stays `coordination: planning`; delegation is opt-in.

**Zero extra VRAM:** the one loaded out-of-process Gemma answers `plan`, `check_done` **and** `ground` over the same server.

**Core**
- `runners/agents/runtime.py` — `GroundingProvider` protocol.
- `runners/agents/planner.py` — `LLMPlanner.ground()` + grounding prompt + `_parse_grounding`.
- `runners/agents/remote_planner.py` / `planner_server.py` — **additive** IPC `{"ground": {...}}` → `{"target": "..."}` (mirrors `{"check"}`); short `ground_timeout`; fail-safe echoes the query; back-compat with an old server (no `target` key → echo query).
- `runners/agents/delegated.py` (**new**) — `DelegatedEvalRuntime` + `DelegationConfig` + `PICK_PLACE_TEMPLATE`; same public surface as `PlannedEvalRuntime` (`begin_episode` / `get_action` / `drain_phase_events` / `close`); detector auto-adopted from the grounder; buffered `phase_advance` events with `capability` (`grounding` | `handback`) and `reason` (`grounding` | `completion` | `cap`).
- `runners/evals/libero.py` / `robosuite.py` — `coordination: planning | delegation` selector + shared `_build_pilot_and_specialist` helper + `_build_delegated_runtime`.

**Example / docs**
- `examples/franka-libero/mission-multiagent-delegation.yaml`.
- `examples/franka-libero/README.md` — "Planner vs delegation" section (comparison table, per-phase mechanics, telemetry, scope).

## Backward compatibility

- Default stays `coordination: planning`; the planner arm and single-agent path are untouched.
- IPC is additive — legacy `{"instruction"}` / `{"check"}` / `{"shutdown"}` intact; an old server that doesn't understand `{"ground"}` replies `{"error"}`/plan → client echoes the query → degrades safely.

## How to test

**Local (no GPU) — CI-covered:**
```bash
pip install -e ".[dev]"
ruff check src/ tests/
mypy
pytest tests/unit/test_agent_runtimes.py tests/unit/test_remote_planner.py tests/integration/test_multiagent_eval.py
```
New coverage: `ground()` (parsed phrase, fail-safe echo, text-only/no-image), the `{"ground"}` IPC path + legacy back-compat, `GroundingProvider`/`CompletionDetector` conformance, and `DelegatedEvalRuntime` orchestration (grounding delegation, completion hand-back, cap fallback, re-ground per phase, detector auto-adoption, event schema, grounding-failure fallback) + the `drain_phase_events()` → `phase_advance` telemetry contract.

**GPU VM (real, manual — deferred):** run `mission-multiagent-delegation.yaml` (with `ODYSSEY_SPECIALIST_PYTHON` set) on the L4 and confirm `phase_advance` telemetry shows `completion` hand-backs (not just `cap`), both models fit VRAM (grounding reuses the loaded Gemma), and compare `success_rate` on `libero_object` `task_0` against the `coordination: planning` arm — the planner-vs-delegation comparison.

## Scope / follow-ups

- The orchestrator's routing is a fixed `pick → place` template with completion-gated hand-back (a deliberate skeleton). Capability advertising / A2A-style task lifecycle / an LLM router that *chooses* which agent to invoke (the full delegation-driven regime) are deferred.
- Custom (non pick→place) templates are not yet mission-configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)