### PR TITLE
chore(versioning): bump to 0.1.0a3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lovell-odyssey"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Open-source framework for defining, running, and benchmarking robot training missions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
 """Odyssey — open-source framework for robot training missions."""
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a3"


### PR DESCRIPTION
## What

Bump version `0.1.0a2` → `0.1.0a3` in `pyproject.toml` and `src/odyssey/__init__.py`.

## Why

This is **step 1 of the release**. The bump lands on `develop` **before** the
`develop → main` release PR, so `main` never receives a direct version commit —
that direct-to-main bump was a root cause of past `main`/`develop` divergence and
the phantom-conflict back-merges.

## Merge instructions

- ✅ Merge this into `develop` normally.
- ⚠️ For the **subsequent `develop → main` release PR**: merge with **"Create a
  merge commit"**, NOT squash. Squashing rewrites develop's commits onto main and
  destroys the shared ancestor → that is exactly what caused the 13-conflict slog
  and forced the back-merges (#60, #34). A merge commit keeps ancestry and makes
  the release clean and the back-merge unnecessary.

## Release contents (develop is 57 commits ahead of main)

LIBERO eval, GR00T pilot + Isaac/LIBERO eval bridge, rollout video decouple,
Dependabot + HF model-drift watcher, graceful shutdown, watchdog, and more.

🤖 Generated with [Claude Code](https://claude.com/claude-code)