### PR TITLE
feat(pi05): chunk-emitting π0.5 pilot + FAST scoping (issue #74)

### DIFF
--- a/docs/pi05-scoping.md
+++ b/docs/pi05-scoping.md
@@ -1,0 +1,412 @@
+# Scoping de pi0.5 (issue #74)
+
+## Licencia y pesos
+
+### Resumen ejecutivo
+
+Los checkpoints de **π0.5 (pi05)** publicados por Physical Intelligence en el
+repositorio oficial `openpi` se distribuyen bajo **licencia Apache 2.0**. Apache
+2.0 es una licencia permisiva que **permite explícitamente el uso comercial**,
+la modificación, la distribución y el uso en despliegues privados/industriales,
+sin regalías, siempre que se conserven el aviso de copyright, el texto de la
+licencia y el fichero `NOTICE` (si existe) en las redistribuciones. **No hay
+cláusula de "solo investigación" ni restricción de uso comercial.**
+
+→ Para el uso previsto (**despliegue industrial comercial**), la licencia **no
+supone un bloqueo**.
+
+### Checkpoints disponibles abiertamente
+
+Physical Intelligence libera pesos de π0.5 por dos vías equivalentes: Google
+Cloud Storage (`gs://openpi-assets/...`, la fuente que consume el repo `openpi`)
+y el Hub de Hugging Face (mirror bajo la organización `lerobot`).
+
+| Checkpoint | Ruta / repo | Uso previsto |
+| --- | --- | --- |
+| **π0.5 base** | `gs://openpi-assets/checkpoints/pi05_base` · HF: [`lerobot/pi05_base`](https://huggingface.co/lerobot/pi05_base) | Fine-tuning (modelo generalista pre-entrenado en 10k+ h de datos de robot) |
+| **π0.5-LIBERO** | `gs://openpi-assets/checkpoints/pi05_libero` · HF: [`lerobot/pi05_libero`](https://huggingface.co/lerobot/pi05_libero) | Inferencia / benchmark LIBERO (SOTA) |
+| **π0.5-DROID** | `gs://openpi-assets/checkpoints/pi05_droid` | Inferencia / fine-tuning (fine-tuned sobre DROID con *knowledge insulation*, inferencia rápida y seguimiento de lenguaje) |
+
+Notas:
+- π0.5 es la evolución de π0 orientada a **generalización open-world** (publicado
+  en septiembre de 2025).
+- El código del repo `openpi` está igualmente bajo Apache 2.0; la implementación
+  en LeRobot (`policy.type=pi05`) deriva del mismo repositorio y declara la misma
+  licencia Apache 2.0 para el modelo.
+- `chunk_size` por defecto de π0.5 = 50 (relevante para la pasarela de *chunking*
+  de la pilot).
+
+### Diligencia recomendada antes de producción
+
+Aunque la licencia es permisiva, para un despliegue comercial conviene:
+1. **Conservar `LICENSE`/`NOTICE`** de openpi en cualquier artefacto redistribuido
+   o imagen de contenedor que incluya los pesos.
+2. Verificar la **model card** de cada checkpoint en el Hub en el momento de la
+   descarga: Apache 2.0 aplica hoy, pero una tarjeta concreta podría añadir
+   términos de dataset (p. ej. DROID) o *acceptable use* — revisar antes de
+   fijar el pin.
+3. Comprobar la licencia de los **datasets** usados si se hace fine-tuning propio
+   (los pesos base son Apache 2.0, pero los datos de fine-tuning que aporte el
+   proyecto tienen su propia procedencia).
+
+### Fuentes
+
+- Physical-Intelligence/openpi — repositorio y checkpoints (LICENSE = Apache 2.0):
+  https://github.com/Physical-Intelligence/openpi
+- LICENSE (Apache License, Version 2.0):
+  https://raw.githubusercontent.com/Physical-Intelligence/openpi/main/LICENSE
+- Physical Intelligence — "Open Sourcing π0" (blog):
+  https://www.pi.website/blog/openpi
+- Physical Intelligence — π0.5 (open-world generalization):
+  https://www.physicalintelligence.company/blog/pi05
+- LeRobot docs — π0.5 (Pi05) Policy, "This model follows the Apache 2.0 License":
+  https://huggingface.co/docs/lerobot/pi05
+- HF checkpoints: [`lerobot/pi05_base`](https://huggingface.co/lerobot/pi05_base),
+  [`lerobot/pi05_libero`](https://huggingface.co/lerobot/pi05_libero)
+
+**Conclusión:** π0.5 se publica bajo **Apache 2.0**, que autoriza el uso
+comercial e industrial. **No se añade línea de BLOQUEO** — la licencia permite el
+uso previsto.
+
+## FAST tokenizer
+
+### Resumen ejecutivo
+
+**FAST (Frequency-space Action Sequence Tokenization) está disponible como
+librería reusable — NO requiere reimplementación.** Physical Intelligence lo
+publica de dos formas complementarias, ambas bajo **Apache 2.0**:
+
+1. **Como HuggingFace `AutoProcessor`** (checkpoint `physical-intelligence/fast`),
+   consumible en 3 líneas vía `transformers` + `scipy`, sin dependencia de openpi.
+2. **Wrapper `FASTTokenizer`** dentro de `openpi`
+   (`src/openpi/models/tokenizer.py`), que a su vez carga el mismo `AutoProcessor`
+   por debajo. Es la vía que usa el propio π0-FAST / π0.5 en entrenamiento.
+
+→ Para la pilot de π0.5, la tokenización de acciones **se reutiliza tal cual**; el
+único trabajo es de integración (normalización a `[-1, 1]`, wiring del chunk), no
+de reimplementar el algoritmo (DCT + cuantización estilo JPEG).
+
+### Vía A — librería universal vía `transformers` (independiente de openpi)
+
+Requisitos: `pip install transformers scipy`. Checkpoint: `physical-intelligence/fast`
+(tokenizer **FAST+** universal, entrenado sobre 1M de secuencias de acción reales).
+
+```python
+from transformers import AutoProcessor
+import numpy as np
+
+# trust_remote_code=True: el algoritmo FAST viaja como código en el repo del Hub
+tokenizer = AutoProcessor.from_pretrained("physical-intelligence/fast", trust_remote_code=True)
+
+action_data = np.random.rand(256, 50, 14)  # (batch, time_horizon, action_dim), normalizado a [-1, 1]
+tokens = tokenizer(action_data)             # -> list[int]  (codificación con compresión)
+decoded = tokenizer.decode(tokens)          # -> acciones reconstruidas
+```
+
+Notas de uso:
+- Recomendado para *chunks* de ~1 s **pre-normalizados a `[-1, 1]`**.
+- Encode/decode soportan **inferencia por lotes** (batched).
+- Se puede **entrenar un tokenizer propio** para un dataset concreto con
+  `tokenizer.fit(action_data)`, seguido de `save_pretrained(...)` /
+  `push_to_hub(...)`. Útil si las estadísticas de acción del embodiment objetivo
+  difieren mucho de FAST+.
+
+### Vía B — wrapper `FASTTokenizer` en openpi (la que usa π0.5)
+
+En `openpi`, la clase `FASTTokenizer` (`src/openpi/models/tokenizer.py`) envuelve
+el mismo `AutoProcessor` y añade el ensamblado con el tokenizer de lenguaje del VLM:
+
+```python
+# openpi (resumido)
+self._fast_tokenizer = AutoProcessor.from_pretrained(fast_tokenizer_path, trust_remote_code=True)
+#   fast_tokenizer_path por defecto = "physical-intelligence/fast"
+
+action_tokens = self._fast_tokenizer(actions[None])[0]                    # tokenize()
+... = self._fast_tokenizer.decode([action_tokens.tolist()],              # extract_actions()
+                                  time_horizon=action_horizon, action_dim=action_dim)[0]
+```
+
+Implicación para la pilot: si se apoya en el stack de `openpi` para π0.5, la
+tokenización llega **gratis** con el repo (mismo checkpoint del Hub por debajo);
+no hay que traer una dependencia extra ni reimplementar nada.
+
+### Cómo funciona (por qué "frequency-space")
+
+FAST comprime cada secuencia de acción mediante: (1) normalización, (2) **DCT
+(Discrete Cosine Transform)** por dimensión de acción, y (3) cuantización que
+redondea/descarta coeficientes poco significativos — el mismo principio de
+compresión que JPEG (imagen) o MP3 (audio). Esto permite entrenar VLA
+**autorregresivas** sobre acciones de alta frecuencia/destreza, alcanzando la
+destreza de flow-matching/diffusion con ~5× menos tiempo de entrenamiento.
+
+### Fuentes
+
+- Modelo/tokenizer universal en el Hub (Apache 2.0), con ejemplo de uso y `.fit()`:
+  https://huggingface.co/physical-intelligence/fast
+  · README: https://huggingface.co/physical-intelligence/fast/blob/main/README.md
+- Wrapper `FASTTokenizer` en openpi:
+  https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/models/tokenizer.py
+- Paper "FAST: Efficient Action Tokenization for Vision-Language-Action Models":
+  https://arxiv.org/abs/2501.09747 · PDF: https://www.pi.website/download/fast.pdf
+- Página de research (resumen + figuras): https://www.pi.website/research/fast
+- Integración en LeRobot (π0-FAST policy, misma licencia Apache 2.0):
+  https://huggingface.co/docs/lerobot/pi0fast
+  · mirror del tokenizer: https://huggingface.co/lerobot/fast-action-tokenizer
+
+**Conclusión:** FAST **es reusable como librería** (`AutoProcessor` del Hub o el
+wrapper `FASTTokenizer` de openpi), Apache 2.0. **No se requiere
+reimplementación** — solo integración (normalización + wiring del chunk). **No se
+añade línea de BLOQUEO.**
+
+## VRAM footprint (estimado)
+
+> ⚠️ **NO VERIFICADO EN HARDWARE.** Todas las cifras de esta sección son una
+> estimación **analítica** (parámetros × precisión + KV cache + overhead de
+> runtime). **No** proceden de una medición real en GPU (`nvidia-smi`, perfilado
+> de memoria, ni OOM observados). Sirven para dimensionar *a priori* la
+> co-residencia; hay que confirmarlas en una L4 real antes de fijar cualquier
+> decisión de despliegue.
+
+### Objetivo
+
+¿Caben **π0.5 (pilot)** y un **Specialist tipo Gemma** (juez/grounding,
+cuantizado int4) **co-residentes** en una única **NVIDIA L4 de 24 GB**?
+
+### Supuestos de partida
+
+| Parámetro | Valor asumido | Base del supuesto |
+| --- | --- | --- |
+| Arquitectura π0.5 | PaliGemma-3B (SigLIP ViT ~0.4B + Gemma-2B) + *action expert* ~0.3B | Misma familia que π0/π0.5 en openpi; ≈ **3.3B parámetros** totales |
+| Precisión de inferencia π0.5 | **bf16** (2 bytes/parám) | openpi/JAX corre en bf16 por defecto |
+| Contexto (tokens de prefijo) | ~1–2k tokens (256 tok/imagen × ~2–3 cámaras + lenguaje) | Config típica de π0.5 multi-cámara |
+| `chunk_size` | 50 | Ya documentado arriba (default π0.5) |
+| Specialist | Gemma **int4** (≈4B) VLM juez | Nota de memoria: `check_done` = "Gemma int4" |
+| Precisión Specialist | int4 (~0.5 byte/parám efectivo + escalas) | Cuantización GPTQ/AWQ-style |
+
+### Desglose analítico
+
+**1. Pesos de π0.5 (bf16)**
+- 3.3B × 2 bytes ≈ **6.6 GB**
+- (Si se corriese en fp32 se duplicaría a ~13.2 GB → la co-residencia dejaría de
+  ser cómoda; **usar bf16/fp16 es un requisito**, no una optimización.)
+
+**2. KV cache de π0.5** — *despreciable*
+- Gemma-2B usa MQA (≈1 KV head, head_dim 256, 18 capas).
+- Por token: `2 (K,V) × 18 capas × 1 KV head × 256 × 2 bytes ≈ 18 KB/token`.
+- Con ~2k tokens de contexto: **~0.04 GB**. Incluso con márgenes generosos, < 0.1 GB.
+- Razón: a diferencia de un chat LLM, el contexto es corto y fijo (prefijo de
+  imágenes + instrucción); no crece por decodificación larga.
+
+**3. Activaciones / workspace de inferencia (batch 1)**
+- Encoder de visión (SigLIP) + atención del backbone + muestreo del *action
+  expert* (varios pasos de denoising que reutilizan buffers): **~1–2 GB**.
+
+**4. Overhead de runtime (contexto CUDA + XLA/cuDNN)**
+- Contexto CUDA, kernels, cuDNN/cuBLAS workspaces de **dos** frameworks
+  co-residentes (JAX para π0.5 + PyTorch para el Specialist): **~1–1.5 GB**.
+
+**5. Specialist Gemma int4 (≈4B)**
+- Pesos: 4B × 0.5 byte ≈ 2.0 GB + escalas/zeros del esquema int4 (~+10–15%) ≈
+  **~2.3 GB**.
+- KV cache + activaciones + (si es VLM) tokens de imagen: **~0.5–0.7 GB**.
+- Subtotal Specialist: **~3.0 GB**.
+- (Si el Specialist fuese un Gemma-2B int4, bajaría a ~1.2 GB de pesos → ~1.7 GB
+  totales.)
+
+### Total estimado
+
+| Componente | VRAM (GB) |
+| --- | --- |
+| π0.5 pesos (bf16) | 6.6 |
+| π0.5 KV cache | ~0.05 |
+| π0.5 activaciones/workspace | 1.5 |
+| Overhead runtime (CUDA + XLA/cuDNN, 2 frameworks) | 1.5 |
+| Specialist Gemma int4 (~4B) | 3.0 |
+| **Total** | **≈ 12.6 GB** |
+
+**Sobre L4 (24 GB): ~12.6 GB usados → ~11 GB de holgura (~52% libre).**
+
+Rango con incertidumbre (peor caso de activaciones/overhead y Specialist 4B):
+**~11–15 GB**. La co-residencia **cabe con margen cómodo** en la estimación; el
+riesgo no es el *tamaño* estático sino la **gestión de asignación** (ver abajo).
+
+### Caveats críticos para la co-residencia (riesgos operativos, no de tamaño)
+
+1. **Preasignación de JAX/XLA (riesgo #1).** Por defecto JAX reserva el **75–90%
+   de la VRAM** al arrancar, lo que **mataría por OOM** al Specialist de PyTorch
+   aunque el footprint real quepa. **Obligatorio** fijar
+   `XLA_PYTHON_CLIENT_PREALLOCATE=false` o
+   `XLA_PYTHON_CLIENT_MEM_FRACTION=~0.5` para acotar a π0.5.
+2. **Fragmentación entre dos allocators.** JAX y PyTorch mantienen pools de
+   memoria independientes; la suma nominal puede caber pero la fragmentación
+   reduce el máximo asignable contiguo. Considerar
+   `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
+3. **Precisión.** El cálculo asume bf16 para π0.5; en fp32 no cabría con holgura.
+4. **Tamaño real del Specialist sin confirmar.** "Gemma int4" no fija variante
+   (2B vs 4B vs 3-4B VLM) ni esquema de cuantización — cambia el subtotal en
+   ±1.3 GB. Confirmar el checkpoint exacto.
+5. **Picos transitorios en carga.** La carga de checkpoints (dequant int4,
+   conversión de dtype) puede exigir un pico temporal por encima del estado
+   estacionario; secuenciar las cargas (no cargar ambos modelos en paralelo).
+
+### Cómo verificarlo en hardware (pendiente)
+
+- `nvidia-smi --query-gpu=memory.used --format=csv -l 1` durante un rollout
+  co-residente.
+- `torch.cuda.max_memory_allocated()` para el Specialist y el *memory profiler*
+  de JAX (`jax.profiler` / `XLA_FLAGS=--xla_dump...`) para π0.5.
+- Prueba de estrés: rollout completo (chunk 50) con ambos modelos activos y
+  medición de pico, no de media.
+
+## Mapeo de espacio de acción
+
+### Resumen ejecutivo
+
+La pregunta operativa es: **¿cuál es el `unnorm_key` de π0.5?** Respuesta corta:
+π0.5 **no expone un `unnorm_key` en la config de la misión**. El papel que en
+OpenVLA juega el string `unnorm_key` (seleccionar, en tiempo de inferencia, qué
+estadísticas de des-normalización aplicar a la acción) lo cubre en `openpi` un
+fichero **`norm_stats`** que viene **empaquetado dentro del propio checkpoint**
+(bajo `assets/<asset_id>/`) y se selecciona por el **`repo_id`/`asset_id`** con el
+que se entrenó — no por una clave que el usuario pase en la config. Para
+`pi05_libero` ese `asset_id` es `physical-intelligence/libero`.
+
+→ Consecuencia práctica para la pilot: donde OpenVLA lleva
+`config.unnorm_key: libero_object`, **π0.5-LIBERO no lleva ninguna clave
+equivalente** en el YAML. La normalización correcta viaja con los pesos. El
+"knob" análogo solo existe en *entrenamiento* (elegir el `repo_id`/`norm_stats`
+del embodiment), no en *evaluación*.
+
+### El análogo exacto de `unnorm_key`
+
+| | OpenVLA (`predict_action`) | π0.5 / `openpi` |
+| --- | --- | --- |
+| Qué normaliza | La acción de salida (7-D), de espacio normalizado → unidades físicas del robot | Estado de entrada **y** acción de salida (chunk), vía `Normalize`/`Unnormalize` |
+| Dónde viven las estadísticas | `dataset_statistics` dentro del `config.json` del checkpoint (varios datasets a la vez) | `norm_stats.json` bajo `assets/<asset_id>/` del checkpoint (uno por embodiment) |
+| Cómo se selecciona | String `unnorm_key` pasado en inferencia (`predict_action(..., unnorm_key=...)`) | Implícito: `asset_id = assets.asset_id or repo_id`, fijado al entrenar |
+| Superficie en la misión | `config.unnorm_key` (obligatorio, debe casar suite/checkpoint) | **ninguna** — el checkpoint es autocontenido |
+| Fallo típico | `unnorm_key` mal → acciones a escala equivocada, arm errático | (no aplica en eval) checkpoint/repo_id equivocado al entrenar |
+
+Referencia en el repo del lado OpenVLA: `src/odyssey/runners/models/openvla.py:481`
+(`unnorm_key = cfg.get("unnorm_key", "bridge_orig")`) y su paso a
+`model.predict_action(..., unnorm_key=self._unnorm_key)`
+(`openvla.py:674`).
+
+### Espacio de observación de π0.5-LIBERO
+
+`openpi` normaliza la observación LIBERO al mismo *embodiment* Franka Panda que
+consume el resto del stack (robosuite/LIBERO), a través de `LiberoInputs`:
+
+- **Imágenes** (3 entradas del modelo, familia PaliGemma/Pi0):
+  - `base_0_rgb` ← vista cenital de tercera persona (`observation/image`, `agentview`).
+  - `left_wrist_0_rgb` ← cámara de muñeca (`observation/wrist_image`).
+  - `right_wrist_0_rgb` ← **rellena a ceros** (LIBERO es de un brazo; se enmascara
+    con `image_mask`).
+  - Formato normalizado a `uint8 (H, W, C)`.
+- **Estado propioceptivo, 8-D** (idéntico a la convención Franka Panda de
+  robosuite/LIBERO):
+
+  ```python
+  state = np.concatenate([
+      obs["robot0_eef_pos"],                    # (3) posición EEF x,y,z
+      quat2axisangle(obs["robot0_eef_quat"]),   # (3) orientación EEF: quat xyzw -> eje-ángulo
+      obs["robot0_gripper_qpos"],               # (2) qpos de las dos falanges del gripper
+  ])                                            # -> 8-D
+  ```
+
+  Este es exactamente el mismo vector de estado que construye el eval de LIBERO de
+  NVIDIA para GR00T (`quat_xyzw_to_axis_angle` en
+  `src/odyssey/runners/evals/gr00t_transforms.py:172`) y que OpenVLA asume
+  implícitamente. La conversión clave de convención es
+  **quaternion `xyzw` (robosuite) → eje-ángulo** vía `quat2axisangle`.
+- **Padding a la dimensión del modelo:** el estado 8-D se rellena con ceros hasta
+  `action_dim` del modelo (**32** en la familia Pi0) mediante `pad_to_dim` /
+  `PadStatesAndActions`, y luego se **normaliza** con `norm_stats`. El *prompt* de
+  lenguaje se toma de la tarea (`prompt_from_task=True`).
+
+### Espacio de acción de π0.5-LIBERO
+
+El modelo emite un **chunk** de acciones normalizadas de forma
+`(action_horizon, 32)`; `LiberoOutputs` lo des-normaliza (con el mismo
+`norm_stats`) y **recorta las 32 dims al 7-DoF de LIBERO**:
+
+```python
+# openpi LiberoOutputs
+return {"actions": np.asarray(data["actions"][..., :7])}   # el resto es padding
+```
+
+Las 7 dims son la acción **OSC_POSE** nativa de LIBERO/Franka Panda:
+`[dx, dy, dz, droll, dpitch, dyaw, gripper]` (delta de pose EEF + gripper), que se
+aplica **directamente** a `env.step(action.tolist())`.
+
+**Diferencia crítica frente a OpenVLA — el gripper NO se re-procesa.** En OpenVLA
+el eval de odyssey aplica `_libero_action` (`src/odyssey/runners/evals/libero.py:159`):
+re-escala el gripper `[0,1]→[-1,1]`, lo **binariza** y lo **invierte** para casar
+el signo de LIBERO. En π0.5/`openpi` **no hay** ese fix-up en evaluación: el
+checkpoint se entrenó sobre datos ya en la convención de gripper de LIBERO y las
+`norm_stats` fijan la escala, así que la salida se pasa tal cual a `env.step`
+(igual criterio que `examples/libero/main.py` de openpi, sin `binarize`/`invert`).
+Contrasta también con GR00T-N1.7-LIBERO, que **sí** aplica
+`normalize_gripper_action` + `invert_gripper_action`
+(`gr00t_transforms.py:218-228`) porque su checkpoint emite el gripper en `[0,1]`.
+
+> ⚠️ **Verificar la polaridad del gripper en el primer rollout en GPU.** Aunque la
+> teoría dice "sin fix-up", un signo de gripper invertido es un fallo silencioso
+> clásico (el brazo se mueve y se aproxima pero nunca agarra). Es el mismo footgun
+> anotado para GR00T; confirmarlo contra el servidor π0.5 antes de fijar la config.
+
+### Tabla comparativa de los tres pilots sobre LIBERO/Franka Panda
+
+| | OpenVLA-7B | GR00T-N1.7-LIBERO | **π0.5-LIBERO** |
+| --- | --- | --- | --- |
+| Estado de entrada | (implícito) | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos |
+| Acción emitida | 1 paso 7-D | chunk 7-D (`action.*`, absoluta) | **chunk** `(H, 32)` → recorte 7-D |
+| Espacio de acción | OSC_POSE 7-DoF | OSC_POSE 7-DoF | OSC_POSE 7-DoF `[dx,dy,dz,droll,dpitch,dyaw,g]` |
+| Selección de norm-stats | `unnorm_key` en config | (baked en checkpoint) | `norm_stats`/`asset_id` baked (`physical-intelligence/libero`) |
+| Fix-up de gripper en eval | binariza + invierte (`_libero_action`) | normaliza + invierte | **ninguno** (baked en datos + norm_stats) |
+| `action_horizon` (chunk) | 1 | 40 (`ACTION_HORIZON`) | 10 (`pi05_libero`), 50 default de π0.5 |
+
+Nota sobre el horizonte: el default general de π0.5 es `chunk_size = 50` (ver
+sección de licencia/pesos), pero el `TrainConfig` `pi05_libero` de openpi usa
+`action_horizon=10`. Relevante para la pasarela de *chunking* de la pilot: el nº
+de acciones consumidas por consulta al pilot depende del checkpoint concreto, no
+de una constante global.
+
+### Implicaciones para la integración en odyssey
+
+1. **No añadir `unnorm_key` al YAML de π0.5.** El checkpoint `pi05_libero` es
+   autocontenido; la des-normalización viaja en `assets/`. Cualquier clave de
+   normalización en la config de una misión π0.5 sería inerte o engañosa.
+2. **El adaptador de acción de π0.5 recorta a 7-D y aplica sin fix-up de gripper**
+   — a diferencia del `VLARuntime`/`_libero_action` de OpenVLA. El
+   `ChunkPilotAdapter` (ver nota de multiagente) debe tratar π0.5 como
+   *chunk-emitting* y **no** reintroducir binarización/inversión de gripper salvo
+   que el smoke en GPU demuestre polaridad invertida.
+3. **La convención de estado es la misma Franka Panda** (8-D, quat xyzw→axis-angle,
+   2 gripper qpos), así que la construcción de observación se puede compartir con
+   el path de GR00T-LIBERO (`build_gr00t_libero_obs`) reordenando a las claves que
+   espera `openpi` (`observation/image`, `observation/wrist_image`,
+   `observation/state`), sin re-derivar la cinemática.
+
+### Fuentes
+
+- `openpi` — transforms LIBERO (`LiberoInputs`/`LiberoOutputs`, estado 8-D, recorte 7-D):
+  https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/policies/libero_policy.py
+- `openpi` — eval LIBERO (construcción de estado desde robosuite, `env.step` sin
+  inversión de gripper):
+  https://github.com/Physical-Intelligence/openpi/blob/main/examples/libero/main.py
+- `openpi` — config de entrenamiento (`LeRobotLiberoDataConfig`,
+  `asset_id = assets.asset_id or repo_id`, `norm_stats`, `pi05_libero`):
+  https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/training/config.py
+- Convención Franka Panda / gripper en el repo: `src/odyssey/runners/evals/libero.py:159`
+  (`_libero_action`), `src/odyssey/runners/evals/gr00t_transforms.py:172,218-270`
+  (estado y acción LIBERO_PANDA), `src/odyssey/runners/models/openvla.py:481,674`
+  (`unnorm_key`).
+
+**Conclusión:** el análogo de `unnorm_key` en π0.5 es el par
+`asset_id`/`norm_stats` **empaquetado en el checkpoint** — no una clave de
+misión. La observación (8-D Franka Panda: eef_pos + quat→axis-angle + 2 gripper
+qpos) y la acción (7-DoF OSC_POSE, recorte de las 32 dims del modelo) casan con la
+convención LIBERO/robosuite que ya usan OpenVLA y GR00T; la única diferencia
+operativa es que π0.5 **no requiere fix-up de gripper en evaluación** (pendiente
+de confirmar polaridad en GPU). **No se añade línea de BLOQUEO.**

--- a/docs/pi05-scoping.md
+++ b/docs/pi05-scoping.md
@@ -1,57 +1,57 @@
-# Scoping de pi0.5 (issue #74)
+# pi0.5 scoping (issue #74)
 
-## Licencia y pesos
+## License and weights
 
-### Resumen ejecutivo
+### Executive summary
 
-Los checkpoints de **π0.5 (pi05)** publicados por Physical Intelligence en el
-repositorio oficial `openpi` se distribuyen bajo **licencia Apache 2.0**. Apache
-2.0 es una licencia permisiva que **permite explícitamente el uso comercial**,
-la modificación, la distribución y el uso en despliegues privados/industriales,
-sin regalías, siempre que se conserven el aviso de copyright, el texto de la
-licencia y el fichero `NOTICE` (si existe) en las redistribuciones. **No hay
-cláusula de "solo investigación" ni restricción de uso comercial.**
+The **π0.5 (pi05)** checkpoints published by Physical Intelligence in the
+official `openpi` repository are distributed under the **Apache 2.0 license**. Apache
+2.0 is a permissive license that **explicitly permits commercial use**,
+modification, distribution, and use in private/industrial deployments,
+royalty-free, provided the copyright notice, license text, and `NOTICE` file (if
+present) are retained in redistributions. **There is no "research-only"
+clause and no commercial-use restriction.**
 
-→ Para el uso previsto (**despliegue industrial comercial**), la licencia **no
-supone un bloqueo**.
+→ For the intended use (**commercial industrial deployment**), the license **is
+not a blocker**.
 
-### Checkpoints disponibles abiertamente
+### Openly available checkpoints
 
-Physical Intelligence libera pesos de π0.5 por dos vías equivalentes: Google
-Cloud Storage (`gs://openpi-assets/...`, la fuente que consume el repo `openpi`)
-y el Hub de Hugging Face (mirror bajo la organización `lerobot`).
+Physical Intelligence releases π0.5 weights through two equivalent channels: Google
+Cloud Storage (`gs://openpi-assets/...`, the source consumed by the `openpi` repo)
+and the Hugging Face Hub (mirror under the `lerobot` organization).
 
-| Checkpoint | Ruta / repo | Uso previsto |
+| Checkpoint | Path / repo | Intended use |
 | --- | --- | --- |
-| **π0.5 base** | `gs://openpi-assets/checkpoints/pi05_base` · HF: [`lerobot/pi05_base`](https://huggingface.co/lerobot/pi05_base) | Fine-tuning (modelo generalista pre-entrenado en 10k+ h de datos de robot) |
-| **π0.5-LIBERO** | `gs://openpi-assets/checkpoints/pi05_libero` · HF: [`lerobot/pi05_libero`](https://huggingface.co/lerobot/pi05_libero) | Inferencia / benchmark LIBERO (SOTA) |
-| **π0.5-DROID** | `gs://openpi-assets/checkpoints/pi05_droid` | Inferencia / fine-tuning (fine-tuned sobre DROID con *knowledge insulation*, inferencia rápida y seguimiento de lenguaje) |
+| **π0.5 base** | `gs://openpi-assets/checkpoints/pi05_base` · HF: [`lerobot/pi05_base`](https://huggingface.co/lerobot/pi05_base) | Fine-tuning (generalist model pre-trained on 10k+ h of robot data) |
+| **π0.5-LIBERO** | `gs://openpi-assets/checkpoints/pi05_libero` · HF: [`lerobot/pi05_libero`](https://huggingface.co/lerobot/pi05_libero) | Inference / LIBERO benchmark (SOTA) |
+| **π0.5-DROID** | `gs://openpi-assets/checkpoints/pi05_droid` | Inference / fine-tuning (fine-tuned on DROID with *knowledge insulation*, fast inference and language following) |
 
-Notas:
-- π0.5 es la evolución de π0 orientada a **generalización open-world** (publicado
-  en septiembre de 2025).
-- El código del repo `openpi` está igualmente bajo Apache 2.0; la implementación
-  en LeRobot (`policy.type=pi05`) deriva del mismo repositorio y declara la misma
-  licencia Apache 2.0 para el modelo.
-- `chunk_size` por defecto de π0.5 = 50 (relevante para la pasarela de *chunking*
-  de la pilot).
+Notes:
+- π0.5 is the evolution of π0 oriented toward **open-world generalization** (published
+  in September 2025).
+- The `openpi` repo code is likewise under Apache 2.0; the LeRobot
+  implementation (`policy.type=pi05`) derives from the same repository and declares the same
+  Apache 2.0 license for the model.
+- π0.5 default `chunk_size` = 50 (relevant to the pilot's *chunking*
+  gateway).
 
-### Diligencia recomendada antes de producción
+### Recommended diligence before production
 
-Aunque la licencia es permisiva, para un despliegue comercial conviene:
-1. **Conservar `LICENSE`/`NOTICE`** de openpi en cualquier artefacto redistribuido
-   o imagen de contenedor que incluya los pesos.
-2. Verificar la **model card** de cada checkpoint en el Hub en el momento de la
-   descarga: Apache 2.0 aplica hoy, pero una tarjeta concreta podría añadir
-   términos de dataset (p. ej. DROID) o *acceptable use* — revisar antes de
-   fijar el pin.
-3. Comprobar la licencia de los **datasets** usados si se hace fine-tuning propio
-   (los pesos base son Apache 2.0, pero los datos de fine-tuning que aporte el
-   proyecto tienen su propia procedencia).
+Although the license is permissive, for a commercial deployment it is advisable to:
+1. **Retain openpi's `LICENSE`/`NOTICE`** in any redistributed artifact
+   or container image that includes the weights.
+2. Verify each checkpoint's **model card** on the Hub at download
+   time: Apache 2.0 applies today, but a specific card could add
+   dataset terms (e.g. DROID) or *acceptable use* terms — review before
+   pinning.
+3. Check the license of the **datasets** used if you do your own fine-tuning
+   (the base weights are Apache 2.0, but the fine-tuning data the project
+   provides has its own provenance).
 
-### Fuentes
+### Sources
 
-- Physical-Intelligence/openpi — repositorio y checkpoints (LICENSE = Apache 2.0):
+- Physical-Intelligence/openpi — repository and checkpoints (LICENSE = Apache 2.0):
   https://github.com/Physical-Intelligence/openpi
 - LICENSE (Apache License, Version 2.0):
   https://raw.githubusercontent.com/Physical-Intelligence/openpi/main/LICENSE
@@ -64,349 +64,349 @@ Aunque la licencia es permisiva, para un despliegue comercial conviene:
 - HF checkpoints: [`lerobot/pi05_base`](https://huggingface.co/lerobot/pi05_base),
   [`lerobot/pi05_libero`](https://huggingface.co/lerobot/pi05_libero)
 
-**Conclusión:** π0.5 se publica bajo **Apache 2.0**, que autoriza el uso
-comercial e industrial. **No se añade línea de BLOQUEO** — la licencia permite el
-uso previsto.
+**Conclusion:** π0.5 is published under **Apache 2.0**, which authorizes
+commercial and industrial use. **No BLOCKER line is added** — the license permits the
+intended use.
 
 ## FAST tokenizer
 
-### Resumen ejecutivo
+### Executive summary
 
-**FAST (Frequency-space Action Sequence Tokenization) está disponible como
-librería reusable — NO requiere reimplementación.** Physical Intelligence lo
-publica de dos formas complementarias, ambas bajo **Apache 2.0**:
+**FAST (Frequency-space Action Sequence Tokenization) is available as a
+reusable library — it does NOT require reimplementation.** Physical Intelligence
+publishes it in two complementary forms, both under **Apache 2.0**:
 
-1. **Como HuggingFace `AutoProcessor`** (checkpoint `physical-intelligence/fast`),
-   consumible en 3 líneas vía `transformers` + `scipy`, sin dependencia de openpi.
-2. **Wrapper `FASTTokenizer`** dentro de `openpi`
-   (`src/openpi/models/tokenizer.py`), que a su vez carga el mismo `AutoProcessor`
-   por debajo. Es la vía que usa el propio π0-FAST / π0.5 en entrenamiento.
+1. **As a HuggingFace `AutoProcessor`** (checkpoint `physical-intelligence/fast`),
+   consumable in 3 lines via `transformers` + `scipy`, with no openpi dependency.
+2. **`FASTTokenizer` wrapper** inside `openpi`
+   (`src/openpi/models/tokenizer.py`), which in turn loads the same `AutoProcessor`
+   underneath. It is the path used by π0-FAST / π0.5 itself in training.
 
-→ Para la pilot de π0.5, la tokenización de acciones **se reutiliza tal cual**; el
-único trabajo es de integración (normalización a `[-1, 1]`, wiring del chunk), no
-de reimplementar el algoritmo (DCT + cuantización estilo JPEG).
+→ For the π0.5 pilot, action tokenization **is reused as-is**; the
+only work is integration (normalization to `[-1, 1]`, chunk wiring), not
+reimplementing the algorithm (DCT + JPEG-style quantization).
 
-### Vía A — librería universal vía `transformers` (independiente de openpi)
+### Path A — universal library via `transformers` (independent of openpi)
 
-Requisitos: `pip install transformers scipy`. Checkpoint: `physical-intelligence/fast`
-(tokenizer **FAST+** universal, entrenado sobre 1M de secuencias de acción reales).
+Requirements: `pip install transformers scipy`. Checkpoint: `physical-intelligence/fast`
+(universal **FAST+** tokenizer, trained on 1M real action sequences).
 
 ```python
 from transformers import AutoProcessor
 import numpy as np
 
-# trust_remote_code=True: el algoritmo FAST viaja como código en el repo del Hub
+# trust_remote_code=True: the FAST algorithm travels as code in the Hub repo
 tokenizer = AutoProcessor.from_pretrained("physical-intelligence/fast", trust_remote_code=True)
 
-action_data = np.random.rand(256, 50, 14)  # (batch, time_horizon, action_dim), normalizado a [-1, 1]
-tokens = tokenizer(action_data)             # -> list[int]  (codificación con compresión)
-decoded = tokenizer.decode(tokens)          # -> acciones reconstruidas
+action_data = np.random.rand(256, 50, 14)  # (batch, time_horizon, action_dim), normalized to [-1, 1]
+tokens = tokenizer(action_data)             # -> list[int]  (encoding with compression)
+decoded = tokenizer.decode(tokens)          # -> reconstructed actions
 ```
 
-Notas de uso:
-- Recomendado para *chunks* de ~1 s **pre-normalizados a `[-1, 1]`**.
-- Encode/decode soportan **inferencia por lotes** (batched).
-- Se puede **entrenar un tokenizer propio** para un dataset concreto con
-  `tokenizer.fit(action_data)`, seguido de `save_pretrained(...)` /
-  `push_to_hub(...)`. Útil si las estadísticas de acción del embodiment objetivo
-  difieren mucho de FAST+.
+Usage notes:
+- Recommended for ~1 s *chunks* **pre-normalized to `[-1, 1]`**.
+- Encode/decode support **batched inference**.
+- You can **train your own tokenizer** for a specific dataset with
+  `tokenizer.fit(action_data)`, followed by `save_pretrained(...)` /
+  `push_to_hub(...)`. Useful if the target embodiment's action statistics
+  differ significantly from FAST+.
 
-### Vía B — wrapper `FASTTokenizer` en openpi (la que usa π0.5)
+### Path B — `FASTTokenizer` wrapper in openpi (the one π0.5 uses)
 
-En `openpi`, la clase `FASTTokenizer` (`src/openpi/models/tokenizer.py`) envuelve
-el mismo `AutoProcessor` y añade el ensamblado con el tokenizer de lenguaje del VLM:
+In `openpi`, the `FASTTokenizer` class (`src/openpi/models/tokenizer.py`) wraps
+the same `AutoProcessor` and adds the assembly with the VLM's language tokenizer:
 
 ```python
-# openpi (resumido)
+# openpi (abridged)
 self._fast_tokenizer = AutoProcessor.from_pretrained(fast_tokenizer_path, trust_remote_code=True)
-#   fast_tokenizer_path por defecto = "physical-intelligence/fast"
+#   fast_tokenizer_path default = "physical-intelligence/fast"
 
 action_tokens = self._fast_tokenizer(actions[None])[0]                    # tokenize()
 ... = self._fast_tokenizer.decode([action_tokens.tolist()],              # extract_actions()
                                   time_horizon=action_horizon, action_dim=action_dim)[0]
 ```
 
-Implicación para la pilot: si se apoya en el stack de `openpi` para π0.5, la
-tokenización llega **gratis** con el repo (mismo checkpoint del Hub por debajo);
-no hay que traer una dependencia extra ni reimplementar nada.
+Implication for the pilot: if you rely on the `openpi` stack for π0.5,
+tokenization comes **free** with the repo (same Hub checkpoint underneath);
+there is no need to bring an extra dependency or reimplement anything.
 
-### Cómo funciona (por qué "frequency-space")
+### How it works (why "frequency-space")
 
-FAST comprime cada secuencia de acción mediante: (1) normalización, (2) **DCT
-(Discrete Cosine Transform)** por dimensión de acción, y (3) cuantización que
-redondea/descarta coeficientes poco significativos — el mismo principio de
-compresión que JPEG (imagen) o MP3 (audio). Esto permite entrenar VLA
-**autorregresivas** sobre acciones de alta frecuencia/destreza, alcanzando la
-destreza de flow-matching/diffusion con ~5× menos tiempo de entrenamiento.
+FAST compresses each action sequence via: (1) normalization, (2) **DCT
+(Discrete Cosine Transform)** per action dimension, and (3) quantization that
+rounds/discards insignificant coefficients — the same compression principle
+as JPEG (image) or MP3 (audio). This allows training **autoregressive** VLAs
+on high-frequency/dexterous actions, reaching the dexterity of
+flow-matching/diffusion with ~5× less training time.
 
-### Fuentes
+### Sources
 
-- Modelo/tokenizer universal en el Hub (Apache 2.0), con ejemplo de uso y `.fit()`:
+- Universal model/tokenizer on the Hub (Apache 2.0), with usage example and `.fit()`:
   https://huggingface.co/physical-intelligence/fast
   · README: https://huggingface.co/physical-intelligence/fast/blob/main/README.md
-- Wrapper `FASTTokenizer` en openpi:
+- `FASTTokenizer` wrapper in openpi:
   https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/models/tokenizer.py
 - Paper "FAST: Efficient Action Tokenization for Vision-Language-Action Models":
   https://arxiv.org/abs/2501.09747 · PDF: https://www.pi.website/download/fast.pdf
-- Página de research (resumen + figuras): https://www.pi.website/research/fast
-- Integración en LeRobot (π0-FAST policy, misma licencia Apache 2.0):
+- Research page (summary + figures): https://www.pi.website/research/fast
+- LeRobot integration (π0-FAST policy, same Apache 2.0 license):
   https://huggingface.co/docs/lerobot/pi0fast
-  · mirror del tokenizer: https://huggingface.co/lerobot/fast-action-tokenizer
+  · tokenizer mirror: https://huggingface.co/lerobot/fast-action-tokenizer
 
-**Conclusión:** FAST **es reusable como librería** (`AutoProcessor` del Hub o el
-wrapper `FASTTokenizer` de openpi), Apache 2.0. **No se requiere
-reimplementación** — solo integración (normalización + wiring del chunk). **No se
-añade línea de BLOQUEO.**
+**Conclusion:** FAST **is reusable as a library** (`AutoProcessor` from the Hub or the
+`FASTTokenizer` wrapper in openpi), Apache 2.0. **No
+reimplementation is required** — only integration (normalization + chunk wiring). **No
+BLOCKER line is added.**
 
-## VRAM footprint (estimado)
+## VRAM footprint (estimate)
 
-> ⚠️ **NO VERIFICADO EN HARDWARE.** Todas las cifras de esta sección son una
-> estimación **analítica** (parámetros × precisión + KV cache + overhead de
-> runtime). **No** proceden de una medición real en GPU (`nvidia-smi`, perfilado
-> de memoria, ni OOM observados). Sirven para dimensionar *a priori* la
-> co-residencia; hay que confirmarlas en una L4 real antes de fijar cualquier
-> decisión de despliegue.
+> ⚠️ **NOT VERIFIED ON HARDWARE.** All figures in this section are an
+> **analytical** estimate (parameters × precision + KV cache + runtime
+> overhead). They do **not** come from a real GPU measurement (`nvidia-smi`, memory
+> profiling, or observed OOM). They serve to size co-residence *a priori*;
+> they must be confirmed on a real L4 before fixing any
+> deployment decision.
 
-### Objetivo
+### Objective
 
-¿Caben **π0.5 (pilot)** y un **Specialist tipo Gemma** (juez/grounding,
-cuantizado int4) **co-residentes** en una única **NVIDIA L4 de 24 GB**?
+Do **π0.5 (pilot)** and a **Gemma-type Specialist** (judge/grounding,
+int4-quantized) fit **co-resident** on a single **24 GB NVIDIA L4**?
 
-### Supuestos de partida
+### Starting assumptions
 
-| Parámetro | Valor asumido | Base del supuesto |
+| Parameter | Assumed value | Assumption basis |
 | --- | --- | --- |
-| Arquitectura π0.5 | PaliGemma-3B (SigLIP ViT ~0.4B + Gemma-2B) + *action expert* ~0.3B | Misma familia que π0/π0.5 en openpi; ≈ **3.3B parámetros** totales |
-| Precisión de inferencia π0.5 | **bf16** (2 bytes/parám) | openpi/JAX corre en bf16 por defecto |
-| Contexto (tokens de prefijo) | ~1–2k tokens (256 tok/imagen × ~2–3 cámaras + lenguaje) | Config típica de π0.5 multi-cámara |
-| `chunk_size` | 50 | Ya documentado arriba (default π0.5) |
-| Specialist | Gemma **int4** (≈4B) VLM juez | Nota de memoria: `check_done` = "Gemma int4" |
-| Precisión Specialist | int4 (~0.5 byte/parám efectivo + escalas) | Cuantización GPTQ/AWQ-style |
+| π0.5 architecture | PaliGemma-3B (SigLIP ViT ~0.4B + Gemma-2B) + *action expert* ~0.3B | Same family as π0/π0.5 in openpi; ≈ **3.3B parameters** total |
+| π0.5 inference precision | **bf16** (2 bytes/param) | openpi/JAX runs in bf16 by default |
+| Context (prefix tokens) | ~1–2k tokens (256 tok/image × ~2–3 cameras + language) | Typical multi-camera π0.5 config |
+| `chunk_size` | 50 | Documented above (π0.5 default) |
+| Specialist | Gemma **int4** (≈4B) VLM judge | Memory note: `check_done` = "Gemma int4" |
+| Specialist precision | int4 (~0.5 byte/param effective + scales) | GPTQ/AWQ-style quantization |
 
-### Desglose analítico
+### Analytical breakdown
 
-**1. Pesos de π0.5 (bf16)**
+**1. π0.5 weights (bf16)**
 - 3.3B × 2 bytes ≈ **6.6 GB**
-- (Si se corriese en fp32 se duplicaría a ~13.2 GB → la co-residencia dejaría de
-  ser cómoda; **usar bf16/fp16 es un requisito**, no una optimización.)
+- (If run in fp32 it would double to ~13.2 GB → co-residence would no longer be
+  comfortable; **using bf16/fp16 is a requirement**, not an optimization.)
 
-**2. KV cache de π0.5** — *despreciable*
-- Gemma-2B usa MQA (≈1 KV head, head_dim 256, 18 capas).
-- Por token: `2 (K,V) × 18 capas × 1 KV head × 256 × 2 bytes ≈ 18 KB/token`.
-- Con ~2k tokens de contexto: **~0.04 GB**. Incluso con márgenes generosos, < 0.1 GB.
-- Razón: a diferencia de un chat LLM, el contexto es corto y fijo (prefijo de
-  imágenes + instrucción); no crece por decodificación larga.
+**2. π0.5 KV cache** — *negligible*
+- Gemma-2B uses MQA (≈1 KV head, head_dim 256, 18 layers).
+- Per token: `2 (K,V) × 18 layers × 1 KV head × 256 × 2 bytes ≈ 18 KB/token`.
+- With ~2k context tokens: **~0.04 GB**. Even with generous margins, < 0.1 GB.
+- Reason: unlike a chat LLM, the context is short and fixed (image
+  prefix + instruction); it does not grow with long decoding.
 
-**3. Activaciones / workspace de inferencia (batch 1)**
-- Encoder de visión (SigLIP) + atención del backbone + muestreo del *action
-  expert* (varios pasos de denoising que reutilizan buffers): **~1–2 GB**.
+**3. Activations / inference workspace (batch 1)**
+- Vision encoder (SigLIP) + backbone attention + *action expert* sampling
+  (several denoising steps that reuse buffers): **~1–2 GB**.
 
-**4. Overhead de runtime (contexto CUDA + XLA/cuDNN)**
-- Contexto CUDA, kernels, cuDNN/cuBLAS workspaces de **dos** frameworks
-  co-residentes (JAX para π0.5 + PyTorch para el Specialist): **~1–1.5 GB**.
+**4. Runtime overhead (CUDA context + XLA/cuDNN)**
+- CUDA context, kernels, cuDNN/cuBLAS workspaces of **two** co-resident
+  frameworks (JAX for π0.5 + PyTorch for the Specialist): **~1–1.5 GB**.
 
 **5. Specialist Gemma int4 (≈4B)**
-- Pesos: 4B × 0.5 byte ≈ 2.0 GB + escalas/zeros del esquema int4 (~+10–15%) ≈
+- Weights: 4B × 0.5 byte ≈ 2.0 GB + int4 scheme scales/zeros (~+10–15%) ≈
   **~2.3 GB**.
-- KV cache + activaciones + (si es VLM) tokens de imagen: **~0.5–0.7 GB**.
-- Subtotal Specialist: **~3.0 GB**.
-- (Si el Specialist fuese un Gemma-2B int4, bajaría a ~1.2 GB de pesos → ~1.7 GB
-  totales.)
+- KV cache + activations + (if VLM) image tokens: **~0.5–0.7 GB**.
+- Specialist subtotal: **~3.0 GB**.
+- (If the Specialist were a Gemma-2B int4, it would drop to ~1.2 GB of weights → ~1.7 GB
+  total.)
 
-### Total estimado
+### Estimated total
 
-| Componente | VRAM (GB) |
+| Component | VRAM (GB) |
 | --- | --- |
-| π0.5 pesos (bf16) | 6.6 |
+| π0.5 weights (bf16) | 6.6 |
 | π0.5 KV cache | ~0.05 |
-| π0.5 activaciones/workspace | 1.5 |
-| Overhead runtime (CUDA + XLA/cuDNN, 2 frameworks) | 1.5 |
+| π0.5 activations/workspace | 1.5 |
+| Runtime overhead (CUDA + XLA/cuDNN, 2 frameworks) | 1.5 |
 | Specialist Gemma int4 (~4B) | 3.0 |
 | **Total** | **≈ 12.6 GB** |
 
-**Sobre L4 (24 GB): ~12.6 GB usados → ~11 GB de holgura (~52% libre).**
+**On L4 (24 GB): ~12.6 GB used → ~11 GB of headroom (~52% free).**
 
-Rango con incertidumbre (peor caso de activaciones/overhead y Specialist 4B):
-**~11–15 GB**. La co-residencia **cabe con margen cómodo** en la estimación; el
-riesgo no es el *tamaño* estático sino la **gestión de asignación** (ver abajo).
+Range with uncertainty (worst case of activations/overhead and 4B Specialist):
+**~11–15 GB**. Co-residence **fits with a comfortable margin** in the estimate; the
+risk is not the static *size* but **allocation management** (see below).
 
-### Caveats críticos para la co-residencia (riesgos operativos, no de tamaño)
+### Critical caveats for co-residence (operational risks, not size risks)
 
-1. **Preasignación de JAX/XLA (riesgo #1).** Por defecto JAX reserva el **75–90%
-   de la VRAM** al arrancar, lo que **mataría por OOM** al Specialist de PyTorch
-   aunque el footprint real quepa. **Obligatorio** fijar
-   `XLA_PYTHON_CLIENT_PREALLOCATE=false` o
-   `XLA_PYTHON_CLIENT_MEM_FRACTION=~0.5` para acotar a π0.5.
-2. **Fragmentación entre dos allocators.** JAX y PyTorch mantienen pools de
-   memoria independientes; la suma nominal puede caber pero la fragmentación
-   reduce el máximo asignable contiguo. Considerar
+1. **JAX/XLA preallocation (risk #1).** By default JAX reserves **75–90%
+   of VRAM** at startup, which would **kill the PyTorch Specialist by OOM**
+   even if the real footprint fits. It is **mandatory** to set
+   `XLA_PYTHON_CLIENT_PREALLOCATE=false` or
+   `XLA_PYTHON_CLIENT_MEM_FRACTION=~0.5` to bound π0.5.
+2. **Fragmentation between two allocators.** JAX and PyTorch maintain
+   independent memory pools; the nominal sum may fit but fragmentation
+   reduces the maximum contiguous allocatable block. Consider
    `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`.
-3. **Precisión.** El cálculo asume bf16 para π0.5; en fp32 no cabría con holgura.
-4. **Tamaño real del Specialist sin confirmar.** "Gemma int4" no fija variante
-   (2B vs 4B vs 3-4B VLM) ni esquema de cuantización — cambia el subtotal en
-   ±1.3 GB. Confirmar el checkpoint exacto.
-5. **Picos transitorios en carga.** La carga de checkpoints (dequant int4,
-   conversión de dtype) puede exigir un pico temporal por encima del estado
-   estacionario; secuenciar las cargas (no cargar ambos modelos en paralelo).
+3. **Precision.** The calculation assumes bf16 for π0.5; in fp32 it would not fit with headroom.
+4. **Actual Specialist size unconfirmed.** "Gemma int4" does not fix the variant
+   (2B vs 4B vs 3-4B VLM) nor the quantization scheme — it changes the subtotal by
+   ±1.3 GB. Confirm the exact checkpoint.
+5. **Transient peaks at load.** Loading checkpoints (int4 dequant,
+   dtype conversion) may demand a temporary peak above the steady
+   state; sequence the loads (do not load both models in parallel).
 
-### Cómo verificarlo en hardware (pendiente)
+### How to verify it on hardware (pending)
 
-- `nvidia-smi --query-gpu=memory.used --format=csv -l 1` durante un rollout
-  co-residente.
-- `torch.cuda.max_memory_allocated()` para el Specialist y el *memory profiler*
-  de JAX (`jax.profiler` / `XLA_FLAGS=--xla_dump...`) para π0.5.
-- Prueba de estrés: rollout completo (chunk 50) con ambos modelos activos y
-  medición de pico, no de media.
+- `nvidia-smi --query-gpu=memory.used --format=csv -l 1` during a co-resident
+  rollout.
+- `torch.cuda.max_memory_allocated()` for the Specialist and JAX's *memory profiler*
+  (`jax.profiler` / `XLA_FLAGS=--xla_dump...`) for π0.5.
+- Stress test: full rollout (chunk 50) with both models active and
+  peak measurement, not average.
 
-## Mapeo de espacio de acción
+## Action space mapping
 
-### Resumen ejecutivo
+### Executive summary
 
-La pregunta operativa es: **¿cuál es el `unnorm_key` de π0.5?** Respuesta corta:
-π0.5 **no expone un `unnorm_key` en la config de la misión**. El papel que en
-OpenVLA juega el string `unnorm_key` (seleccionar, en tiempo de inferencia, qué
-estadísticas de des-normalización aplicar a la acción) lo cubre en `openpi` un
-fichero **`norm_stats`** que viene **empaquetado dentro del propio checkpoint**
-(bajo `assets/<asset_id>/`) y se selecciona por el **`repo_id`/`asset_id`** con el
-que se entrenó — no por una clave que el usuario pase en la config. Para
-`pi05_libero` ese `asset_id` es `physical-intelligence/libero`.
+The operational question is: **what is π0.5's `unnorm_key`?** Short answer:
+π0.5 **does not expose an `unnorm_key` in the mission config**. The role that the
+string `unnorm_key` plays in OpenVLA (selecting, at inference time, which
+de-normalization statistics to apply to the action) is covered in `openpi` by a
+**`norm_stats`** file that comes **packaged inside the checkpoint itself**
+(under `assets/<asset_id>/`) and is selected by the **`repo_id`/`asset_id`** it
+was trained with — not by a key the user passes in the config. For
+`pi05_libero` that `asset_id` is `physical-intelligence/libero`.
 
-→ Consecuencia práctica para la pilot: donde OpenVLA lleva
-`config.unnorm_key: libero_object`, **π0.5-LIBERO no lleva ninguna clave
-equivalente** en el YAML. La normalización correcta viaja con los pesos. El
-"knob" análogo solo existe en *entrenamiento* (elegir el `repo_id`/`norm_stats`
-del embodiment), no en *evaluación*.
+→ Practical consequence for the pilot: where OpenVLA carries
+`config.unnorm_key: libero_object`, **π0.5-LIBERO carries no
+equivalent key** in the YAML. The correct normalization travels with the weights. The
+analogous "knob" only exists in *training* (choosing the embodiment's
+`repo_id`/`norm_stats`), not in *evaluation*.
 
-### El análogo exacto de `unnorm_key`
+### The exact analog of `unnorm_key`
 
 | | OpenVLA (`predict_action`) | π0.5 / `openpi` |
 | --- | --- | --- |
-| Qué normaliza | La acción de salida (7-D), de espacio normalizado → unidades físicas del robot | Estado de entrada **y** acción de salida (chunk), vía `Normalize`/`Unnormalize` |
-| Dónde viven las estadísticas | `dataset_statistics` dentro del `config.json` del checkpoint (varios datasets a la vez) | `norm_stats.json` bajo `assets/<asset_id>/` del checkpoint (uno por embodiment) |
-| Cómo se selecciona | String `unnorm_key` pasado en inferencia (`predict_action(..., unnorm_key=...)`) | Implícito: `asset_id = assets.asset_id or repo_id`, fijado al entrenar |
-| Superficie en la misión | `config.unnorm_key` (obligatorio, debe casar suite/checkpoint) | **ninguna** — el checkpoint es autocontenido |
-| Fallo típico | `unnorm_key` mal → acciones a escala equivocada, arm errático | (no aplica en eval) checkpoint/repo_id equivocado al entrenar |
+| What it normalizes | The output action (7-D), from normalized space → robot physical units | Input state **and** output action (chunk), via `Normalize`/`Unnormalize` |
+| Where the statistics live | `dataset_statistics` inside the checkpoint's `config.json` (multiple datasets at once) | `norm_stats.json` under the checkpoint's `assets/<asset_id>/` (one per embodiment) |
+| How it is selected | `unnorm_key` string passed at inference (`predict_action(..., unnorm_key=...)`) | Implicit: `asset_id = assets.asset_id or repo_id`, fixed at training |
+| Mission surface | `config.unnorm_key` (required, must match suite/checkpoint) | **none** — the checkpoint is self-contained |
+| Typical failure | wrong `unnorm_key` → actions at the wrong scale, erratic arm | (n/a in eval) wrong checkpoint/repo_id at training |
 
-Referencia en el repo del lado OpenVLA: `src/odyssey/runners/models/openvla.py:481`
-(`unnorm_key = cfg.get("unnorm_key", "bridge_orig")`) y su paso a
+Reference in the repo on the OpenVLA side: `src/odyssey/runners/models/openvla.py:481`
+(`unnorm_key = cfg.get("unnorm_key", "bridge_orig")`) and its passing to
 `model.predict_action(..., unnorm_key=self._unnorm_key)`
 (`openvla.py:674`).
 
-### Espacio de observación de π0.5-LIBERO
+### π0.5-LIBERO observation space
 
-`openpi` normaliza la observación LIBERO al mismo *embodiment* Franka Panda que
-consume el resto del stack (robosuite/LIBERO), a través de `LiberoInputs`:
+`openpi` normalizes the LIBERO observation to the same Franka Panda *embodiment* that
+the rest of the stack consumes (robosuite/LIBERO), through `LiberoInputs`:
 
-- **Imágenes** (3 entradas del modelo, familia PaliGemma/Pi0):
-  - `base_0_rgb` ← vista cenital de tercera persona (`observation/image`, `agentview`).
-  - `left_wrist_0_rgb` ← cámara de muñeca (`observation/wrist_image`).
-  - `right_wrist_0_rgb` ← **rellena a ceros** (LIBERO es de un brazo; se enmascara
-    con `image_mask`).
-  - Formato normalizado a `uint8 (H, W, C)`.
-- **Estado propioceptivo, 8-D** (idéntico a la convención Franka Panda de
-  robosuite/LIBERO):
+- **Images** (3 model inputs, PaliGemma/Pi0 family):
+  - `base_0_rgb` ← third-person overhead view (`observation/image`, `agentview`).
+  - `left_wrist_0_rgb` ← wrist camera (`observation/wrist_image`).
+  - `right_wrist_0_rgb` ← **zero-filled** (LIBERO is single-arm; masked
+    with `image_mask`).
+  - Format normalized to `uint8 (H, W, C)`.
+- **Proprioceptive state, 8-D** (identical to the robosuite/LIBERO Franka Panda
+  convention):
 
   ```python
   state = np.concatenate([
-      obs["robot0_eef_pos"],                    # (3) posición EEF x,y,z
-      quat2axisangle(obs["robot0_eef_quat"]),   # (3) orientación EEF: quat xyzw -> eje-ángulo
-      obs["robot0_gripper_qpos"],               # (2) qpos de las dos falanges del gripper
+      obs["robot0_eef_pos"],                    # (3) EEF position x,y,z
+      quat2axisangle(obs["robot0_eef_quat"]),   # (3) EEF orientation: quat xyzw -> axis-angle
+      obs["robot0_gripper_qpos"],               # (2) qpos of the two gripper phalanges
   ])                                            # -> 8-D
   ```
 
-  Este es exactamente el mismo vector de estado que construye el eval de LIBERO de
-  NVIDIA para GR00T (`quat_xyzw_to_axis_angle` en
-  `src/odyssey/runners/evals/gr00t_transforms.py:172`) y que OpenVLA asume
-  implícitamente. La conversión clave de convención es
-  **quaternion `xyzw` (robosuite) → eje-ángulo** vía `quat2axisangle`.
-- **Padding a la dimensión del modelo:** el estado 8-D se rellena con ceros hasta
-  `action_dim` del modelo (**32** en la familia Pi0) mediante `pad_to_dim` /
-  `PadStatesAndActions`, y luego se **normaliza** con `norm_stats`. El *prompt* de
-  lenguaje se toma de la tarea (`prompt_from_task=True`).
+  This is exactly the same state vector that NVIDIA's LIBERO eval builds for
+  GR00T (`quat_xyzw_to_axis_angle` in
+  `src/odyssey/runners/evals/gr00t_transforms.py:172`) and that OpenVLA assumes
+  implicitly. The key convention conversion is
+  **quaternion `xyzw` (robosuite) → axis-angle** via `quat2axisangle`.
+- **Padding to the model dimension:** the 8-D state is zero-padded up to
+  the model's `action_dim` (**32** in the Pi0 family) via `pad_to_dim` /
+  `PadStatesAndActions`, and then **normalized** with `norm_stats`. The language
+  *prompt* is taken from the task (`prompt_from_task=True`).
 
-### Espacio de acción de π0.5-LIBERO
+### π0.5-LIBERO action space
 
-El modelo emite un **chunk** de acciones normalizadas de forma
-`(action_horizon, 32)`; `LiberoOutputs` lo des-normaliza (con el mismo
-`norm_stats`) y **recorta las 32 dims al 7-DoF de LIBERO**:
+The model emits a **chunk** of normalized actions of shape
+`(action_horizon, 32)`; `LiberoOutputs` de-normalizes it (with the same
+`norm_stats`) and **crops the 32 dims to LIBERO's 7-DoF**:
 
 ```python
 # openpi LiberoOutputs
-return {"actions": np.asarray(data["actions"][..., :7])}   # el resto es padding
+return {"actions": np.asarray(data["actions"][..., :7])}   # the rest is padding
 ```
 
-Las 7 dims son la acción **OSC_POSE** nativa de LIBERO/Franka Panda:
-`[dx, dy, dz, droll, dpitch, dyaw, gripper]` (delta de pose EEF + gripper), que se
-aplica **directamente** a `env.step(action.tolist())`.
+The 7 dims are LIBERO/Franka Panda's native **OSC_POSE** action:
+`[dx, dy, dz, droll, dpitch, dyaw, gripper]` (EEF pose delta + gripper), which is
+applied **directly** to `env.step(action.tolist())`.
 
-**Diferencia crítica frente a OpenVLA — el gripper NO se re-procesa.** En OpenVLA
-el eval de odyssey aplica `_libero_action` (`src/odyssey/runners/evals/libero.py:159`):
-re-escala el gripper `[0,1]→[-1,1]`, lo **binariza** y lo **invierte** para casar
-el signo de LIBERO. En π0.5/`openpi` **no hay** ese fix-up en evaluación: el
-checkpoint se entrenó sobre datos ya en la convención de gripper de LIBERO y las
-`norm_stats` fijan la escala, así que la salida se pasa tal cual a `env.step`
-(igual criterio que `examples/libero/main.py` de openpi, sin `binarize`/`invert`).
-Contrasta también con GR00T-N1.7-LIBERO, que **sí** aplica
+**Critical difference from OpenVLA — the gripper is NOT re-processed.** In OpenVLA
+odyssey's eval applies `_libero_action` (`src/odyssey/runners/evals/libero.py:159`):
+it re-scales the gripper `[0,1]→[-1,1]`, **binarizes** it and **inverts** it to match
+LIBERO's sign. In π0.5/`openpi` there is **no** such fix-up in evaluation: the
+checkpoint was trained on data already in LIBERO's gripper convention and the
+`norm_stats` fix the scale, so the output is passed as-is to `env.step`
+(same criterion as openpi's `examples/libero/main.py`, without `binarize`/`invert`).
+It also contrasts with GR00T-N1.7-LIBERO, which **does** apply
 `normalize_gripper_action` + `invert_gripper_action`
-(`gr00t_transforms.py:218-228`) porque su checkpoint emite el gripper en `[0,1]`.
+(`gr00t_transforms.py:218-228`) because its checkpoint emits the gripper in `[0,1]`.
 
-> ⚠️ **Verificar la polaridad del gripper en el primer rollout en GPU.** Aunque la
-> teoría dice "sin fix-up", un signo de gripper invertido es un fallo silencioso
-> clásico (el brazo se mueve y se aproxima pero nunca agarra). Es el mismo footgun
-> anotado para GR00T; confirmarlo contra el servidor π0.5 antes de fijar la config.
+> ⚠️ **Verify gripper polarity on the first GPU rollout.** Although the
+> theory says "no fix-up", an inverted gripper sign is a classic silent
+> failure (the arm moves and approaches but never grasps). It is the same footgun
+> noted for GR00T; confirm it against the π0.5 server before fixing the config.
 
-### Tabla comparativa de los tres pilots sobre LIBERO/Franka Panda
+### Comparative table of the three pilots on LIBERO/Franka Panda
 
 | | OpenVLA-7B | GR00T-N1.7-LIBERO | **π0.5-LIBERO** |
 | --- | --- | --- | --- |
-| Estado de entrada | (implícito) | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos |
-| Acción emitida | 1 paso 7-D | chunk 7-D (`action.*`, absoluta) | **chunk** `(H, 32)` → recorte 7-D |
-| Espacio de acción | OSC_POSE 7-DoF | OSC_POSE 7-DoF | OSC_POSE 7-DoF `[dx,dy,dz,droll,dpitch,dyaw,g]` |
-| Selección de norm-stats | `unnorm_key` en config | (baked en checkpoint) | `norm_stats`/`asset_id` baked (`physical-intelligence/libero`) |
-| Fix-up de gripper en eval | binariza + invierte (`_libero_action`) | normaliza + invierte | **ninguno** (baked en datos + norm_stats) |
-| `action_horizon` (chunk) | 1 | 40 (`ACTION_HORIZON`) | 10 (`pi05_libero`), 50 default de π0.5 |
+| Input state | (implicit) | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos | 8-D: eef_pos + quat→axis-angle + 2 gripper qpos |
+| Emitted action | 1 step 7-D | chunk 7-D (`action.*`, absolute) | **chunk** `(H, 32)` → 7-D crop |
+| Action space | OSC_POSE 7-DoF | OSC_POSE 7-DoF | OSC_POSE 7-DoF `[dx,dy,dz,droll,dpitch,dyaw,g]` |
+| Norm-stats selection | `unnorm_key` in config | (baked in checkpoint) | `norm_stats`/`asset_id` baked (`physical-intelligence/libero`) |
+| Gripper fix-up in eval | binarize + invert (`_libero_action`) | normalize + invert | **none** (baked in data + norm_stats) |
+| `action_horizon` (chunk) | 1 | 40 (`ACTION_HORIZON`) | 10 (`pi05_libero`), 50 π0.5 default |
 
-Nota sobre el horizonte: el default general de π0.5 es `chunk_size = 50` (ver
-sección de licencia/pesos), pero el `TrainConfig` `pi05_libero` de openpi usa
-`action_horizon=10`. Relevante para la pasarela de *chunking* de la pilot: el nº
-de acciones consumidas por consulta al pilot depende del checkpoint concreto, no
-de una constante global.
+Note on the horizon: π0.5's general default is `chunk_size = 50` (see
+license/weights section), but openpi's `pi05_libero` `TrainConfig` uses
+`action_horizon=10`. Relevant to the pilot's *chunking* gateway: the number
+of actions consumed per pilot query depends on the specific checkpoint, not
+on a global constant.
 
-### Implicaciones para la integración en odyssey
+### Implications for odyssey integration
 
-1. **No añadir `unnorm_key` al YAML de π0.5.** El checkpoint `pi05_libero` es
-   autocontenido; la des-normalización viaja en `assets/`. Cualquier clave de
-   normalización en la config de una misión π0.5 sería inerte o engañosa.
-2. **El adaptador de acción de π0.5 recorta a 7-D y aplica sin fix-up de gripper**
-   — a diferencia del `VLARuntime`/`_libero_action` de OpenVLA. El
-   `ChunkPilotAdapter` (ver nota de multiagente) debe tratar π0.5 como
-   *chunk-emitting* y **no** reintroducir binarización/inversión de gripper salvo
-   que el smoke en GPU demuestre polaridad invertida.
-3. **La convención de estado es la misma Franka Panda** (8-D, quat xyzw→axis-angle,
-   2 gripper qpos), así que la construcción de observación se puede compartir con
-   el path de GR00T-LIBERO (`build_gr00t_libero_obs`) reordenando a las claves que
-   espera `openpi` (`observation/image`, `observation/wrist_image`,
-   `observation/state`), sin re-derivar la cinemática.
+1. **Do not add `unnorm_key` to the π0.5 YAML.** The `pi05_libero` checkpoint is
+   self-contained; de-normalization travels in `assets/`. Any normalization
+   key in a π0.5 mission config would be inert or misleading.
+2. **The π0.5 action adapter crops to 7-D and applies without gripper fix-up**
+   — unlike OpenVLA's `VLARuntime`/`_libero_action`. The
+   `ChunkPilotAdapter` (see multiagent note) must treat π0.5 as
+   *chunk-emitting* and **not** reintroduce gripper binarization/inversion unless
+   the GPU smoke demonstrates inverted polarity.
+3. **The state convention is the same Franka Panda** (8-D, quat xyzw→axis-angle,
+   2 gripper qpos), so the observation construction can be shared with the
+   GR00T-LIBERO path (`build_gr00t_libero_obs`) by reordering to the keys that
+   `openpi` expects (`observation/image`, `observation/wrist_image`,
+   `observation/state`), without re-deriving the kinematics.
 
-### Fuentes
+### Sources
 
-- `openpi` — transforms LIBERO (`LiberoInputs`/`LiberoOutputs`, estado 8-D, recorte 7-D):
+- `openpi` — LIBERO transforms (`LiberoInputs`/`LiberoOutputs`, 8-D state, 7-D crop):
   https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/policies/libero_policy.py
-- `openpi` — eval LIBERO (construcción de estado desde robosuite, `env.step` sin
-  inversión de gripper):
+- `openpi` — LIBERO eval (state construction from robosuite, `env.step` without
+  gripper inversion):
   https://github.com/Physical-Intelligence/openpi/blob/main/examples/libero/main.py
-- `openpi` — config de entrenamiento (`LeRobotLiberoDataConfig`,
+- `openpi` — training config (`LeRobotLiberoDataConfig`,
   `asset_id = assets.asset_id or repo_id`, `norm_stats`, `pi05_libero`):
   https://github.com/Physical-Intelligence/openpi/blob/main/src/openpi/training/config.py
-- Convención Franka Panda / gripper en el repo: `src/odyssey/runners/evals/libero.py:159`
+- Franka Panda / gripper convention in the repo: `src/odyssey/runners/evals/libero.py:159`
   (`_libero_action`), `src/odyssey/runners/evals/gr00t_transforms.py:172,218-270`
-  (estado y acción LIBERO_PANDA), `src/odyssey/runners/models/openvla.py:481,674`
+  (LIBERO_PANDA state and action), `src/odyssey/runners/models/openvla.py:481,674`
   (`unnorm_key`).
 
-**Conclusión:** el análogo de `unnorm_key` en π0.5 es el par
-`asset_id`/`norm_stats` **empaquetado en el checkpoint** — no una clave de
-misión. La observación (8-D Franka Panda: eef_pos + quat→axis-angle + 2 gripper
-qpos) y la acción (7-DoF OSC_POSE, recorte de las 32 dims del modelo) casan con la
-convención LIBERO/robosuite que ya usan OpenVLA y GR00T; la única diferencia
-operativa es que π0.5 **no requiere fix-up de gripper en evaluación** (pendiente
-de confirmar polaridad en GPU). **No se añade línea de BLOQUEO.**
+**Conclusion:** the analog of `unnorm_key` in π0.5 is the
+`asset_id`/`norm_stats` pair **packaged in the checkpoint** — not a mission
+key. The observation (8-D Franka Panda: eef_pos + quat→axis-angle + 2 gripper
+qpos) and the action (7-DoF OSC_POSE, cropping the model's 32 dims) match the
+LIBERO/robosuite convention that OpenVLA and GR00T already use; the only
+operational difference is that π0.5 **requires no gripper fix-up in evaluation** (pending
+polarity confirmation on GPU). **No BLOCKER line is added.**

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,10 @@
 | `quickstart-gr00t/` | GR00T N1.7 3B fine-tune on the Isaac-GR00T demo set + Isaac Lab eval. | 24 GB+ GPU for training; eval mock-only until the Isaac Lab runner lands |
 | `multiagent-openvla-gemma/` | Multi-agent eval: OpenVLA **PILOT** + an out-of-process multimodal Gemma 4 **SPECIALIST** planner, on Robosuite Lift. Needs extra setup — [see its README →](multiagent-openvla-gemma/README.md). | 24 GB GPU (PILOT + SPECIALIST share it) |
 | `franka-libero/` | **Eval-only**: score a published OpenVLA-7B checkpoint on the LIBERO sim benchmark (Franka pick-and-place), single- **or** multi-agent (Gemma planner). Needs a dedicated venv — [see its README →](franka-libero/README.md). | 24 GB GPU |
+| `quickstart-pi05/` | **Eval-only**: score a Physical Intelligence **π0.5** checkpoint on the LIBERO object suite (Franka), driven out-of-process via a pre-started openpi policy server. Chunk-emitting pilot (issue #74). **Wiring done; GPU smoke pending** — [see its README →](quickstart-pi05/README.md). | 24 GB GPU (+ an openpi/JAX server) |
 
-More quickstarts (Octo, Pi0.5) arrive in later releases. See the
-publication plan for the cadence.
+More quickstarts (Octo) arrive in later releases. See the publication plan for
+the cadence.
 
 ## LIBERO eval (`franka-libero/`)
 
@@ -31,6 +32,7 @@ Once `lovell-odyssey` is installed:
 ```bash
 odyssey validate examples/quickstart-openvla/mission.yaml
 odyssey validate examples/quickstart-gr00t/mission.yaml
+odyssey validate examples/quickstart-pi05/mission.yaml
 odyssey validate examples/multiagent-openvla-gemma/mission.yaml
 ```
 

--- a/examples/quickstart-pi05/README.md
+++ b/examples/quickstart-pi05/README.md
@@ -2,8 +2,9 @@
 
 Score a **π0.5 (pi05)** checkpoint on the LIBERO object suite (Franka Panda,
 sim). π0.5 is a **chunk-emitting generalist pilot**: one policy query returns a
-whole action chunk that the env replays open-loop, so the pilot is queried ~an
-order of magnitude fewer times per episode than the single-step OpenVLA pilot.
+whole action chunk that the env replays open-loop *within the chunk* (no
+re-observation until it drains), so the pilot is queried ~an order of magnitude
+fewer times per episode than the single-step OpenVLA pilot.
 This is the "fewer calls/episode" latency win tracked in [issue #74][74].
 
 This directory is the **eval half only** — there is no training task. π0.5 runs
@@ -147,7 +148,7 @@ script as flags.
 ## Troubleshooting
 
 - **Connection refused / timeout** — the openpi server isn't up (or wrong
-  `host`/`port`). This mission is open-loop: start the server first.
+  `host`/`port`). This mission is externally-served: start the server first.
 - **`NotImplementedError: … requires the openpi client ('openpi_client')`** —
   install `openpi-client` in the odyssey env.
 - **Gripper does the opposite of what it should** — the "no fix-up" assumption is

--- a/examples/quickstart-pi05/README.md
+++ b/examples/quickstart-pi05/README.md
@@ -41,27 +41,42 @@ attempt* an inference run, not *proven*. Specifically:
 
 ## Prerequisites
 
-1. **A running openpi π0.5 policy server.** openpi lives in its own environment
-   (JAX). Install it per [Physical-Intelligence/openpi][openpi] and serve a
-   `pi05_libero` checkpoint, e.g. (check your openpi version for exact flags):
+### Automated — `setup.sh` (GCP L4 target)
+
+```bash
+bash examples/quickstart-pi05/setup.sh
+```
+
+Sets up **both** environments: the odyssey client venv (`env_pilot_pi05`: this
+repo + `openpi-client` + the LIBERO/MuJoCo stack) and the openpi server env
+(clones [Physical-Intelligence/openpi][openpi] + `uv sync`). It prints the
+two-terminal serve+run flow at the end; pass `--serve` to also exec the server.
+
+> ⚠️ The odyssey client half reuses the validated `franka-libero` LIBERO install;
+> the **openpi server half is not yet validated on hardware** — confirm the exact
+> `serve_policy.py` flags + checkpoint id against your openpi version. See the
+> script header and the *Status* section above.
+
+Flags: `--venv`, `--openpi-dir`, `--checkpoint`, `--host`, `--port`, `--serve`
+(`--help` for details).
+
+### Manual (what the script automates)
+
+1. **A running openpi π0.5 policy server.** openpi lives in its own JAX env; serve
+   a `pi05_libero` checkpoint (Apache 2.0; `docs/pi05-scoping.md` → "License and
+   weights"), e.g. (check your openpi version for exact flags):
 
    ```bash
-   # in the openpi repo/env — serves a WebsocketPolicyServer on 0.0.0.0:8000
+   # in the openpi repo/env — serves a WebsocketPolicyServer on host:port
    uv run scripts/serve_policy.py --env LIBERO
    #   (or: policy:checkpoint --policy.config=pi05_libero \
    #        --policy.dir=gs://openpi-assets/checkpoints/pi05_libero)
    ```
 
-   The checkpoint is Apache 2.0 (`docs/pi05-scoping.md` → "License and weights").
-
 2. **The openpi client + LIBERO in the odyssey env.** The eval recipe imports
-   `openpi_client` (the lightweight websocket client) and the `libero` package:
-
-   ```bash
-   pip install openpi-client            # the client only, not the JAX server stack
-   # LIBERO + robosuite/MuJoCo: see examples/franka-libero/setup.sh
-   export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl   # headless VM
-   ```
+   `openpi_client` (the lightweight websocket client, `openpi/packages/openpi-client`)
+   and the `libero` package (see `examples/franka-libero/setup.sh` for the LIBERO
+   deps). Headless render: `export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl`.
 
 [openpi]: https://github.com/Physical-Intelligence/openpi
 

--- a/examples/quickstart-pi05/README.md
+++ b/examples/quickstart-pi05/README.md
@@ -1,0 +1,146 @@
+# quickstart-pi05 — Physical Intelligence π0.5 pilot on LIBERO (eval-only)
+
+Score a **π0.5 (pi05)** checkpoint on the LIBERO object suite (Franka Panda,
+sim). π0.5 is a **chunk-emitting generalist pilot**: one policy query returns a
+whole action chunk that the env replays open-loop, so the pilot is queried ~an
+order of magnitude fewer times per episode than the single-step OpenVLA pilot.
+This is the "fewer calls/episode" latency win tracked in [issue #74][74].
+
+This directory is the **eval half only** — there is no training task. π0.5 runs
+out-of-process in an **openpi `WebsocketPolicyServer`** (openpi/JAX, a separate
+env); odyssey holds only the lightweight websocket client + the LIBERO env.
+
+[74]: https://github.com/lovellai-dev/odyssey/issues/74
+
+---
+
+## ⚠️ Status — read this first
+
+The odyssey-side wiring is **complete and CPU-tested**, but **no end-to-end
+LIBERO rollout has been run on real hardware yet.** Treat this as *ready to
+attempt* an inference run, not *proven*. Specifically:
+
+- **Not GPU-verified.** The CI tests pin the argv/protocol/import contracts only,
+  not a real rollout. First smoke on an L4 is the acceptance gate.
+- **Gripper polarity is unverified.** π0.5 applies **no** gripper fix-up (unlike
+  GR00T, which normalizes+inverts) because its checkpoint is assumed baked to
+  LIBERO's convention. If the gripper opens when it should close on the first
+  rollout, flip it (see *Troubleshooting*).
+- **openpi `infer` wire shape is assumed.** The recipe expects the server to
+  return `{"actions": <ndarray>}` (openpi `LiberoOutputs`, already 7-D). Confirm
+  against your openpi version's `serve_policy.py`.
+- **VRAM footprint is an analytical estimate**, not a measurement
+  (`docs/pi05-scoping.md` → "VRAM footprint"). Single-agent on a 24 GB L4 is the
+  target; co-residence with a SPECIALIST for the multi-agent arms is unconfirmed.
+- **FAST is NOT on the inference path here.** π0.5 is flow-matching → it emits
+  **continuous** action chunks, so FAST detokenization does not run at inference
+  (it only matters in π0.5 *training* or for an autoregressive π0-FAST model).
+  The `pi05_fast.py` codec is reserved scaffolding, not wired in.
+
+---
+
+## Prerequisites
+
+1. **A running openpi π0.5 policy server.** openpi lives in its own environment
+   (JAX). Install it per [Physical-Intelligence/openpi][openpi] and serve a
+   `pi05_libero` checkpoint, e.g. (check your openpi version for exact flags):
+
+   ```bash
+   # in the openpi repo/env — serves a WebsocketPolicyServer on 0.0.0.0:8000
+   uv run scripts/serve_policy.py --env LIBERO
+   #   (or: policy:checkpoint --policy.config=pi05_libero \
+   #        --policy.dir=gs://openpi-assets/checkpoints/pi05_libero)
+   ```
+
+   The checkpoint is Apache 2.0 (`docs/pi05-scoping.md` → "License and weights").
+
+2. **The openpi client + LIBERO in the odyssey env.** The eval recipe imports
+   `openpi_client` (the lightweight websocket client) and the `libero` package:
+
+   ```bash
+   pip install openpi-client            # the client only, not the JAX server stack
+   # LIBERO + robosuite/MuJoCo: see examples/franka-libero/setup.sh
+   export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl   # headless VM
+   ```
+
+[openpi]: https://github.com/Physical-Intelligence/openpi
+
+---
+
+## Run
+
+Point the mission at your server's `host`/`port` (defaults `127.0.0.1:8000` in
+`mission.yaml`), then:
+
+```bash
+odyssey validate examples/quickstart-pi05/mission.yaml
+odyssey run      examples/quickstart-pi05/mission.yaml
+```
+
+The runner spawns `src/odyssey/runners/evals/pi05_libero_eval.py`, which:
+
+1. builds the LIBERO env for `benchmark_name` / `task_id`;
+2. connects to the openpi server via `make_pi05_pilot(host, port, …)`, wrapping
+   the client in the shared `ChunkPilotAdapter` (buffer + replay + flush-on-
+   instruction-change);
+3. per env step calls `pilot.act(...)`, which re-queries the server only when the
+   chunk drains (every `n_action_steps`);
+4. streams the `ODYSSEY_EPISODE` / `ODYSSEY_RESULT` protocol the runner scores.
+
+Videos (one MP4 per episode) land under the task's output dir when
+`capture_video: true`.
+
+---
+
+## What this covers vs [issue #74][74]
+
+| Acceptance item (#74) | State here |
+| --- | --- |
+| Confirm π0.5 weights + FAST availability/license | ✅ `docs/pi05-scoping.md` (Apache 2.0; FAST reusable via openpi/HF) |
+| Shared chunk-aware `PilotRuntime` abstraction (GR00T + π0.5) | ✅ `ChunkPilotAdapter` (pilot-agnostic, reused, not forked) |
+| π0.5 pilot runs a LIBERO eval end-to-end (single-agent) on the VM | 🚧 **wiring done, GPU smoke pending** (this mission is the vehicle) |
+| Measure calls/episode + wall-clock vs OpenVLA baseline | ⬜ after the smoke runs |
+| Docs: pilot line-up + chunk-aware runtime notes | ✅ scoping doc + this README |
+
+Open questions from #74 and where they stand: **weights/license** (Q1) and **FAST
+availability** (Q2) are resolved in the scoping doc; **VRAM on a single L4** (Q3)
+and **sim embodiment/action mapping** (Q4) are implemented per the scoping
+analysis but **await the GPU smoke** for confirmation.
+
+---
+
+## Config keys (`tasks[].config`)
+
+| key | meaning |
+| --- | --- |
+| `pilot: pi05` | routes the eval to `pi05_libero_eval.py` + the openpi client |
+| `checkpoint` | recorded in the summary; the **server** loads the real weights |
+| `task_id` | which task within the suite (0..9) |
+| `host` / `port` | the pre-started openpi `WebsocketPolicyServer` address |
+| `api_key` | optional, only if your server requires one |
+| `n_action_steps` | steps replayed per chunk before re-query (10 for `pi05_libero`) |
+| `translation_only` | de-risk knob: zero rotation + force gripper open |
+| `capture_video` | one MP4 per episode |
+| `task_instruction` / `strict_instruction` | optional instruction-drift alignment contract |
+
+Keys the runner consumes itself (`pilot`, `checkpoint`, `runner`,
+`capture_video`, `video_fps`, `video_format`) are **not** forwarded to the eval
+script as flags.
+
+---
+
+## Troubleshooting
+
+- **Connection refused / timeout** — the openpi server isn't up (or wrong
+  `host`/`port`). This mission is open-loop: start the server first.
+- **`NotImplementedError: … requires the openpi client ('openpi_client')`** —
+  install `openpi-client` in the odyssey env.
+- **Gripper does the opposite of what it should** — the "no fix-up" assumption is
+  wrong for your checkpoint. As a stopgap, try `translation_only: true` to
+  isolate the arm, then port GR00T's gripper fix-up into `pi05_action_to_libero`
+  (`src/odyssey/runners/evals/pi05_transforms.py`) if confirmed.
+- **`'libero' is not a package`** — the recipe drops its own directory from
+  `sys.path` to avoid shadowing the real LIBERO namespace; if you see this,
+  you're likely importing the script wrong (run via `odyssey run`, not directly).
+- **Black/upside-down video** — LIBERO's offscreen frames are stored 180°-rotated;
+  `flip_images` defaults on. Leave it unless your frames are already upright.

--- a/examples/quickstart-pi05/mission.yaml
+++ b/examples/quickstart-pi05/mission.yaml
@@ -3,17 +3,18 @@
 # Scores a Physical Intelligence π0.5 (pi05) checkpoint on the LIBERO object
 # suite — a Franka Panda doing language-conditioned pick-and-place in sim. π0.5
 # is a chunk-emitting generalist pilot: one policy query returns a whole action
-# chunk executed open-loop, so the pilot is queried ~an order of magnitude fewer
-# times per episode than the single-step OpenVLA pilot (issue #74).
+# chunk, replayed open-loop *within the chunk* (no re-observation until it drains),
+# so the pilot is queried ~an order of magnitude fewer times per episode than the
+# single-step OpenVLA pilot (issue #74).
 #
 # EVAL-ONLY: there is NO training task. π0.5 runs OUT-OF-PROCESS in an openpi
 # WebsocketPolicyServer (openpi/JAX, a separate env); this mission is the eval
 # half only. The server holds the weights — `config.checkpoint` below is recorded
 # in the run summary but NOT loaded on the odyssey side.
 #
-# OPEN-LOOP ONLY: unlike the GR00T quickstart (which can auto-serve its own server
-# in-process), you must START the openpi server yourself and point this mission at
-# its host:port. See examples/quickstart-pi05/README.md.
+# EXTERNALLY-SERVED: unlike the GR00T quickstart (which can self-serve its own
+# server in-process), you must START the openpi server yourself and point this
+# mission at its host:port. See examples/quickstart-pi05/README.md.
 #
 # ⚠️ UNVERIFIED ON GPU as of this PR: the odyssey-side wiring is complete and
 # CPU-tested, but no end-to-end LIBERO rollout has been run on real hardware.
@@ -35,7 +36,7 @@ metadata:
 objective: |
   Evaluate a π0.5 LIBERO checkpoint on the LIBERO object suite and confirm a real
   (non-zero) success rate in simulation, replaying the emitted action chunk
-  open-loop through the shared chunk-aware pilot adapter.
+  open-loop *within the chunk* through the shared chunk-aware pilot adapter.
 
 acceptance_criteria: |
   The openpi server serves the checkpoint, π0.5 action chunks execute in LIBERO,
@@ -68,7 +69,7 @@ tasks:
       checkpoint: gs://openpi-assets/checkpoints/pi05_libero
       task_id: 0                          # which task within the suite (0..9)
 
-      # --- openpi policy server (OPEN-LOOP: pre-started by you; see README) ---
+      # --- openpi policy server (EXTERNALLY-SERVED: pre-started by you; see README) ---
       host: 127.0.0.1
       port: 8000                          # openpi WebsocketPolicyServer default
       # api_key: "..."                    # only if your server sets one

--- a/examples/quickstart-pi05/mission.yaml
+++ b/examples/quickstart-pi05/mission.yaml
@@ -1,0 +1,92 @@
+# π0.5 quickstart mission (LIBERO eval-only, single-agent).
+#
+# Scores a Physical Intelligence π0.5 (pi05) checkpoint on the LIBERO object
+# suite — a Franka Panda doing language-conditioned pick-and-place in sim. π0.5
+# is a chunk-emitting generalist pilot: one policy query returns a whole action
+# chunk executed open-loop, so the pilot is queried ~an order of magnitude fewer
+# times per episode than the single-step OpenVLA pilot (issue #74).
+#
+# EVAL-ONLY: there is NO training task. π0.5 runs OUT-OF-PROCESS in an openpi
+# WebsocketPolicyServer (openpi/JAX, a separate env); this mission is the eval
+# half only. The server holds the weights — `config.checkpoint` below is recorded
+# in the run summary but NOT loaded on the odyssey side.
+#
+# OPEN-LOOP ONLY: unlike the GR00T quickstart (which can auto-serve its own server
+# in-process), you must START the openpi server yourself and point this mission at
+# its host:port. See examples/quickstart-pi05/README.md.
+#
+# ⚠️ UNVERIFIED ON GPU as of this PR: the odyssey-side wiring is complete and
+# CPU-tested, but no end-to-end LIBERO rollout has been run on real hardware.
+# The gripper polarity (π0.5 uses NO fix-up) and the openpi `infer` wire shape are
+# the two things to confirm on the first L4 smoke.
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: quickstart-pi05-libero-object
+  description: >-
+    Eval-only — score a π0.5 (openpi) checkpoint on the LIBERO object suite
+    (Franka, sim), driven out-of-process via a pre-started openpi
+    WebsocketPolicyServer. Chunk-emitting pilot: far fewer calls/episode than
+    single-step OpenVLA (issue #74).
+  tags: [pi05, openpi, physical-intelligence, libero, robosuite, franka, eval-only]
+
+objective: |
+  Evaluate a π0.5 LIBERO checkpoint on the LIBERO object suite and confirm a real
+  (non-zero) success rate in simulation, replaying the emitted action chunk
+  open-loop through the shared chunk-aware pilot adapter.
+
+acceptance_criteria: |
+  The openpi server serves the checkpoint, π0.5 action chunks execute in LIBERO,
+  and the run reports a non-trivial success_rate across the evaluation episodes.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        # HF mirror of the openpi π0.5 base weights (Apache 2.0). Documentation of
+        # the pilot identity only — the openpi SERVER is what actually loads/serves
+        # a LIBERO checkpoint (see config.checkpoint + README).
+        base: lerobot/pi05_base
+
+tasks:
+  - name: eval-libero-object-pi05
+    kind: evaluation
+    evaluation_type: libero
+    description: Pick-and-place of the task_id=0 object (LIBERO object suite), π0.5 pilot.
+    benchmark_name: libero_object        # LIBERO suite (spatial/object/goal/libero_10)
+    num_episodes: 10
+    config:
+      pilot: pi05                         # -> pi05_libero_eval.py subprocess + openpi client
+      # Recorded in the summary only; the openpi server (below) already holds the
+      # weights. This is the checkpoint you served (openpi ships pi05_libero at
+      # gs://openpi-assets/checkpoints/pi05_libero).
+      checkpoint: gs://openpi-assets/checkpoints/pi05_libero
+      task_id: 0                          # which task within the suite (0..9)
+
+      # --- openpi policy server (OPEN-LOOP: pre-started by you; see README) ---
+      host: 127.0.0.1
+      port: 8000                          # openpi WebsocketPolicyServer default
+      # api_key: "..."                    # only if your server sets one
+
+      # --- action chunk (LIBERO action is ABSOLUTE 7-DoF; π0.5 does NO gripper fix-up) ---
+      # Replay this many steps of each emitted chunk before re-querying. Match the
+      # checkpoint's action_horizon (10 for pi05_libero; openpi chunk_size default 50).
+      n_action_steps: 10
+      # translation_only: true            # de-risk knob: zero rotation + force gripper open
+
+      capture_video: true                 # one MP4 per episode
+
+      # OPTIONAL alignment contract: declare the instruction you believe task_id
+      # carries; the runner cross-checks it against the benchmark's task.language
+      # and WARNS on drift (strict_instruction: true to hard-fail). Grab the exact
+      # string from the first run's log line, then paste it here verbatim.
+      # task_instruction: "pick up the ... and place it in the basket"
+      # strict_instruction: false
+
+leaderboard:
+  publish: false   # Backend not live yet.

--- a/examples/quickstart-pi05/setup.sh
+++ b/examples/quickstart-pi05/setup.sh
@@ -2,8 +2,8 @@
 #
 # Setup for the π0.5 (openpi) LIBERO eval quickstart — GCP L4 24GB target.
 #
-# It ONLY sets things up — it does NOT run a mission (and, being open-loop, it does
-# NOT boot the policy server for you unless you pass --serve). Two SEPARATE
+# It ONLY sets things up — it does NOT run a mission (and, being externally-served,
+# it does NOT boot the policy server for you unless you pass --serve). Two SEPARATE
 # environments by design (their python/CUDA/JAX-vs-torch ABIs clash); they are wired
 # by host:port, not co-installed:
 #
@@ -176,7 +176,7 @@ SERVE_CMD=( uv run --project "$OPENPI_DIR" scripts/serve_policy.py
 
 cat <<EOF
 
-[setup] Done. Two-terminal flow (open-loop):
+[setup] Done. Two-terminal flow (externally-served: you start the server):
 
   TERMINAL 1 — serve π0.5 (openpi env; downloads the checkpoint on first run):
     ${SERVE_CMD[*]}

--- a/examples/quickstart-pi05/setup.sh
+++ b/examples/quickstart-pi05/setup.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+#
+# Setup for the π0.5 (openpi) LIBERO eval quickstart — GCP L4 24GB target.
+#
+# It ONLY sets things up — it does NOT run a mission (and, being open-loop, it does
+# NOT boot the policy server for you unless you pass --serve). Two SEPARATE
+# environments by design (their python/CUDA/JAX-vs-torch ABIs clash); they are wired
+# by host:port, not co-installed:
+#
+#   1. Odyssey client env  — a dedicated venv (this repo + openpi-client + LIBERO)
+#                            -> drives the mission, holds the LIBERO/MuJoCo env
+#   2. openpi server env   — openpi's own uv env (JAX)   -> serves π0.5 on host:port
+#
+# ─── ⚠️ NOT YET VALIDATED ON HARDWARE ──────────────────────────────────────────────
+#  Unlike examples/franka-libero/setup.sh (validated on a GCP L4), the openpi SERVER
+#  half here is UNVERIFIED end-to-end. The odyssey client half reuses the validated
+#  LIBERO install; the openpi clone/sync/serve steps follow openpi's docs but have
+#  not been run through to a green LIBERO rollout. Treat the server section as a
+#  best-effort scaffold — confirm the exact `serve_policy.py` flags + checkpoint id
+#  against YOUR openpi version. The two things to watch on the first smoke: gripper
+#  polarity (π0.5 uses no fix-up) and the `infer` -> {"actions": ...} wire shape.
+#
+# What the client half installs (mirrors the validated franka-libero LIBERO deps):
+#  * LIBERO ships NO top-level package — it's a PEP 420 namespace package; register
+#    the repo root via a .pth file (pip install -e registers nothing).
+#  * robosuite is pinned 1.4.0 (LIBERO requires it) in a DEDICATED venv so it can't
+#    disturb a validated OpenVLA/RobosuiteRunner env elsewhere.
+#  * robomimic pulls egl_probe, which builds from C source -> needs cmake + headers.
+#  * π0.5 needs NO `transformers` (FAST is reserved/off the inference path), so the
+#    OpenVLA transformers pin does not apply here.
+#
+# Usage:
+#   bash examples/quickstart-pi05/setup.sh                 # set up both envs
+#   bash examples/quickstart-pi05/setup.sh --serve         # ...then exec the server (foreground)
+#
+#   --venv PATH        odyssey client venv (default: <repo>/env_pilot_pi05)
+#   --openpi-dir PATH  openpi checkout (default: $HOME/openpi)
+#   --checkpoint ID    π0.5 checkpoint the server serves
+#                      (default: gs://openpi-assets/checkpoints/pi05_libero)
+#   --host / --port    server bind address baked into the print-out (default 127.0.0.1:8000)
+#   --serve            after setup, exec the openpi server in the foreground (blocks)
+#
+# Env overrides: LIBERO_DIR (default $HOME/LIBERO), HF_HOME (default $HOME/.cache/huggingface)
+#
+# Linux + NVIDIA GPU assumed (GCP L4, 24GB). Re-runnable / idempotent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+VENV="${VENV:-$REPO_ROOT/env_pilot_pi05}"
+OPENPI_DIR="${OPENPI_DIR:-$HOME/openpi}"
+LIBERO_DIR="${LIBERO_DIR:-$HOME/LIBERO}"
+CHECKPOINT="gs://openpi-assets/checkpoints/pi05_libero"
+HOST="127.0.0.1"
+PORT="8000"
+DO_SERVE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --venv) VENV="$2"; shift 2 ;;
+    --openpi-dir) OPENPI_DIR="$2"; shift 2 ;;
+    --checkpoint) CHECKPOINT="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --port) PORT="$2"; shift 2 ;;
+    --serve) DO_SERVE=1; shift ;;
+    -h|--help) grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v uv >/dev/null || {
+  echo "[setup] ERROR: 'uv' not found — install then re-run:" >&2
+  echo "  curl -LsSf https://astral.sh/uv/install.sh | sh && source ~/.bashrc" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+echo "==> [1/5] system build + render deps (sudo; egl_probe/MuJoCo need these)"
+# ---------------------------------------------------------------------------
+sudo apt-get update && sudo apt-get install -y \
+  cmake build-essential python3-dev python3.10-dev \
+  libegl1-mesa-dev libgl1-mesa-dev libgles2-mesa-dev libosmesa6-dev
+
+# ---------------------------------------------------------------------------
+echo "==> [2/5] openpi checkout (source of both the client package and the server)"
+# ---------------------------------------------------------------------------
+if [ ! -d "$OPENPI_DIR/.git" ]; then
+  echo "[setup] cloning Physical-Intelligence/openpi into $OPENPI_DIR"
+  git clone https://github.com/Physical-Intelligence/openpi.git "$OPENPI_DIR"
+else
+  echo "[setup] openpi already at $OPENPI_DIR — reusing"
+fi
+
+# ---------------------------------------------------------------------------
+echo "==> [3/5] odyssey client venv ($VENV): odyssey + openpi-client + LIBERO deps"
+# ---------------------------------------------------------------------------
+uv venv --python 3.10 "$VENV"
+PYBIN="$VENV/bin/python"
+uv pip install --python "$PYBIN" -e "$REPO_ROOT[dev,huggingface]"
+
+# openpi's lightweight websocket client (what pi05.py imports as `openpi_client`).
+# It lives in the openpi repo at packages/openpi-client — install THAT (no JAX).
+if [ -d "$OPENPI_DIR/packages/openpi-client" ]; then
+  uv pip install --python "$PYBIN" -e "$OPENPI_DIR/packages/openpi-client"
+else
+  echo "[setup] WARNING: $OPENPI_DIR/packages/openpi-client not found — trying PyPI 'openpi-client'." >&2
+  uv pip install --python "$PYBIN" openpi-client \
+    || echo "[setup] WARNING: could not install openpi-client; the eval will raise NotImplementedError until it is present." >&2
+fi
+
+# LIBERO client stack (pilot-agnostic; same pins the validated franka-libero uses,
+# MINUS transformers/numpy — π0.5 needs neither). Installed into the pi05 venv.
+uv pip install --python "$PYBIN" \
+  robosuite==1.4.0 bddl==1.0.1 robomimic==0.2.0 hydra-core==1.2.0 easydict==1.9 \
+  einops==0.4.1 gym==0.25.2 cloudpickle==2.1.0 future==0.18.2 thop==0.1.1.post2209072238 \
+  opencv-python==4.6.0.66 matplotlib==3.5.3
+uv pip install --python "$PYBIN" "imageio[ffmpeg]"   # mp4 encoder for capture_video
+
+# LIBERO is a PEP 420 namespace package: clone + register the repo root on the path.
+if [ ! -d "$LIBERO_DIR/.git" ]; then
+  echo "[setup] cloning LIBERO into $LIBERO_DIR"
+  git clone https://github.com/Lifelong-Robot-Learning/LIBERO.git "$LIBERO_DIR"
+else
+  echo "[setup] LIBERO already at $LIBERO_DIR — reusing"
+fi
+SP="$("$PYBIN" -c 'import site;print(site.getsitepackages()[0])')"
+echo "$LIBERO_DIR" > "$SP/libero_src.pth"
+echo "[setup] registered $LIBERO_DIR via $SP/libero_src.pth"
+
+# Pre-init ~/.libero/config.yaml non-interactively (the init prompts on stdin and
+# would otherwise block `odyssey run`). The prompt fires on `libero.libero`, and
+# `yes N` answers every prompt. Skip if already initialized.
+if [ ! -f "$HOME/.libero/config.yaml" ]; then
+  yes N | "$PYBIN" -c "import libero.libero" >/dev/null 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+echo "==> [4/5] verify the client env (no transformers needed for π0.5)"
+# ---------------------------------------------------------------------------
+"$PYBIN" - <<'PY'
+import sys
+try:
+    import odyssey                                   # noqa: F401
+    import libero
+    from libero.libero import benchmark              # noqa: F401
+    import robosuite, imageio_ffmpeg                 # noqa: F401
+    import importlib.util as u
+    has_client = bool(u.find_spec("openpi_client"))
+    print(f"[setup] odyssey       : OK")
+    print(f"[setup] libero        : path={list(libero.__path__)}")
+    print(f"[setup] robosuite     : {robosuite.__version__}  (1.4.0 expected in this venv)")
+    print(f"[setup] openpi_client : {'OK' if has_client else 'MISSING (install before running)'}")
+except Exception as e:  # noqa: BLE001
+    print(f"[setup] VERIFY FAILED: {e}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# ---------------------------------------------------------------------------
+echo "==> [5/5] openpi SERVER env (JAX, separate) — best-effort; see ⚠️ header"
+# ---------------------------------------------------------------------------
+# openpi manages its own env with uv. `uv sync` inside the checkout builds it.
+# This is the UNVERIFIED half — it downloads a large JAX/CUDA stack; on an L4 it is
+# the single-agent VRAM tenant. Non-fatal: warn + print the manual steps on failure.
+if ( cd "$OPENPI_DIR" && uv sync ); then
+  echo "[setup] openpi env synced under $OPENPI_DIR (.venv)"
+else
+  echo "[setup] WARNING: 'uv sync' in $OPENPI_DIR did not complete — finish it per openpi's" >&2
+  echo "        README before serving (GIT_LFS_SKIP_SMUDGE, CUDA wheels, etc. may apply)." >&2
+fi
+
+SERVE_CMD=( uv run --project "$OPENPI_DIR" scripts/serve_policy.py
+            policy:checkpoint --policy.config=pi05_libero
+            "--policy.dir=$CHECKPOINT" "--host=$HOST" "--port=$PORT" )
+
+cat <<EOF
+
+[setup] Done. Two-terminal flow (open-loop):
+
+  TERMINAL 1 — serve π0.5 (openpi env; downloads the checkpoint on first run):
+    ${SERVE_CMD[*]}
+    # ⚠ exact flags vary by openpi version — the simplest form is often:
+    #   uv run --project $OPENPI_DIR scripts/serve_policy.py --env LIBERO
+    # Verify the server prints it is listening on $HOST:$PORT.
+
+  TERMINAL 2 — run the eval (this repo's venv):
+    source $VENV/bin/activate
+    export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl     # L4 has NVIDIA EGL; osmesa = CPU fallback
+    # point the mission at the server if you changed host/port:
+    #   examples/quickstart-pi05/mission.yaml -> config.host/config.port
+    odyssey validate examples/quickstart-pi05/mission.yaml
+    odyssey run      examples/quickstart-pi05/mission.yaml
+
+  Per-episode MP4s:
+    find ~/.odyssey/runs -path "*/videos/*.mp4" -exec ls -lh {} \\;
+
+  First-smoke watch-list (see the README + PR #81 limits):
+    * gripper polarity — π0.5 applies NO fix-up; if inverted, patch pi05_transforms.py
+    * infer wire shape — recipe expects {"actions": <ndarray>} (7-D)
+EOF
+
+if [ "$DO_SERVE" -eq 1 ]; then
+  echo "[setup] --serve: exec'ing the openpi server (foreground; Ctrl-C to stop)…"
+  exec "${SERVE_CMD[@]}"
+fi

--- a/examples/quickstart-pi05/setup.sh
+++ b/examples/quickstart-pi05/setup.sh
@@ -111,9 +111,14 @@ else
 fi
 
 # LIBERO client stack (pilot-agnostic; same pins the validated franka-libero uses,
-# MINUS transformers/numpy — π0.5 needs neither). Installed into the pi05 venv.
+# MINUS transformers — π0.5 needs no transformers). Installed into the pi05 venv.
+# mujoco + numpy ARE pinned here (unlike franka-libero, which omits them to protect
+# a co-installed OpenVLA stack): this venv is standalone, and left unpinned pip
+# resolves mujoco 3.x (robosuite 1.4.0 calls the old MjData.qM API -> AttributeError)
+# and numpy 2.x (ABI clash with mujoco 2.3.x + gym 0.25). Pin both to known-good.
 uv pip install --python "$PYBIN" \
-  robosuite==1.4.0 bddl==1.0.1 robomimic==0.2.0 hydra-core==1.2.0 easydict==1.9 \
+  robosuite==1.4.0 mujoco==2.3.2 "numpy<2" \
+  bddl==1.0.1 robomimic==0.2.0 hydra-core==1.2.0 easydict==1.9 \
   einops==0.4.1 gym==0.25.2 cloudpickle==2.1.0 future==0.18.2 thop==0.1.1.post2209072238 \
   opencv-python==4.6.0.66 matplotlib==3.5.3
 uv pip install --python "$PYBIN" "imageio[ffmpeg]"   # mp4 encoder for capture_video

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,4 +174,9 @@ ignore_errors = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+# Resolve `import odyssey` from THIS tree's src/ (front of sys.path), so tests run
+# against the working copy — not whatever an editable-install .pth happens to point
+# at. Essential when developing in a git worktree whose src/ differs from the
+# globally-installed checkout (e.g. new modules not yet in the editable file map).
+pythonpath = ["src"]
 addopts = ["-ra", "--strict-markers"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,20 @@ module = [
 ]
 ignore_errors = true
 
+# The π0.5 (openpi) mirrors are the same category as the GR00T transforms above:
+# numpy-only re-implementations of openpi's server-side Normalize/Unnormalize/FAST
+# and the wire glue around the untyped ``openpi_client`` SDK. They interface with an
+# external, stub-less policy server, so they're exempt from strict checking (their
+# behaviour is pinned by the unit tests in tests/unit/test_pi05_*.py instead).
+[[tool.mypy.overrides]]
+module = [
+    "odyssey.runners.evals.pi05_norm",
+    "odyssey.runners.evals.pi05_fast",
+    "odyssey.runners.evals.pi05_transforms",
+    "odyssey.runners.models.pi05",
+]
+ignore_errors = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,7 @@ module = [
     "odyssey.runners.evals.pi05_norm",
     "odyssey.runners.evals.pi05_fast",
     "odyssey.runners.evals.pi05_transforms",
+    "odyssey.runners.evals.pi05_libero_eval",
     "odyssey.runners.models.pi05",
 ]
 ignore_errors = true

--- a/src/odyssey/runners/agents/chunk_pilot.py
+++ b/src/odyssey/runners/agents/chunk_pilot.py
@@ -1,0 +1,124 @@
+"""Chunk-aware pilot adapter — the shared engine behind chunk-emitting VLAs.
+
+A *chunk-emitting* pilot (GR00T, π0.5, any FAST/flow-matching VLA) answers one
+policy query with a whole **action chunk** of ``n_action_steps`` future actions,
+which the env then replays open-loop before the next query. The GR00T LIBERO
+recipe hard-codes that replay as an inline ``for k in range(n_action_steps)``
+loop (``gr00t_libero_eval.py``); this module factors that loop out ONCE, as a
+pilot-agnostic adapter, so π0.5 reuses the exact same gating instead of shipping
+a second copy that drifts.
+
+The adapter presents the single-step ``PilotRuntime`` surface (``act`` →
+one action per call) on top of a chunk-emitting policy, hiding the buffer:
+
+  * **buffer + cursor** — a query fills a chunk; each ``act`` returns the next
+    step and advances a cursor;
+  * **re-query on drain** — when the cursor reaches ``n_action_steps`` (or no
+    chunk has been fetched yet) the next ``act`` queries the policy again;
+  * **flush-on-instruction-change** — if the instruction differs from the one
+    the current chunk was computed for, the chunk is discarded and re-queried
+    immediately. This is what lets a closed-loop planner advance a phase
+    mid-chunk (the multi-agent completion-gating path) without replaying stale
+    actions planned for the previous sub-instruction.
+
+Everything pilot-specific is injected, so the adapter carries **no** heavy deps
+(no numpy/torch/openpi at import time) and is unit-testable with plain fakes:
+
+  * ``predict_chunk(wire_obs) -> chunk`` — the policy call (e.g. an openpi
+    ``WebsocketClientPolicy.infer`` or a GR00T ``PolicyClient.get_action``). May
+    return a bare chunk or a ``(chunk, extra)`` tuple; the leading element is used.
+  * ``action_decoder(chunk, k) -> action`` — map step ``k`` of the chunk to the
+    env's action vector (e.g. ``pi05_action_to_libero`` / ``gr00t_action_to_libero``).
+  * ``observation_builder(raw_obs, instruction) -> wire_obs`` *(optional)* —
+    turn the env observation into the policy's wire format; identity if omitted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def _unwrap_chunk(result: Any) -> Any:
+    """A policy may return a bare chunk or ``(chunk, extra)``; take the chunk."""
+    return result[0] if isinstance(result, tuple) else result
+
+
+class ChunkPilotAdapter:
+    """Replay a chunk-emitting policy one action per ``act`` call.
+
+    Satisfies the ``PilotRuntime`` protocol structurally: ``act(observation,
+    instruction) -> action``. The first argument is named ``observation`` (not
+    ``image``) because a proprio-conditioned chunk pilot needs the full env
+    observation — the injected ``observation_builder`` decides what the policy
+    actually consumes, so an image-only pilot still fits by passing the image
+    straight through.
+    """
+
+    def __init__(
+        self,
+        *,
+        predict_chunk: Callable[[Any], Any],
+        action_decoder: Callable[[Any, int], Any],
+        n_action_steps: int,
+        observation_builder: Callable[[Any, str], Any] | None = None,
+    ) -> None:
+        if int(n_action_steps) < 1:
+            raise ValueError(f"n_action_steps must be >= 1, got {n_action_steps}")
+        self._predict = predict_chunk
+        self._decode = action_decoder
+        self._build_obs = observation_builder
+        self._n = int(n_action_steps)
+        self._chunk: Any = None
+        self._cursor = 0
+        self._instruction: str | None = None
+
+    # -- introspection (handy for tests + logging; not part of PilotRuntime) --
+
+    @property
+    def n_action_steps(self) -> int:
+        return self._n
+
+    @property
+    def steps_remaining(self) -> int:
+        """Actions left in the current buffer before the next re-query."""
+        if self._chunk is None:
+            return 0
+        return max(0, self._n - self._cursor)
+
+    def reset(self) -> None:
+        """Drop the buffer so the next ``act`` re-queries. Call per episode."""
+        self._chunk = None
+        self._cursor = 0
+        self._instruction = None
+
+    # -- PilotRuntime surface --------------------------------------------------
+
+    def _needs_requery(self, instruction: str) -> bool:
+        return (
+            self._chunk is None
+            or self._cursor >= self._n
+            or instruction != self._instruction  # flush-on-instruction-change
+        )
+
+    def _requery(self, observation: Any, instruction: str) -> None:
+        wire = (
+            self._build_obs(observation, instruction)
+            if self._build_obs is not None
+            else observation
+        )
+        self._chunk = _unwrap_chunk(self._predict(wire))
+        self._cursor = 0
+        self._instruction = instruction
+
+    def act(self, observation: Any, instruction: str) -> Any:
+        """Return one action, re-querying the policy when the chunk is spent.
+
+        A fresh chunk is fetched when there is none buffered, the buffer has
+        been fully replayed, or ``instruction`` changed since the last query.
+        """
+        if self._needs_requery(instruction):
+            self._requery(observation, instruction)
+        action = self._decode(self._chunk, self._cursor)
+        self._cursor += 1
+        return action

--- a/src/odyssey/runners/agents/completion_gate.py
+++ b/src/odyssey/runners/agents/completion_gate.py
@@ -1,0 +1,166 @@
+"""Chunk-aware completion / hand-back gate — the shared closed-loop trigger.
+
+A *chunk-emitting* pilot (GR00T, π0.5, any FAST/flow-matching VLA) answers one
+policy query with a whole action **chunk** of ``n_action_steps`` future actions,
+which the env replays open-loop before the next query (see
+``runners/agents/chunk_pilot.py``). This module decides, at each **chunk
+boundary**, whether the active sub-instruction is done and control should be
+*handed back* to the orchestrator (advance the planner's phase, or end the
+episode on the final phase).
+
+Why gate *on chunks* rather than *per step*:
+
+  * **cost** — the completion judge is a VLM (Gemma int4, GR00T's
+    ``cosmos_reason``); running it on every one of ``n_action_steps`` replayed
+    steps is wasteful when the pilot won't re-plan until the chunk drains anyway.
+  * **staleness** — the world barely moves within one open-loop chunk, so a
+    per-step judgement mostly repeats itself. One judgement per chunk lines the
+    completion check up with the pilot's own decision cadence.
+
+Historically each pilot inlined its own advancement rule (GR00T's fixed
+``for k in range(n_action_steps)`` loop; ``PlannedEvalRuntime``'s fixed-step /
+timeout strategies). This gate factors the *closed-loop* rule out ONCE, as a
+pilot-agnostic component, so GR00T, π0.5 and the orchestrator share a single
+implementation instead of three that drift (the same move ``ChunkPilotAdapter``
+made for chunk replay).
+
+Dependency-free by construction: the completion detector is injected — either a
+plain ``detector(observation, instruction) -> bool`` callable or any
+``CompletionDetector`` (an object with ``is_complete``) — so the gate carries no
+torch/VLM import and is unit-testable with a trivial fake.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+# A detector is either a bare callable or a CompletionDetector-shaped object.
+DetectorLike = Callable[[Any, str], bool] | Any
+
+
+def _as_callable(detector: DetectorLike) -> Callable[[Any, str], bool]:
+    """Normalise a detector to a ``(observation, instruction) -> bool`` callable.
+
+    Accepts a bare callable or any ``CompletionDetector`` (an object exposing
+    ``is_complete``), so callers can pass a VLM-judge object or a one-line lambda
+    interchangeably.
+    """
+    is_complete = getattr(detector, "is_complete", None)
+    if callable(is_complete):
+        return is_complete
+    if callable(detector):
+        return detector
+    raise TypeError(
+        "detector must be callable(observation, instruction) -> bool or expose "
+        f"an is_complete method; got {type(detector).__name__}"
+    )
+
+
+class ChunkCompletionGate:
+    """Poll a completion judge at chunk boundaries and report hand-back.
+
+    Call :meth:`update` once per env step (after the action is applied). The gate
+    counts steps; only when a full chunk of ``n_action_steps`` has been replayed
+    does it consult the injected detector, and it returns ``True`` exactly when
+    the detector judges the current sub-instruction complete — the signal for the
+    caller to hand control back (advance the phase / end the episode).
+
+    Parameters
+    ----------
+    detector:
+        The completion judge — a ``detector(observation, instruction) -> bool``
+        callable or any :class:`CompletionDetector` (has ``is_complete``).
+    n_action_steps:
+        Chunk size — how many steps the pilot replays open-loop per query. The
+        gate polls once every ``n_action_steps`` steps. Match it to the pilot's
+        replay horizon (e.g. a :class:`ChunkPilotAdapter`'s ``n_action_steps``)
+        so the completion check lines up with the pilot's re-query points.
+    min_steps:
+        Warm-up: never poll (never hand back) before this many steps have elapsed
+        in the current phase. Guards against a premature "done" on the very first
+        chunk before the arm has moved. Default ``0`` (poll from the first
+        boundary).
+    poll_every_chunks:
+        Throttle: consult the detector only every Nth chunk boundary. Default
+        ``1`` (every boundary). Use a higher value to trade responsiveness for
+        fewer (expensive) judge calls.
+    """
+
+    def __init__(
+        self,
+        *,
+        detector: DetectorLike,
+        n_action_steps: int,
+        min_steps: int = 0,
+        poll_every_chunks: int = 1,
+    ) -> None:
+        if int(n_action_steps) < 1:
+            raise ValueError(f"n_action_steps must be >= 1, got {n_action_steps}")
+        if int(poll_every_chunks) < 1:
+            raise ValueError(
+                f"poll_every_chunks must be >= 1, got {poll_every_chunks}"
+            )
+        if int(min_steps) < 0:
+            raise ValueError(f"min_steps must be >= 0, got {min_steps}")
+        self._detect = _as_callable(detector)
+        self._n = int(n_action_steps)
+        self._min_steps = int(min_steps)
+        self._poll_every = int(poll_every_chunks)
+        self._steps = 0
+        self._chunks = 0
+
+    # -- introspection (handy for tests + logging) -----------------------------
+
+    @property
+    def n_action_steps(self) -> int:
+        return self._n
+
+    @property
+    def steps_in_phase(self) -> int:
+        """Steps elapsed since the last :meth:`reset` (i.e. in this phase)."""
+        return self._steps
+
+    @property
+    def chunks_completed(self) -> int:
+        """Chunk boundaries crossed since the last :meth:`reset`."""
+        return self._chunks
+
+    def at_chunk_boundary(self) -> bool:
+        """Whether the last :meth:`update` landed on a chunk boundary."""
+        return self._steps > 0 and self._steps % self._n == 0
+
+    def reset(self) -> None:
+        """Drop the counters so the next chunk window starts fresh.
+
+        Call on every hand-back (new sub-instruction) and at the start of each
+        episode. A mid-chunk reset re-aligns the gate's boundary with the pilot's
+        own re-query — a chunk pilot flushes on the instruction change, so both
+        restart their chunk window together.
+        """
+        self._steps = 0
+        self._chunks = 0
+
+    # -- the closed-loop trigger ----------------------------------------------
+
+    def update(self, observation: Any, instruction: str) -> bool:
+        """Advance one step; return ``True`` iff control should be handed back.
+
+        Increments the step counter and, only at a chunk boundary (and past the
+        warm-up / throttle), consults the detector. Between boundaries this is a
+        cheap counter bump that always returns ``False`` — the detector (and its
+        VLM cost) is untouched.
+
+        Does **not** self-reset on a hand-back: the caller resets when it acts on
+        the signal (advances the phase), which keeps a hand-back the caller
+        chooses to ignore — e.g. on the final phase — from silently re-arming.
+        """
+        self._steps += 1
+        if self._steps % self._n != 0:
+            return False  # mid-chunk: no judge call
+        self._chunks += 1
+        if self._steps < self._min_steps:
+            return False  # still warming up
+        if self._chunks % self._poll_every != 0:
+            return False  # throttled this boundary
+        return bool(self._detect(observation, instruction))

--- a/src/odyssey/runners/agents/completion_gate.py
+++ b/src/odyssey/runners/agents/completion_gate.py
@@ -33,7 +33,7 @@ torch/VLM import and is unit-testable with a trivial fake.
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 # A detector is either a bare callable or a CompletionDetector-shaped object.
 DetectorLike = Callable[[Any, str], bool] | Any
@@ -48,7 +48,7 @@ def _as_callable(detector: DetectorLike) -> Callable[[Any, str], bool]:
     """
     is_complete = getattr(detector, "is_complete", None)
     if callable(is_complete):
-        return is_complete
+        return cast("Callable[[Any, str], bool]", is_complete)
     if callable(detector):
         return detector
     raise TypeError(

--- a/src/odyssey/runners/agents/planned.py
+++ b/src/odyssey/runners/agents/planned.py
@@ -6,8 +6,13 @@ This is the multi-agent eval orchestrator. Before each episode:
      phase transition strategy determining when to advance.
 
 Phase transition strategies:
-  * ``fixed_steps`` (default) — advance after N steps per phase.
-  * ``timeout`` — advance after T seconds per phase.
+  * ``fixed_steps`` (default) — advance after N steps per phase (open-loop).
+  * ``timeout`` — advance after T seconds per phase (open-loop).
+  * ``completion`` — advance when a ``ChunkCompletionGate`` judges the current
+    sub-instruction done (closed-loop *hand-back*). This is the chunk-aware
+    completion-gated regime: the gate polls a completion detector once per
+    action chunk (shared with the GR00T / π0.5 chunk pilots), and the phase
+    advances the moment control is handed back, instead of on a fixed budget.
 
 The runtime is simulator-agnostic: callers (e.g. RobosuiteRunner)
 drive the step loop and call ``get_action()`` each tick. The runtime
@@ -26,6 +31,7 @@ from typing import Any
 import numpy as np
 from numpy.typing import NDArray
 
+from odyssey.runners.agents.completion_gate import ChunkCompletionGate
 from odyssey.runners.agents.runtime import PilotRuntime, PlannerRuntime
 
 logger = logging.getLogger(__name__)
@@ -34,6 +40,7 @@ logger = logging.getLogger(__name__)
 class PhaseStrategy(str, Enum):
     FIXED_STEPS = "fixed_steps"
     TIMEOUT = "timeout"
+    COMPLETION = "completion"
 
 
 @dataclass
@@ -84,6 +91,13 @@ class PlannedEvalRuntime:
         Controls when to advance between sub-instructions.
     fallback_instruction:
         Used if the planner is None or returns no plan.
+    completion_gate:
+        Required only for ``PhaseStrategy.COMPLETION`` — the chunk-aware
+        ``ChunkCompletionGate`` that decides, once per action chunk, when the
+        current sub-instruction is done and the phase should advance (closed-loop
+        hand-back). Ignored by the ``fixed_steps`` / ``timeout`` strategies. If
+        the strategy is ``completion`` but no gate is supplied, the runtime never
+        advances on completion (falls back to running each phase open-ended).
     """
 
     def __init__(
@@ -93,12 +107,22 @@ class PlannedEvalRuntime:
         *,
         phase_config: PhaseConfig | None = None,
         fallback_instruction: str = "complete the task",
+        completion_gate: ChunkCompletionGate | None = None,
     ) -> None:
         self._pilot = pilot
         self._planner = planner
         self._phase_config = phase_config or PhaseConfig()
         self._fallback = fallback_instruction
+        self._gate = completion_gate
         self._state = _PhaseState()
+        if (
+            self._phase_config.strategy == PhaseStrategy.COMPLETION
+            and self._gate is None
+        ):
+            logger.warning(
+                "PlannedEvalRuntime: COMPLETION strategy without a completion_gate "
+                "— phases will not advance on completion (open-ended per phase)."
+            )
 
     @property
     def current_phase_index(self) -> int:
@@ -133,6 +157,8 @@ class PlannedEvalRuntime:
             sub_instructions=steps,
             phase_start_time=time.monotonic(),
         )
+        if self._gate is not None:
+            self._gate.reset()  # fresh chunk window for the new episode
         logger.info(
             "PlannedEvalRuntime: episode plan with %d phases: %s",
             len(steps),
@@ -152,10 +178,10 @@ class PlannedEvalRuntime:
 
         action = self._pilot.act(image, instruction)
         self._state.steps_in_phase += 1
-        self._maybe_advance_phase()
+        self._maybe_advance_phase(image, instruction)
         return action
 
-    def _maybe_advance_phase(self) -> None:
+    def _maybe_advance_phase(self, image: Any = None, instruction: str = "") -> None:
         if self._state.is_complete:
             return
 
@@ -169,10 +195,17 @@ class PlannedEvalRuntime:
             elapsed = time.monotonic() - self._state.phase_start_time
             if elapsed >= cfg.timeout_seconds:
                 advance = True
+        elif cfg.strategy == PhaseStrategy.COMPLETION:
+            # Closed-loop hand-back: the gate polls the completion detector once
+            # per action chunk and returns True when the sub-instruction is done.
+            if self._gate is not None and self._gate.update(image, instruction):
+                advance = True
 
         if advance:
             old_idx = self._state.current_index
             self._state.advance()
+            if self._gate is not None:
+                self._gate.reset()  # new sub-instruction -> fresh chunk window
             if not self._state.is_complete:
                 logger.debug(
                     "Phase %d → %d: %s",

--- a/src/odyssey/runners/agents/planned.py
+++ b/src/odyssey/runners/agents/planned.py
@@ -195,11 +195,14 @@ class PlannedEvalRuntime:
             elapsed = time.monotonic() - self._state.phase_start_time
             if elapsed >= cfg.timeout_seconds:
                 advance = True
-        elif cfg.strategy == PhaseStrategy.COMPLETION:
-            # Closed-loop hand-back: the gate polls the completion detector once
-            # per action chunk and returns True when the sub-instruction is done.
-            if self._gate is not None and self._gate.update(image, instruction):
-                advance = True
+        # Closed-loop hand-back: the gate polls the completion detector once
+        # per action chunk and returns True when the sub-instruction is done.
+        elif (
+            cfg.strategy == PhaseStrategy.COMPLETION
+            and self._gate is not None
+            and self._gate.update(image, instruction)
+        ):
+            advance = True
 
         if advance:
             old_idx = self._state.current_index

--- a/src/odyssey/runners/agents/runtime.py
+++ b/src/odyssey/runners/agents/runtime.py
@@ -1,6 +1,6 @@
 """Agent runtime protocols for multi-agent evaluation.
 
-Three runtime protocols define the interfaces between components:
+Four runtime protocols define the interfaces between components:
 
   * ``TextGenerator`` — wraps any text generation model. Maps chat
     messages to generated text. Lives at the model layer.
@@ -9,6 +9,10 @@ Three runtime protocols define the interfaces between components:
   * ``PlannerRuntime`` — wraps a task-planner. Decomposes a high-level
     task instruction into an ordered list of sub-instructions the pilot
     executes sequentially.
+  * ``CompletionDetector`` — wraps a completion judge (e.g. a VLM like
+    Gemma int4). Answers "is the current sub-instruction done?" so the
+    orchestrator can advance the phase (closed-loop *hand-back*) instead
+    of relying on a fixed step budget.
 
 These are ``typing.Protocol`` classes — any object that implements the
 right methods satisfies the protocol without explicit inheritance.
@@ -74,6 +78,36 @@ class PilotRuntime(Protocol):
         Returns
         -------
         7-DoF action array (end-effector delta + gripper).
+        """
+        ...
+
+
+@runtime_checkable
+class CompletionDetector(Protocol):
+    """Judges whether the current sub-instruction has been completed.
+
+    This is the closed-loop counterpart to a fixed step/timeout budget:
+    a completion judge (typically a VLM such as Gemma int4, or GR00T's
+    ``cosmos_reason``) looks at the current observation and the active
+    sub-instruction and answers whether the pilot has finished it, so the
+    orchestrator can *hand back* control and advance the phase.
+
+    Kept deliberately minimal so any fake/heuristic detector satisfies it
+    structurally. The polling cadence (once per action chunk, not per step)
+    is the ``ChunkCompletionGate``'s job, not the detector's — the detector
+    only answers the yes/no question when asked.
+    """
+
+    def is_complete(self, observation: Any, instruction: str) -> bool:
+        """Return ``True`` when ``instruction`` is judged complete.
+
+        Parameters
+        ----------
+        observation:
+            The current observation the judge grounds its decision in —
+            typically the camera image (PIL Image or HWC uint8 ndarray).
+        instruction:
+            The active sub-instruction whose completion is being judged.
         """
         ...
 

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -204,12 +204,18 @@ class LiberoRunner(Runner):
         cfg = spec.config or {}
 
         # Pilot backend. Default: the in-process OpenVLA policy / multi-agent
-        # runtime below. ``pilot: gr00t`` swaps to a GR00T pilot driven
-        # out-of-process via a policy server — its own subprocess recipe (same
-        # pattern as IsaacLabRunner), because GR00T inference is server-based,
-        # not in-process. Action chunking + a smaller footprint is why it exists.
-        if str(cfg.get("pilot", "openvla")).lower() == "gr00t":
+        # runtime below. ``pilot: gr00t`` and ``pilot: pi05`` both swap to a
+        # chunk-emitting pilot driven out-of-process via a policy server — each
+        # its own subprocess recipe (same pattern as IsaacLabRunner), because
+        # that inference is server-based, not in-process. Action chunking + a
+        # smaller footprint is why they exist. Both reuse the GR00T-LIBERO
+        # bridge (EvalProtocolCollector + summarize + the subprocess helper);
+        # only the eval script + argv builder differ.
+        pilot = str(cfg.get("pilot", "openvla")).lower()
+        if pilot == "gr00t":
             return await self._run_gr00t_pilot(context, spec)
+        if pilot == "pi05":
+            return await self._run_pi05_pilot(context, spec)
 
         suite_name = spec.benchmark_name
         task_id = int(cfg.get("task_id", 0))
@@ -427,6 +433,57 @@ class LiberoRunner(Runner):
             eval_script=script,
         )
 
+    async def _run_pi05_pilot(
+        self, context: TaskContext, spec: EvaluationTask
+    ) -> dict[str, Any]:
+        """Evaluate a π0.5 (openpi) pilot on LIBERO via the subprocess recipe.
+
+        Mirrors ``_run_gr00t_pilot`` — the two share the whole GR00T-LIBERO
+        bridge (``EvalProtocolCollector`` + ``summarize`` + the subprocess
+        helper); only the eval script (``pi05_libero_eval.py``, which serves /
+        drives the openpi WebsocketPolicyServer and replays chunks through the
+        pilot-agnostic ``ChunkPilotAdapter``) and the argv builder differ.
+        π0.5 inference is server-based, so this process only orchestrates and
+        scores.
+        """
+        cfg = spec.config or {}
+        checkpoint = resolve_eval_checkpoint(context)
+        script = str(Path(__file__).parent / "pi05_libero_eval.py")
+
+        video_dir: Path | None = None
+        if bool(cfg.get("capture_video", False)) and context.output_dir is not None:
+            video_dir = context.output_dir / "videos"
+
+        await context.emit_progress(
+            "executing",
+            step="env_construct",
+            step_label=f"suite={spec.benchmark_name} pilot=pi05",
+        )
+
+        collector = EvalProtocolCollector()
+        process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
+            script_path=script,
+            argv_extra=build_pi05_libero_argv(
+                spec=spec, checkpoint=checkpoint, video_dir=video_dir
+            ),
+            line_parser=collector.parse,
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("LIBERO(pi05) task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"pi05_libero_eval exited with code {rc}")
+
+        return summarize(
+            collector=collector,
+            spec=spec,
+            checkpoint=checkpoint,
+            eval_script=script,
+        )
+
 
 # Config keys the GR00T-LIBERO runner consumes itself — never forwarded as flags
 # to the eval script (mirrors isaac_lab._HANDLED_CONFIG_KEYS). Video is wired via
@@ -455,6 +512,37 @@ def build_gr00t_libero_argv(
         argv += ["--video_dir", str(video_dir)]
     for key, value in cfg.items():
         if key in _GR00T_HANDLED_CONFIG_KEYS:
+            continue
+        argv += [f"--{key}", str(value)]
+    return argv
+
+
+# π0.5 shares the GR00T handled-keys contract: video is wired via the resolved
+# --video_dir, and pilot/checkpoint/runner are consumed by the runner itself.
+_PI05_HANDLED_CONFIG_KEYS = _GR00T_HANDLED_CONFIG_KEYS
+
+
+def build_pi05_libero_argv(
+    *, spec: EvaluationTask, checkpoint: Path, video_dir: Path | None
+) -> list[str]:
+    """Build ``pi05_libero_eval.py`` argv: contract flags + config passthrough.
+
+    Same contract as ``build_gr00t_libero_argv`` (the shared GR00T-LIBERO
+    bridge): the eval script uses argparse snake_case flags, so ``task.config``
+    keys pass through verbatim (``n_action_steps`` → ``--n_action_steps``,
+    ``host``/``port`` → the openpi server address), minus the keys the runner
+    consumes itself.
+    """
+    cfg = spec.config or {}
+    argv: list[str] = [
+        "--task", spec.benchmark_name,
+        "--num_episodes", str(spec.num_episodes),
+        "--checkpoint", str(checkpoint),
+    ]
+    if video_dir is not None:
+        argv += ["--video_dir", str(video_dir)]
+    for key, value in cfg.items():
+        if key in _PI05_HANDLED_CONFIG_KEYS:
             continue
         argv += [f"--{key}", str(value)]
     return argv

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -89,7 +89,24 @@ def _make_libero_env(
             f"(has {n_tasks} tasks 0..{n_tasks - 1})."
         )
     task = suite.get_task(task_id)
-    init_states = suite.get_task_init_states(task_id)
+    # LIBERO's get_task_init_states() reads pickled numpy init states via
+    # torch.load(). PyTorch >= 2.6 flipped weights_only to True by default, which
+    # rejects numpy globals and raises UnpicklingError. These are trusted files
+    # shipped with the benchmark, so load them with weights_only=False. Contained
+    # monkeypatch (restored in finally) rather than a global torch.load override.
+    import torch
+
+    _orig_torch_load = torch.load
+
+    def _torch_load_weights_only_false(*args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault("weights_only", False)
+        return _orig_torch_load(*args, **kwargs)
+
+    torch.load = _torch_load_weights_only_false  # type: ignore[assignment]
+    try:
+        init_states = suite.get_task_init_states(task_id)
+    finally:
+        torch.load = _orig_torch_load  # type: ignore[assignment]
 
     bddl_file = os.path.join(
         get_libero_path("bddl_files"), task.problem_folder, task.bddl_file

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -96,17 +96,22 @@ def _make_libero_env(
     # monkeypatch (restored in finally) rather than a global torch.load override.
     import torch
 
-    _orig_torch_load = torch.load
+    # Route the reassignment through an Any-typed alias so mypy neither rejects
+    # the method assignment (torch present, with stubs) nor flags an unused
+    # suppression when torch is absent in CI (torch.load is then Any). Same
+    # behaviour either way; just keeps strict mypy green across both environments.
+    _torch: Any = torch
+    _orig_torch_load = _torch.load
 
     def _torch_load_weights_only_false(*args: Any, **kwargs: Any) -> Any:
         kwargs.setdefault("weights_only", False)
         return _orig_torch_load(*args, **kwargs)
 
-    torch.load = _torch_load_weights_only_false  # type: ignore[assignment]
+    _torch.load = _torch_load_weights_only_false
     try:
         init_states = suite.get_task_init_states(task_id)
     finally:
-        torch.load = _orig_torch_load  # type: ignore[assignment]
+        _torch.load = _orig_torch_load
 
     bddl_file = os.path.join(
         get_libero_path("bddl_files"), task.problem_folder, task.bddl_file

--- a/src/odyssey/runners/evals/pi05_fast.py
+++ b/src/odyssey/runners/evals/pi05_fast.py
@@ -6,6 +6,16 @@ quantization (see ``docs/pi05-scoping.md`` → "FAST tokenizer"). To turn those
 tokens back into the ``(action_horizon, action_dim)`` chunk the LIBERO recipe
 consumes, they have to be **detokenized** with the exact same FAST codec.
 
+.. note::
+   **Reserved scaffolding — NOT on the π0.5 flow-matching inference path.** The
+   π0.5 pilot in this repo (``make_pi05_pilot``) runs *flow matching* server-side
+   via the openpi ``WebsocketPolicyServer`` and returns **continuous** action
+   chunks (``client.infer`` → ``{"actions": ...}``); this codec is never called
+   at inference. FAST tokens only matter (a) in π0.5 *training* and (b) at
+   inference for an *autoregressive* ``π0-FAST`` model. This module is kept
+   (pinned by ``tests/unit/test_pi05_fast.py``) for a future π0-FAST pilot /
+   client-side detokenization, not wired into the current eval path.
+
 FAST is a **reusable library, not something to reimplement** — Physical
 Intelligence ships it as the HF ``AutoProcessor`` checkpoint
 ``physical-intelligence/fast`` (Apache 2.0), which openpi's ``FASTTokenizer``

--- a/src/odyssey/runners/evals/pi05_fast.py
+++ b/src/odyssey/runners/evals/pi05_fast.py
@@ -1,0 +1,143 @@
+"""FAST (Frequency-space Action Sequence Tokenization) codec for π0.5 chunks.
+
+π0.5's autoregressive path emits **discrete action tokens**, not a continuous
+chunk: FAST compresses each action sequence with a per-dimension DCT + JPEG-style
+quantization (see ``docs/pi05-scoping.md`` → "FAST tokenizer"). To turn those
+tokens back into the ``(action_horizon, action_dim)`` chunk the LIBERO recipe
+consumes, they have to be **detokenized** with the exact same FAST codec.
+
+FAST is a **reusable library, not something to reimplement** — Physical
+Intelligence ships it as the HF ``AutoProcessor`` checkpoint
+``physical-intelligence/fast`` (Apache 2.0), which openpi's ``FASTTokenizer``
+wraps underneath. So this module is pure integration glue:
+
+  * ``load_fast_tokenizer`` — lazily builds the HF ``AutoProcessor`` (or takes an
+    injected one), matching the missing-optional-backend contract used elsewhere
+    (openvla / gr00t): a ``NotImplementedError`` with an actionable message when
+    ``transformers`` is absent, so nothing downloads weights at import time;
+  * ``FastActionCodec`` — the thin encode/decode wrapper around that tokenizer,
+    single-chunk in / single-chunk out (it owns the batch-dim juggling that the
+    FAST API requires, exactly like openpi's ``tokenize`` / ``extract_actions``);
+  * ``normalize_to_unit`` / ``unnormalize_from_unit`` — the ``[-1, 1]`` mapping
+    FAST expects on its input, the *only* numeric work the scoping doc calls out
+    ("normalización a ``[-1, 1]``, wiring del chunk"), kept as pure functions.
+
+The decoded chunk feeds ``pi05_action_to_libero`` unchanged (slice to 7-D, no
+gripper fix-up). numpy-only at import — ``transformers`` is deferred — so the
+whole codec unit-tests on a CPU box with an injected fake tokenizer, no GPU and
+no weight download.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# The universal FAST+ tokenizer on the Hub (trained on 1M real action sequences).
+# openpi's FASTTokenizer defaults to this exact checkpoint underneath.
+DEFAULT_FAST_TOKENIZER = "physical-intelligence/fast"
+
+
+def load_fast_tokenizer(
+    path: str = DEFAULT_FAST_TOKENIZER,
+    *,
+    tokenizer: Any = None,
+) -> Any:
+    """Return a FAST tokenizer (HF ``AutoProcessor``) or the injected ``tokenizer``.
+
+    ``trust_remote_code=True`` is required: the FAST algorithm (DCT + quantize)
+    travels as code in the Hub repo. Deferred import of ``transformers`` keeps
+    this module numpy-only at load; a missing dep raises ``NotImplementedError``
+    with an actionable message (same contract as ``make_pi05_pilot`` for the
+    missing openpi client) rather than an opaque ``ImportError``.
+    """
+    if tokenizer is not None:
+        return tokenizer
+    try:
+        from transformers import AutoProcessor
+    except ImportError as e:  # pragma: no cover - exercised via load test when absent
+        raise NotImplementedError(
+            "FAST action detokenization requires 'transformers' (+ 'scipy'). "
+            "Install them and let the processor pull the "
+            f"'{DEFAULT_FAST_TOKENIZER}' checkpoint, or inject a tokenizer."
+        ) from e
+    return AutoProcessor.from_pretrained(path, trust_remote_code=True)
+
+
+def normalize_to_unit(actions, lo, hi) -> np.ndarray:
+    """Map physical actions into FAST's ``[-1, 1]`` input range via ``[lo, hi]``.
+
+    ``lo``/``hi`` are per-dimension bounds (e.g. the checkpoint's q01/q99 action
+    quantiles); scalars broadcast. Degenerate dims (``hi == lo``) map to 0 rather
+    than dividing by zero. Output is clipped to ``[-1, 1]`` so out-of-range
+    samples can't push FAST outside its trained domain.
+    """
+    arr = np.asarray(actions, dtype=np.float64)
+    lo = np.asarray(lo, dtype=np.float64)
+    hi = np.asarray(hi, dtype=np.float64)
+    span = hi - lo
+    safe = np.where(span == 0.0, 1.0, span)  # avoid /0 on flat dims
+    unit = 2.0 * (arr - lo) / safe - 1.0
+    unit = np.where(span == 0.0, 0.0, unit)
+    return np.clip(unit, -1.0, 1.0)
+
+
+def unnormalize_from_unit(unit, lo, hi) -> np.ndarray:
+    """Inverse of :func:`normalize_to_unit`: ``[-1, 1]`` → physical ``[lo, hi]``.
+
+    The exact inverse for in-range values (clipping in the forward map is the
+    only lossy step). Flat dims (``hi == lo``) return ``lo``.
+    """
+    u = np.asarray(unit, dtype=np.float64)
+    lo = np.asarray(lo, dtype=np.float64)
+    hi = np.asarray(hi, dtype=np.float64)
+    return lo + (u + 1.0) / 2.0 * (hi - lo)
+
+
+class FastActionCodec:
+    """Encode/detokenize a **single** π0.5 action chunk with a FAST tokenizer.
+
+    Wraps the FAST processor's batched API (``processor(actions)`` → tokens,
+    ``processor.decode(tokens, time_horizon=, action_dim=)`` → actions) so callers
+    work one chunk at a time — the codec adds/strips the leading batch axis itself,
+    mirroring openpi's ``tokenize`` / ``extract_actions``. ``time_horizon`` and
+    ``action_dim`` default the decode reshape (10×32 for ``pi05_libero``); either
+    can be overridden per call.
+    """
+
+    def __init__(self, tokenizer: Any, *, time_horizon: int, action_dim: int) -> None:
+        if time_horizon <= 0 or action_dim <= 0:
+            raise ValueError("time_horizon and action_dim must be positive")
+        self._tok = tokenizer
+        self.time_horizon = int(time_horizon)
+        self.action_dim = int(action_dim)
+
+    def encode(self, actions) -> Any:
+        """Tokenize one ``(time_horizon, action_dim)`` chunk (in ``[-1, 1]``).
+
+        Returns the token sequence for that chunk (FAST yields one token list per
+        batch item; the leading batch axis added here is stripped off the result).
+        """
+        arr = np.asarray(actions, dtype=np.float32)
+        if arr.ndim == 1:  # a single flat action -> horizon-1 chunk
+            arr = arr[None, :]
+        if arr.ndim != 2:
+            raise ValueError(
+                f"expected a (time_horizon, action_dim) chunk, got shape {arr.shape}"
+            )
+        tokens = self._tok(arr[None])  # add batch axis -> list of length 1
+        return tokens[0]
+
+    def decode(self, tokens, *, time_horizon: int | None = None,
+               action_dim: int | None = None) -> np.ndarray:
+        """Detokenize one token sequence back to a ``(time_horizon, action_dim)`` chunk.
+
+        Passes ``time_horizon``/``action_dim`` to the FAST decode (they're needed
+        to un-flatten the variable-length token stream) and strips the batch axis.
+        """
+        th = int(time_horizon) if time_horizon is not None else self.time_horizon
+        ad = int(action_dim) if action_dim is not None else self.action_dim
+        toks = tokens.tolist() if hasattr(tokens, "tolist") else list(tokens)
+        actions = self._tok.decode([toks], time_horizon=th, action_dim=ad)
+        return np.asarray(actions[0], dtype=np.float32).reshape(th, ad)

--- a/src/odyssey/runners/evals/pi05_fast.py
+++ b/src/odyssey/runners/evals/pi05_fast.py
@@ -102,7 +102,7 @@ class FastActionCodec:
     ``processor.decode(tokens, time_horizon=, action_dim=)`` → actions) so callers
     work one chunk at a time — the codec adds/strips the leading batch axis itself,
     mirroring openpi's ``tokenize`` / ``extract_actions``. ``time_horizon`` and
-    ``action_dim`` default the decode reshape (10×32 for ``pi05_libero``); either
+    ``action_dim`` default the decode reshape (10x32 for ``pi05_libero``); either
     can be overridden per call.
     """
 

--- a/src/odyssey/runners/evals/pi05_libero_eval.py
+++ b/src/odyssey/runners/evals/pi05_libero_eval.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""π0.5 (openpi) evaluation recipe for the LIBERO benchmark (single-agent pilot).
+
+Sibling of ``gr00t_libero_eval.py``: same subprocess + policy-server pattern and
+the same LIBERO (robosuite/MuJoCo) env layer, but the pilot is **π0.5** served by
+openpi's ``WebsocketPolicyServer``. ``LiberoRunner`` launches this script
+(``pilot: pi05``) under the Odyssey interpreter, owns the ``ODYSSEY_*`` stdout
+protocol, cancellation and scoring; this script owns the π0.5 <-> LIBERO recipe:
+build the env, drive the pilot, replay the returned action *chunk* open-loop, and
+report each episode.
+
+Unlike GR00T (which can boot its own server in-process with ``--serve_checkpoint``),
+π0.5 here is **open-loop only**: start the openpi server yourself (e.g.
+``scripts/serve_policy.py`` with a ``pi05_libero`` checkpoint) and point this
+recipe at ``--host``/``--port``. ``--checkpoint`` is recorded in the summary but
+NOT loaded here — the server already holds the weights. FAST detokenization (if
+any) happens **server-side**; this process only receives continuous action chunks
+(see ``docs/pi05-scoping.md`` → "FAST tokenizer" and ``pi05_fast.py``'s note).
+
+Chunk replay is NOT hand-rolled here: ``make_pi05_pilot`` wraps the openpi client
+in the pilot-agnostic ``ChunkPilotAdapter`` (buffer + replay + flush-on-
+instruction-change), so this loop just calls ``pilot.act`` once per env step and
+the adapter re-queries when the chunk drains (``runners/agents/chunk_pilot.py``).
+
+Launch contract (built by ``LiberoRunner`` for ``pilot: pi05``)::
+
+    python pi05_libero_eval.py \
+        --task <suite> --num_episodes <N> --checkpoint <path> \
+        --task_id 0 --host H --port P --n_action_steps 10 [--translation_only false ...]
+
+It prints, per the runner's protocol::
+
+    ODYSSEY_EPISODE {"index": 1, "total": 10, "success": true, "return": 1.0}
+    ODYSSEY_RESULT  {"success_rate": 0.1, "performance_score": 0.1, "metrics": {}}
+
+Heavy deps (numpy, libero, the openpi client, the sibling transforms) are imported
+lazily in the run path so the module imports under the bare stdlib and its argv +
+protocol surface stay unit-testable on a CPU box.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# When launched as a script (python …/runners/evals/pi05_libero_eval.py), sys.path[0]
+# is THIS file's directory — which also holds libero.py (the odyssey LiberoRunner).
+# That shadows the real LIBERO namespace package, so `from libero.libero import …`
+# fails with "'libero' is not a package". Drop this dir; odyssey's own modules still
+# import via the installed (editable) package, not the script dir. (Mirrors
+# gr00t_libero_eval.py.)
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path[:] = [p for p in sys.path if os.path.abspath(p or ".") != _HERE]
+
+log = logging.getLogger("pi05_libero_eval")
+
+# Same ODYSSEY_* stdout protocol the runner's EvalProtocolCollector parses
+# (src/odyssey/runners/evals/isaac_lab.py). Kept as small local emitters — each
+# eval recipe owns its protocol output (mirrors gr00t_libero_eval.py).
+_EPISODE_PREFIX = "ODYSSEY_EPISODE "
+_RESULT_PREFIX = "ODYSSEY_RESULT "
+
+
+def _bool(value: str) -> bool:
+    """argparse type for booleans forwarded as ``--flag <value>`` strings.
+
+    The runner forwards every ``task.config`` key verbatim as ``--key value``,
+    so a ``store_true`` flag would choke on the trailing value.
+    """
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Launch contract + ODYSSEY_* protocol  (stdlib only -> unit-testable anywhere)
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    """Argv per the LIBERO launch contract + π0.5 passthrough config."""
+    ap = argparse.ArgumentParser(description="π0.5 (openpi) policy eval on LIBERO.")
+    # --- contract flags ---
+    ap.add_argument("--task", required=True, help="LIBERO suite (benchmark_name).")
+    ap.add_argument("--num_episodes", type=int, default=10)
+    ap.add_argument("--checkpoint", default="",
+                    help="π0.5 checkpoint id/path. Recorded in the summary only — the "
+                         "openpi server (pre-started) already holds the weights.")
+    # --- LIBERO recipe config (task.config passthrough) ---
+    ap.add_argument("--task_id", type=int, default=0, help="task index within the suite.")
+    ap.add_argument("--instruction", default="", help="override; default is the suite's own.")
+    ap.add_argument("--task_instruction", default="", help="declared instruction (contract check).")
+    ap.add_argument("--strict_instruction", type=_bool, default=False)
+    ap.add_argument("--image_key", default="agentview_image")
+    ap.add_argument("--wrist_image_key", default="robot0_eye_in_hand_image")
+    ap.add_argument("--flip_images", type=_bool, default=True,
+                    help="180° flip (LIBERO offscreen frames are stored rotated).")
+    ap.add_argument("--camera_height", type=int, default=256)
+    ap.add_argument("--camera_width", type=int, default=256)
+    ap.add_argument("--max_steps_per_episode", type=int, default=520)
+    ap.add_argument("--num_warmup_steps", type=int, default=10)
+    ap.add_argument("--video_dir", default="", help="if set, write one mp4 per episode here.")
+    # --- openpi server + action-chunk config ---
+    ap.add_argument("--host", default="127.0.0.1", help="openpi WebsocketPolicyServer host.")
+    ap.add_argument("--port", type=int, default=8000, help="openpi WebsocketPolicyServer port.")
+    ap.add_argument("--api_key", default="", help="optional openpi server API key.")
+    ap.add_argument("--n_action_steps", type=int, default=10,
+                    help="steps replayed per π0.5 chunk before re-querying "
+                         "(match the checkpoint's action_horizon; 10 for pi05_libero).")
+    ap.add_argument("--translation_only", type=_bool, default=False,
+                    help="de-risk: zero rotation + fixed-open gripper.")
+    return ap
+
+
+def episode_line(*, index: int, total: int, success: bool, ret: float) -> str:
+    """One ``ODYSSEY_EPISODE`` protocol line (consumed by the runner's collector)."""
+    return _EPISODE_PREFIX + json.dumps(
+        {"index": int(index), "total": int(total),
+         "success": bool(success), "return": float(ret)})
+
+
+def result_line(*, success_rate: float, performance_score: float,
+                metrics: dict | None = None) -> str:
+    """The optional ``ODYSSEY_RESULT`` summary line."""
+    return _RESULT_PREFIX + json.dumps(
+        {"success_rate": float(success_rate),
+         "performance_score": float(performance_score),
+         "metrics": dict(metrics or {})})
+
+
+def _emit(line: str) -> None:
+    # The runner reads stdout line-by-line; flush so episodes stream in real time.
+    print(line, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Env-coupled obs glue (numpy + odyssey helpers; imported lazily)
+# ---------------------------------------------------------------------------
+
+def _frame(obs, key: str, *, flip: bool):
+    import numpy as np
+    img = np.asarray(obs[key])
+    if flip:
+        img = img[::-1, ::-1]
+    return np.ascontiguousarray(img).astype(np.uint8)
+
+
+def _raw_obs(obs, *, image_key, wrist_image_key, flip) -> dict:
+    """Shape a LIBERO env observation into ``make_pi05_pilot``'s ``raw_obs`` kwargs.
+
+    ``ChunkPilotAdapter``'s injected ``observation_builder`` calls
+    ``build_pi05_libero_obs(instruction=..., **raw_obs)``, so the keys here MUST
+    match its signature: image / wrist_image / eef_pos / eef_quat_xyzw /
+    gripper_qpos. robosuite obs keys: ``robot0_eef_pos`` (3), ``robot0_eef_quat``
+    (xyzw, 4), ``robot0_gripper_qpos`` (2 finger joints). Images are pre-flipped
+    to the pilot's orientation, matching the GR00T-LIBERO recipe.
+    """
+    import numpy as np
+    return {
+        "image": _frame(obs, image_key, flip=flip),
+        "wrist_image": _frame(obs, wrist_image_key, flip=flip),
+        "eef_pos": np.asarray(obs["robot0_eef_pos"], np.float64).reshape(-1)[:3],
+        "eef_quat_xyzw": np.asarray(obs["robot0_eef_quat"], np.float64).reshape(-1)[:4],
+        "gripper_qpos": np.asarray(obs["robot0_gripper_qpos"], np.float64).reshape(-1)[:2],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Run path (heavy imports live here)
+# ---------------------------------------------------------------------------
+
+def run_eval(args: argparse.Namespace) -> dict:
+    from odyssey.runners.evals.libero import (
+        _make_libero_env,
+        _resolve_libero_instruction,
+    )
+    from odyssey.runners.models.pi05 import make_pi05_pilot
+    from odyssey.runners.video import save_rollout_video, to_uint8_frame
+
+    cfg = {
+        "camera_height": args.camera_height,
+        "camera_width": args.camera_width,
+        "task_instruction": args.task_instruction or None,
+        "strict_instruction": args.strict_instruction,
+    }
+    # robosuite's internal horizon must exceed the full per-episode step budget
+    # (warmup + max_steps) or it terminates mid-rollout — mirror LiberoRunner.
+    env_horizon = args.num_warmup_steps + args.max_steps_per_episode + 100
+    env, task, init_states = _make_libero_env(
+        args.task, args.task_id, cfg, horizon=env_horizon
+    )
+    instruction = args.instruction or _resolve_libero_instruction(task, cfg)
+    log.info("LIBERO suite=%s task_id=%d instruction=%r", args.task, args.task_id, instruction)
+
+    # Open-loop: the openpi server is pre-started and already holds the weights;
+    # make_pi05_pilot wraps its websocket client in the ChunkPilotAdapter.
+    log.info("connecting to openpi π0.5 server at %s:%d (checkpoint=%r served externally)",
+             args.host, args.port, args.checkpoint)
+    pilot = make_pi05_pilot(
+        host=args.host,
+        port=args.port,
+        n_action_steps=args.n_action_steps,
+        api_key=args.api_key or None,
+        translation_only=args.translation_only,
+    )
+
+    successes, returns = 0, []
+    video_dir = args.video_dir or None
+    dummy = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]  # no-op, gripper open (physics settle)
+
+    for ep in range(1, args.num_episodes + 1):
+        obs = env.reset()
+        env.set_init_state(init_states[(ep - 1) % len(init_states)])
+        for _ in range(args.num_warmup_steps):
+            obs, _, _, _ = env.step(dummy)
+
+        ep_return, success = 0.0, False
+        frames: list = []
+        pilot.reset()  # drop the chunk buffer so the first act re-queries this episode
+        step = 0
+        try:
+            while step < args.max_steps_per_episode and not success:
+                # One act per env step; the ChunkPilotAdapter buffers the chunk and
+                # only re-queries the openpi server when it drains (every n_action_steps).
+                action = pilot.act(
+                    _raw_obs(
+                        obs,
+                        image_key=args.image_key,
+                        wrist_image_key=args.wrist_image_key,
+                        flip=args.flip_images,
+                    ),
+                    instruction,
+                )
+                obs, reward, done, _info = env.step(action.tolist())
+                ep_return += float(reward)
+                if video_dir is not None:
+                    # match the pilot's orientation: LIBERO's agentview is stored
+                    # 180°-rotated, so flip the video frame too (else it's upside down).
+                    frame = to_uint8_frame(_frame(obs, args.image_key, flip=args.flip_images))
+                    if frame is not None:
+                        frames.append(frame)
+                step += 1
+                if done:  # LIBERO sets done=True when the task is solved
+                    success = True
+                    break
+        except Exception as ep_exc:
+            # A flaky infer()/env.step() must not abort the whole sweep (that would
+            # drop the remaining episodes AND the final ODYSSEY_RESULT line).
+            log.warning("episode %d/%d aborted (%s) — recording as fail, continuing.",
+                        ep, args.num_episodes, ep_exc, exc_info=True)
+
+        successes += int(success)
+        returns.append(ep_return)
+        log.info("episode %d/%d: %s (steps=%d, return=%.3f)",
+                 ep, args.num_episodes, "SUCCESS" if success else "fail", step, ep_return)
+        _emit(episode_line(index=ep, total=args.num_episodes, success=success, ret=ep_return))
+
+        if video_dir and frames:
+            os.makedirs(video_dir, exist_ok=True)
+            tag = "PASS" if success else "FAIL"
+            save_rollout_video(frames, Path(video_dir) / f"episode_{ep:02d}_{tag}.mp4", 24)
+
+    env.close()
+    n = max(args.num_episodes, 1)
+    success_rate = successes / n
+    summary = {
+        "success_rate": success_rate,
+        "performance_score": success_rate,
+        "metrics": {
+            "successes": successes,
+            "episode_returns": [round(r, 4) for r in returns],
+            "benchmark": f"{args.task}[task={args.task_id}]",
+            "instruction": instruction,
+        },
+    }
+    _emit(result_line(**summary))
+    return summary
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    args = build_parser().parse_args()
+    run_eval(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/odyssey/runners/evals/pi05_libero_eval.py
+++ b/src/odyssey/runners/evals/pi05_libero_eval.py
@@ -6,11 +6,11 @@ the same LIBERO (robosuite/MuJoCo) env layer, but the pilot is **π0.5** served 
 openpi's ``WebsocketPolicyServer``. ``LiberoRunner`` launches this script
 (``pilot: pi05``) under the Odyssey interpreter, owns the ``ODYSSEY_*`` stdout
 protocol, cancellation and scoring; this script owns the π0.5 <-> LIBERO recipe:
-build the env, drive the pilot, replay the returned action *chunk* open-loop, and
-report each episode.
+build the env, drive the pilot, replay the returned action *chunk* open-loop
+(within the chunk — no re-observation until it drains), and report each episode.
 
 Unlike GR00T (which can boot its own server in-process with ``--serve_checkpoint``),
-π0.5 here is **open-loop only**: start the openpi server yourself (e.g.
+π0.5 here is **externally-served**: start the openpi server yourself (e.g.
 ``scripts/serve_policy.py`` with a ``pi05_libero`` checkpoint) and point this
 recipe at ``--host``/``--port``. ``--checkpoint`` is recorded in the summary but
 NOT loaded here — the server already holds the weights. FAST detokenization (if
@@ -192,8 +192,8 @@ def run_eval(args: argparse.Namespace) -> dict:
     instruction = args.instruction or _resolve_libero_instruction(task, cfg)
     log.info("LIBERO suite=%s task_id=%d instruction=%r", args.task, args.task_id, instruction)
 
-    # Open-loop: the openpi server is pre-started and already holds the weights;
-    # make_pi05_pilot wraps its websocket client in the ChunkPilotAdapter.
+    # Externally-served: the openpi server is pre-started and already holds the
+    # weights; make_pi05_pilot wraps its websocket client in the ChunkPilotAdapter.
     log.info("connecting to openpi π0.5 server at %s:%d (checkpoint=%r served externally)",
              args.host, args.port, args.checkpoint)
     pilot = make_pi05_pilot(

--- a/src/odyssey/runners/evals/pi05_norm.py
+++ b/src/odyssey/runners/evals/pi05_norm.py
@@ -1,6 +1,6 @@
 """π0.5 (openpi) action-space normalization — the analog of OpenVLA's ``unnorm_key``.
 
-See ``docs/pi05-scoping.md`` → "Mapeo de espacio de acción". The one-line summary:
+See ``docs/pi05-scoping.md`` → "Action space mapping". The one-line summary:
 
   **π0.5 has no ``unnorm_key``.** Where OpenVLA passes a string at inference time to
   pick which de-normalization statistics to apply to the 7-D action, π0.5/openpi
@@ -63,11 +63,11 @@ class NormStats:
     q99: np.ndarray | None = None
 
     @staticmethod
-    def from_mean_std(mean, std) -> "NormStats":
+    def from_mean_std(mean, std) -> NormStats:
         return NormStats(mean=_as_1d(mean), std=_as_1d(std))
 
     @staticmethod
-    def from_quantiles(q01, q99) -> "NormStats":
+    def from_quantiles(q01, q99) -> NormStats:
         return NormStats(q01=_as_1d(q01), q99=_as_1d(q99))
 
 
@@ -183,7 +183,7 @@ def assert_no_unnorm_key(config) -> None:
 
     Unlike OpenVLA, π0.5's de-normalization is self-contained in the checkpoint
     (``norm_stats``/``asset_id``), so an ``unnorm_key`` in the YAML would be inert or
-    misleading (``docs/pi05-scoping.md`` → "No añadir ``unnorm_key`` al YAML de π0.5").
+    misleading (``docs/pi05-scoping.md`` → "The exact analog of ``unnorm_key``").
     Reject it early to keep configs honest.
     """
     if isinstance(config, dict) and "unnorm_key" in config:

--- a/src/odyssey/runners/evals/pi05_norm.py
+++ b/src/odyssey/runners/evals/pi05_norm.py
@@ -1,0 +1,194 @@
+"""π0.5 (openpi) action-space normalization — the analog of OpenVLA's ``unnorm_key``.
+
+See ``docs/pi05-scoping.md`` → "Mapeo de espacio de acción". The one-line summary:
+
+  **π0.5 has no ``unnorm_key``.** Where OpenVLA passes a string at inference time to
+  pick which de-normalization statistics to apply to the 7-D action, π0.5/openpi
+  bakes a ``norm_stats.json`` **inside the checkpoint** (under ``assets/<asset_id>/``)
+  and selects it by the ``asset_id``/``repo_id`` it was trained with — NOT by a key
+  the mission YAML carries. For ``pi05_libero`` that ``asset_id`` is
+  ``physical-intelligence/libero``.
+
+So the "knob" analogous to ``unnorm_key`` is the **asset_id** (which norm_stats to
+use); the *math* it drives is a plain affine (mean/std) or quantile map between the
+model's normalized space and the simulator's physical units. openpi runs that math
+server-side inside ``Normalize``/``Unnormalize``; this module mirrors it in numpy so
+the odyssey side can (a) reason about the mapping, (b) resolve the asset_id, and
+(c) reject a stray ``unnorm_key`` in a π0.5 mission config — all without a GPU, a
+served checkpoint, or downloaded weights.
+
+Pipeline this module models (both directions), matching openpi's LIBERO recipe:
+
+  observation  8-D Franka Panda state ──pad_to_dim(32)──► normalize(norm_stats) ──► model
+  action       model (H,32) normalized ──unnormalize(norm_stats)──► slice[:7] ──► env.step
+
+numpy-only, so it imports and unit-tests without openpi / torch / jax.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# PI0/π0.5 family model width; the 8-D state is padded up to this and the action
+# chunk comes out at this width before it is sliced back to LIBERO's 7-DoF.
+PI0_ACTION_DIM = 32
+# LIBERO's native OSC_POSE action applied to env.step: [dx,dy,dz,droll,dpitch,dyaw,gripper].
+LIBERO_ACTION_DIM = 7
+# openpi's normalization epsilon (src/openpi/transforms.py) — keep in lockstep so the
+# numpy mirror round-trips against the served de-normalization.
+NORM_EPS = 1e-6
+
+# The ``unnorm_key`` analog: which baked ``norm_stats`` asset a π0.5 checkpoint uses.
+# Keyed by a checkpoint-name substring; the value is openpi's ``asset_id`` (the string
+# under ``assets/`` in the checkpoint). This is selected at TRAIN time and travels with
+# the weights — it is NOT a mission-config knob (unlike OpenVLA's ``unnorm_key``).
+PI05_NORM_ASSETS = {
+    "pi05_libero": "physical-intelligence/libero",
+}
+
+
+@dataclass(frozen=True)
+class NormStats:
+    """Per-dimension normalization statistics, mirroring openpi's ``NormStats``.
+
+    ``mean``/``std`` drive the default affine map; ``q01``/``q99`` drive the quantile
+    map (``use_quantiles=True``). Only the pair for the chosen mode is required.
+    """
+
+    mean: np.ndarray | None = None
+    std: np.ndarray | None = None
+    q01: np.ndarray | None = None
+    q99: np.ndarray | None = None
+
+    @staticmethod
+    def from_mean_std(mean, std) -> "NormStats":
+        return NormStats(mean=_as_1d(mean), std=_as_1d(std))
+
+    @staticmethod
+    def from_quantiles(q01, q99) -> "NormStats":
+        return NormStats(q01=_as_1d(q01), q99=_as_1d(q99))
+
+
+def _as_1d(x) -> np.ndarray:
+    return np.asarray(x, dtype=np.float64).reshape(-1)
+
+
+def normalize(x, stats: NormStats, *, use_quantiles: bool = False) -> np.ndarray:
+    """Map physical-unit values into the model's normalized space (openpi ``Normalize``).
+
+    ``mean_std`` (default): ``(x - mean) / (std + eps)``.
+    ``quantile``: ``(x - q01) / (q99 - q01 + eps) * 2 - 1`` (target range ``[-1, 1]``).
+    """
+    x = np.asarray(x, dtype=np.float64)
+    if use_quantiles:
+        _require(stats.q01, stats.q99, mode="quantile")
+        return (x - stats.q01) / (stats.q99 - stats.q01 + NORM_EPS) * 2.0 - 1.0
+    _require(stats.mean, stats.std, mode="mean_std")
+    return (x - stats.mean) / (stats.std + NORM_EPS)
+
+
+def unnormalize(x, stats: NormStats, *, use_quantiles: bool = False) -> np.ndarray:
+    """Inverse of :func:`normalize` — model-normalized values back to physical units.
+
+    This is the exact step openpi's ``Unnormalize`` runs on the action chunk with the
+    checkpoint's baked ``norm_stats``; it is the direct analog of OpenVLA applying its
+    ``unnorm_key`` statistics inside ``predict_action``.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    if use_quantiles:
+        _require(stats.q01, stats.q99, mode="quantile")
+        return (x + 1.0) / 2.0 * (stats.q99 - stats.q01 + NORM_EPS) + stats.q01
+    _require(stats.mean, stats.std, mode="mean_std")
+    return x * (stats.std + NORM_EPS) + stats.mean
+
+
+def _require(*fields, mode: str) -> None:
+    if any(f is None for f in fields):
+        raise ValueError(
+            f"NormStats is missing the fields required for '{mode}' normalization"
+        )
+
+
+def pad_to_dim(x, target_dim: int = PI0_ACTION_DIM) -> np.ndarray:
+    """Zero-pad the last axis up to ``target_dim`` (openpi ``pad_to_dim``).
+
+    The 8-D Franka Panda state is padded to the model's 32-D width before it is
+    normalized; a no-op when ``x`` already meets/exceeds ``target_dim``.
+    """
+    x = np.asarray(x, dtype=np.float64)
+    current = x.shape[-1]
+    if current >= target_dim:
+        return x
+    pad = [(0, 0)] * x.ndim
+    pad[-1] = (0, target_dim - current)
+    return np.pad(x, pad)
+
+
+def slice_to_libero(x, dim: int = LIBERO_ACTION_DIM) -> np.ndarray:
+    """Slice the last axis to LIBERO's 7-DoF (openpi ``LiberoOutputs`` ``actions[..., :7]``).
+
+    The tail of the 32-D model action is padding; only the first 7 dims are the
+    ``[dx,dy,dz,droll,dpitch,dyaw,gripper]`` OSC_POSE command env.step consumes.
+    """
+    return np.asarray(x, dtype=np.float64)[..., :dim]
+
+
+def pi05_state_to_model(state, stats: NormStats, *,
+                        use_quantiles: bool = False,
+                        target_dim: int = PI0_ACTION_DIM) -> np.ndarray:
+    """8-D proprio state → padded-to-32 → normalized: what openpi feeds the model."""
+    return normalize(pad_to_dim(state, target_dim), stats, use_quantiles=use_quantiles)
+
+
+def pi05_action_to_sim(action, stats: NormStats, *,
+                       use_quantiles: bool = False,
+                       dim: int = LIBERO_ACTION_DIM) -> np.ndarray:
+    """Model action (normalized, ≥7-D) → un-normalized → sliced to LIBERO's 7-DoF.
+
+    The gripper channel is passed through with NO fix-up — π0.5's checkpoint is baked
+    to LIBERO's gripper convention (contrast GR00T, which normalizes+inverts). See
+    ``docs/pi05-scoping.md``: ⚠ confirm gripper polarity on the first GPU rollout.
+    """
+    return slice_to_libero(
+        unnormalize(action, stats, use_quantiles=use_quantiles), dim
+    )
+
+
+def resolve_pi05_asset_id(checkpoint: str, *, override: str | None = None) -> str:
+    """Resolve the baked ``asset_id`` (the ``unnorm_key`` analog) for a π0.5 checkpoint.
+
+    Matches a known checkpoint-name substring (e.g. ``lerobot/pi05_libero`` or
+    ``gs://openpi-assets/checkpoints/pi05_libero`` → ``physical-intelligence/libero``).
+    ``override`` short-circuits the lookup for a custom fine-tune whose asset differs
+    from its checkpoint name. Raises ``KeyError`` for an unknown checkpoint so a
+    mission fails loudly rather than silently de-normalizing with the wrong stats.
+    """
+    if override:
+        return override
+    name = str(checkpoint).rstrip("/").rsplit("/", 1)[-1].lower()
+    for key, asset in PI05_NORM_ASSETS.items():
+        if key in name:
+            return asset
+    raise KeyError(
+        f"No baked norm-stats asset_id known for π0.5 checkpoint {checkpoint!r}; "
+        f"known checkpoints: {sorted(PI05_NORM_ASSETS)}. Pass override=... for a "
+        f"custom fine-tune."
+    )
+
+
+def assert_no_unnorm_key(config) -> None:
+    """Guard: a π0.5 mission config must NOT carry an ``unnorm_key``.
+
+    Unlike OpenVLA, π0.5's de-normalization is self-contained in the checkpoint
+    (``norm_stats``/``asset_id``), so an ``unnorm_key`` in the YAML would be inert or
+    misleading (``docs/pi05-scoping.md`` → "No añadir ``unnorm_key`` al YAML de π0.5").
+    Reject it early to keep configs honest.
+    """
+    if isinstance(config, dict) and "unnorm_key" in config:
+        raise ValueError(
+            "π0.5 configs must NOT set 'unnorm_key': de-normalization is baked into "
+            "the checkpoint (norm_stats/asset_id), so the key is inert/misleading. "
+            "Remove it; the asset_id is resolved from the checkpoint instead."
+        )

--- a/src/odyssey/runners/evals/pi05_transforms.py
+++ b/src/odyssey/runners/evals/pi05_transforms.py
@@ -1,7 +1,7 @@
 """Pure π0.5 (openpi) obs/action transforms for the LIBERO eval recipe.
 
 π0.5-LIBERO shares the **same Franka Panda convention** as GR00T-N1.7-LIBERO and
-OpenVLA (see ``docs/pi05-scoping.md`` → "Mapeo de espacio de acción"): the 8-D
+OpenVLA (see ``docs/pi05-scoping.md`` → "Action space mapping"): the 8-D
 proprio state (eef pos + eef quat→axis-angle + 2 gripper finger qpos) and the
 7-DoF OSC_POSE action ``[dx,dy,dz,droll,dpitch,dyaw,gripper]``. So this module
 does NOT re-derive the kinematics — it **reuses** ``quat_xyzw_to_axis_angle``

--- a/src/odyssey/runners/evals/pi05_transforms.py
+++ b/src/odyssey/runners/evals/pi05_transforms.py
@@ -1,0 +1,107 @@
+"""Pure π0.5 (openpi) obs/action transforms for the LIBERO eval recipe.
+
+π0.5-LIBERO shares the **same Franka Panda convention** as GR00T-N1.7-LIBERO and
+OpenVLA (see ``docs/pi05-scoping.md`` → "Mapeo de espacio de acción"): the 8-D
+proprio state (eef pos + eef quat→axis-angle + 2 gripper finger qpos) and the
+7-DoF OSC_POSE action ``[dx,dy,dz,droll,dpitch,dyaw,gripper]``. So this module
+does NOT re-derive the kinematics — it **reuses** ``quat_xyzw_to_axis_angle``
+from ``gr00t_transforms`` and only adds the two things π0.5 does differently:
+
+  * **wire format** — openpi's ``LiberoInputs`` expects flat ``observation/*``
+    keys (``observation/image``, ``observation/wrist_image``, ``observation/state``,
+    ``prompt``) and a single 8-D state vector, NOT GR00T's dotted ``state.x`` /
+    ``video.image`` fan-out;
+  * **NO gripper fix-up** — π0.5's checkpoint was trained on data already in
+    LIBERO's gripper convention and its ``norm_stats`` fix the scale, so the
+    action is sliced to 7-D and passed to ``env.step`` verbatim (no
+    normalize/binarize/invert, unlike GR00T's ``gr00t_action_to_libero``).
+    ⚠ Verify gripper polarity on the first GPU rollout (silent-failure footgun).
+
+numpy-only (via ``gr00t_transforms``) so it imports and unit-tests without
+openpi / torch / a GPU.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# Reuse the shared Franka Panda kinematics rather than duplicating it. This is
+# the exact same state convention NVIDIA's LIBERO eval + openpi's LiberoInputs
+# build: quat (xyzw) -> axis-angle.
+from odyssey.runners.evals.gr00t_transforms import quat_xyzw_to_axis_angle
+
+# openpi LiberoInputs wire keys (examples/libero/main.py in Physical-Intelligence/openpi).
+PI05_IMAGE_KEY = "observation/image"
+PI05_WRIST_IMAGE_KEY = "observation/wrist_image"
+PI05_STATE_KEY = "observation/state"
+PI05_PROMPT_KEY = "prompt"
+
+# LIBERO's native action width applied to env.step (dx,dy,dz,droll,dpitch,dyaw,gripper).
+LIBERO_ACTION_DIM = 7
+
+
+def build_pi05_libero_state(*, eef_pos, eef_quat_xyzw, gripper_qpos) -> np.ndarray:
+    """8-D Franka Panda proprio state openpi's ``LiberoInputs`` consumes.
+
+    ``[eef_pos(3), quat2axisangle(eef_quat)(3), gripper_qpos(2)]`` — identical to
+    the vector GR00T's ``build_gr00t_libero_obs`` builds; only the packaging into
+    the wire dict differs (one flat vector here vs. per-axis ``state.*`` there).
+    """
+    return np.concatenate([
+        np.asarray(eef_pos, dtype=np.float32).reshape(-1)[:3],
+        quat_xyzw_to_axis_angle(eef_quat_xyzw),
+        np.asarray(gripper_qpos, dtype=np.float32).reshape(-1)[:2],
+    ]).astype(np.float32)
+
+
+def build_pi05_libero_obs(*, image, wrist_image, eef_pos, eef_quat_xyzw,
+                          gripper_qpos, instruction) -> dict:
+    """FLAT openpi ``observation/*`` obs dict for π0.5-LIBERO.
+
+    Images are ``uint8 (H, W, C)`` (already 180°-flipped by the caller, matching
+    the GR00T-LIBERO recipe). openpi's server-side ``LiberoInputs`` handles the
+    third (right-wrist) camera mask, the pad-to-32 of the state, and normalization
+    with the checkpoint's ``norm_stats`` — so this stays a thin, single-arm packer.
+    """
+    return {
+        PI05_IMAGE_KEY: np.asarray(image, dtype=np.uint8),
+        PI05_WRIST_IMAGE_KEY: np.asarray(wrist_image, dtype=np.uint8),
+        PI05_STATE_KEY: build_pi05_libero_state(
+            eef_pos=eef_pos, eef_quat_xyzw=eef_quat_xyzw, gripper_qpos=gripper_qpos,
+        ),
+        PI05_PROMPT_KEY: str(instruction),
+    }
+
+
+def _pi05_action_chunk(chunk) -> np.ndarray:
+    """Coerce an openpi inference result into a ``(horizon, >=7)`` float array.
+
+    The websocket server returns ``{"actions": ndarray}`` (openpi ``LiberoOutputs``
+    already slices to 7-D); accept either that dict or a bare array, and normalize
+    to a 2-D ``(horizon, width)`` so step indexing is uniform.
+    """
+    arr = chunk["actions"] if isinstance(chunk, dict) and "actions" in chunk else chunk
+    arr = np.asarray(arr, dtype=np.float64)
+    if arr.ndim == 1:  # a single flat action -> a horizon-1 chunk
+        arr = arr[None, :]
+    return arr.reshape(arr.shape[0], -1)
+
+
+def pi05_action_to_libero(chunk, k, *, translation_only=False, **_legacy) -> np.ndarray:
+    """Map step ``k`` of a π0.5 action chunk to LIBERO's 7-DoF OSC_POSE action.
+
+    Slice the (already de-normalized) action to its first 7 dims and pass it
+    through **without** any gripper fix-up — π0.5's gripper is baked to LIBERO's
+    convention in the checkpoint (contrast ``gr00t_action_to_libero``, which
+    normalizes+inverts because GR00T emits the gripper in ``[0,1]``).
+    ``translation_only`` zeroes rotation and forces the gripper open (de-risk knob);
+    ``**_legacy`` swallows retired scale/gripper kwargs so old configs stay accepted.
+    """
+    vec = _pi05_action_chunk(chunk)[int(k)]
+    action = vec[:LIBERO_ACTION_DIM].astype(np.float32)
+    if action.shape[0] < LIBERO_ACTION_DIM:  # pad a short row (shouldn't happen)
+        action = np.concatenate([action, np.zeros(LIBERO_ACTION_DIM - action.shape[0], np.float32)])
+    if translation_only:
+        action[3:6] = 0.0
+        action[6] = 1.0  # gripper forced open
+    return action.astype(np.float32)

--- a/src/odyssey/runners/models/pi05.py
+++ b/src/odyssey/runners/models/pi05.py
@@ -38,6 +38,31 @@ def _make_pi05_client(*, host: str, port: int, api_key: str | None = None) -> An
             "Install openpi and serve a π0.5 checkpoint "
             "(e.g. scripts/serve_policy.py), then point the mission at host:port."
         ) from e
+
+    # Disable the client-side websocket keepalive. openpi's WebsocketPolicyServer
+    # is synchronous: the FIRST infer blocks its handler thread while JAX compiles
+    # the π0.5 graph (can take minutes), so it cannot answer the client's keepalive
+    # pings. With the default ping_interval (20s) the client then tears the
+    # connection down with 1011 "keepalive ping timeout" before the first chunk
+    # ever returns. openpi's WebsocketClientPolicy exposes no ping knob, so patch
+    # the connect it calls (websockets.sync.client.connect, resolved at call time)
+    # to default ping_interval=None. Server->client pings still work (the sync
+    # client auto-pongs on its reader thread); we only stop OUR keepalive.
+    try:  # pragma: no cover - requires the websockets runtime dep
+        import websockets.sync.client as _wsc
+
+        if not getattr(_wsc.connect, "_odyssey_no_keepalive", False):
+            _orig_connect = _wsc.connect
+
+            def _connect_no_keepalive(*a: Any, **k: Any) -> Any:
+                k.setdefault("ping_interval", None)
+                return _orig_connect(*a, **k)
+
+            _connect_no_keepalive._odyssey_no_keepalive = True  # type: ignore[attr-defined]
+            _wsc.connect = _connect_no_keepalive  # type: ignore[assignment]
+    except ImportError:
+        pass
+
     kwargs: dict[str, Any] = {"host": host, "port": int(port)}
     if api_key:
         kwargs["api_key"] = api_key

--- a/src/odyssey/runners/models/pi05.py
+++ b/src/odyssey/runners/models/pi05.py
@@ -1,0 +1,93 @@
+"""π0.5 (openpi) pilot — chunk-emitting VLA behind the shared chunk adapter.
+
+π0.5 runs, like GR00T, as an **out-of-process policy server** (openpi's
+``WebsocketPolicyServer``); this process holds only the lightweight websocket
+client + the LIBERO env. A query returns an action **chunk** (``action_horizon``
+future steps, ``chunk_size`` default 50 / 10 for ``pi05_libero``), so the pilot
+reuses the pilot-agnostic ``ChunkPilotAdapter`` for buffering + replay + the
+flush-on-instruction-change gating — no bespoke replay loop, no duplicated
+abstraction (see ``runners/agents/chunk_pilot.py``).
+
+The wire glue is π0.5-specific but thin: ``build_pi05_libero_obs`` (openpi
+``observation/*`` keys) and ``pi05_action_to_libero`` (slice to 7-D, no gripper
+fix-up), both reusing the Franka Panda kinematics from ``gr00t_transforms``.
+
+Heavy deps (``openpi_client`` for the websocket policy, numpy for the transforms)
+are imported lazily inside the run path, so this module imports under the bare
+stdlib and its factory stays unit-testable on a CPU box.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _make_pi05_client(*, host: str, port: int, api_key: str | None = None) -> Any:
+    """Return a connected openpi ``WebsocketClientPolicy`` (light deps).
+
+    Deferred import: ``openpi_client`` ships with the π0.5 serving stack, which
+    lives in a separate env (openpi/JAX). Raises ``NotImplementedError`` with an
+    actionable message when it is not importable, matching ``VLARuntime``'s
+    contract for a missing optional backend.
+    """
+    try:
+        from openpi_client import websocket_client_policy as _wcp
+    except ImportError as e:  # pragma: no cover - exercised via make_pi05_pilot test
+        raise NotImplementedError(
+            "The π0.5 pilot requires the openpi client ('openpi_client'). "
+            "Install openpi and serve a π0.5 checkpoint "
+            "(e.g. scripts/serve_policy.py), then point the mission at host:port."
+        ) from e
+    kwargs: dict[str, Any] = {"host": host, "port": int(port)}
+    if api_key:
+        kwargs["api_key"] = api_key
+    return _wcp.WebsocketClientPolicy(**kwargs)
+
+
+def make_pi05_pilot(
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    n_action_steps: int = 10,
+    api_key: str | None = None,
+    client: Any = None,
+    translation_only: bool = False,
+) -> Any:
+    """Build a chunk-aware π0.5 ``PilotRuntime`` over a running openpi server.
+
+    Wires the π0.5 wire transforms into the shared ``ChunkPilotAdapter``:
+
+      * ``predict_chunk`` = ``client.infer`` (openpi returns ``{"actions": ...}``);
+      * ``observation_builder`` = ``build_pi05_libero_obs`` (from ``**raw_obs``);
+      * ``action_decoder`` = ``pi05_action_to_libero`` (slice 7-D, no gripper fix-up).
+
+    ``n_action_steps`` is how many steps of each chunk are replayed before the
+    next query — match it to the checkpoint's ``action_horizon`` (10 for
+    ``pi05_libero``, 50 default). ``client`` may be injected (tests / a
+    pre-connected client); otherwise one is created against ``host:port``.
+    """
+    from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
+    from odyssey.runners.evals.pi05_transforms import (
+        build_pi05_libero_obs,
+        pi05_action_to_libero,
+    )
+
+    policy = client if client is not None else _make_pi05_client(
+        host=host, port=port, api_key=api_key,
+    )
+
+    def observation_builder(raw_obs: Any, instruction: str) -> Any:
+        # raw_obs is the kwargs dict already shaped for build_pi05_libero_obs
+        # (image/wrist_image/eef_pos/eef_quat_xyzw/gripper_qpos), assembled by
+        # the eval recipe from the LIBERO env observation.
+        return build_pi05_libero_obs(instruction=instruction, **raw_obs)
+
+    def action_decoder(chunk: Any, k: int) -> Any:
+        return pi05_action_to_libero(chunk, k, translation_only=translation_only)
+
+    return ChunkPilotAdapter(
+        predict_chunk=policy.infer,
+        action_decoder=action_decoder,
+        observation_builder=observation_builder,
+        n_action_steps=n_action_steps,
+    )

--- a/tests/unit/test_pi05_eval.py
+++ b/tests/unit/test_pi05_eval.py
@@ -1,0 +1,452 @@
+"""Wiring tests for the π0.5 LIBERO eval path (issue #74).
+
+These pin the *cabling* that makes ``evaluation_type: libero`` + ``pilot: pi05``
+reach the right code — WITHOUT a GPU, an openpi server, LIBERO, or a real
+simulator. Every heavy edge (the subprocess recipe, the scorer) is mocked the
+same way the existing eval tests mock the runner/sim (see
+``test_robosuite_runner.py`` / ``test_gr00t_libero_eval.py``):
+
+  * the RunnerRegistry routes a LIBERO eval task to ``LiberoRunner`` (π0.5 runs
+    under ``evaluation_type: libero``, same as GR00T);
+  * ``LiberoRunner`` dispatches ``pilot: pi05`` to its π0.5 subprocess path and
+    nowhere else;
+  * the model-ref (``config.checkpoint`` HF id / local path, or the trained
+    PILOT checkpoint) resolves via the shared ``resolve_eval_checkpoint``;
+  * ``build_pi05_libero_argv`` forwards the launch contract + config passthrough
+    and drops the keys the runner consumes itself (the GR00T-LIBERO bridge
+    contract, reused verbatim);
+  * ``_run_pi05_pilot`` launches the ``pi05_libero_eval.py`` recipe through the
+    shared subprocess helper and scores it through the shared ``summarize``.
+
+All tests are named ``test_pi05_eval_*`` (the ``-k pi05_eval`` gate).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.engine.lifecycle import TaskStatus
+from odyssey.engine.records import MissionRun, TaskRun
+from odyssey.runners.base import TaskContext
+from odyssey.runners.evals._common import resolve_eval_checkpoint
+from odyssey.runners.evals.isaac_lab import EvalProtocolCollector, summarize
+from odyssey.runners.evals.libero import LiberoRunner, build_pi05_libero_argv
+from odyssey.runners.evals.robosuite import RobosuiteRunner
+from odyssey.runners.registry import RunnerRegistry
+from odyssey.spec import (
+    AgentRole,
+    AgentSpec,
+    EvaluationTask,
+    EvaluationType,
+    HFModelRef,
+    Mission,
+    MissionMetadata,
+    RobotSpec,
+    TrainingTask,
+    TrainingType,
+)
+from odyssey.telemetry import EventPublisher
+
+# A published π0.5-LIBERO checkpoint stands in for the model-ref throughout.
+PI05_MODEL_REF = "lerobot/pi05_libero"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / builders — an eval-only mission + a TaskContext, no engine.
+# ---------------------------------------------------------------------------
+
+class _NullPublisher(EventPublisher):
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        return
+
+
+def _eval_spec(**config: Any) -> EvaluationTask:
+    """A LIBERO EvaluationTask spec whose ``config`` carries the pilot wiring."""
+    return EvaluationTask(
+        name="pi05-libero-eval",
+        evaluation_type=EvaluationType.LIBERO,
+        benchmark_name="libero_object",
+        num_episodes=4,
+        config=dict(config),
+    )
+
+
+def _mission(
+    *,
+    pilot: str = "pi05",
+    checkpoint: str | None = PI05_MODEL_REF,
+    trained_checkpoint: str | None = None,
+    extra_config: dict[str, Any] | None = None,
+) -> MissionRun:
+    """Eval-only mission: one PILOT agent + a LIBERO eval task.
+
+    ``checkpoint`` sets ``config.checkpoint`` (the eval-only model-ref path).
+    ``trained_checkpoint`` instead simulates a completed training task that
+    produced the PILOT's checkpoint (the fall-back resolution branch).
+    """
+    config: dict[str, Any] = {"pilot": pilot}
+    if checkpoint is not None:
+        config["checkpoint"] = checkpoint
+    if extra_config:
+        config.update(extra_config)
+
+    spec = Mission(
+        metadata=MissionMetadata(name="msn-pi05"),
+        objective="o",
+        acceptance_criteria="a",
+        robot=RobotSpec(
+            embodiment="franka_panda",
+            agents=[
+                AgentSpec(
+                    id="pilot",
+                    role=AgentRole.PILOT,
+                    model=HFModelRef(base="lerobot/pi05_base"),
+                ),
+            ],
+        ),
+        tasks=[
+            TrainingTask(
+                name="train",
+                training_type=TrainingType.DEMONSTRATION,
+                agent_id="pilot",
+            ),
+            EvaluationTask(
+                name="pi05-libero-eval",
+                evaluation_type=EvaluationType.LIBERO,
+                benchmark_name="libero_object",
+                num_episodes=4,
+                config=config,
+            ),
+        ],
+    )
+    mission = MissionRun.from_spec(spec)
+    if trained_checkpoint is not None:
+        mission.tasks[0].status = TaskStatus.COMPLETED
+        mission.tasks[0].result_summary = {
+            "checkpoint_path": trained_checkpoint,
+            "agent_id": "pilot",
+        }
+    return mission
+
+
+def _eval_task(mission: MissionRun) -> TaskRun:
+    return next(t for t in mission.tasks if isinstance(t.spec, EvaluationTask))
+
+
+def _ctx(mission: MissionRun, tmp_path: Path | None = None) -> TaskContext:
+    return TaskContext(
+        task=_eval_task(mission),
+        mission=mission,
+        publisher=_NullPublisher(),
+        output_dir=tmp_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. RunnerRegistry — evaluation_type routes a π0.5 eval to LiberoRunner.
+# ---------------------------------------------------------------------------
+
+def test_pi05_eval_registry_routes_libero_task_to_libero_runner() -> None:
+    registry = RunnerRegistry()
+    registry.register(RobosuiteRunner())
+    registry.register(LiberoRunner())
+
+    # π0.5 rides on evaluation_type: libero — the pilot lives in config, so the
+    # registry key is the same LIBERO route GR00T/OpenVLA take.
+    spec = _eval_spec(pilot="pi05", checkpoint=PI05_MODEL_REF)
+    runner = registry.select(spec)
+    assert isinstance(runner, LiberoRunner)
+    assert runner.name == "libero"
+
+
+def test_pi05_eval_registry_keeps_libero_and_robosuite_distinct() -> None:
+    registry = RunnerRegistry()
+    registry.register(RobosuiteRunner())
+    registry.register(LiberoRunner())
+
+    libero_spec = _eval_spec(pilot="pi05")
+    robosuite_spec = EvaluationTask(
+        name="rs",
+        evaluation_type=EvaluationType.ROBOSUITE,
+        benchmark_name="Lift",
+        num_episodes=1,
+    )
+    assert registry.select(libero_spec).name == "libero"
+    assert registry.select(robosuite_spec).name == "robosuite"
+
+
+# ---------------------------------------------------------------------------
+# 2. LiberoRunner — `pilot: pi05` dispatches to the π0.5 path, and only that.
+# ---------------------------------------------------------------------------
+
+async def test_pi05_eval_pilot_dispatches_to_pi05_path(monkeypatch, tmp_path) -> None:
+    runner = LiberoRunner()
+    calls: list[str] = []
+
+    async def _fake_pi05(context, spec):
+        calls.append("pi05")
+        return {"dispatched": "pi05"}
+
+    async def _fake_gr00t(context, spec):
+        calls.append("gr00t")
+        return {"dispatched": "gr00t"}
+
+    monkeypatch.setattr(runner, "_run_pi05_pilot", _fake_pi05)
+    monkeypatch.setattr(runner, "_run_gr00t_pilot", _fake_gr00t)
+
+    result = await runner.run(_ctx(_mission(pilot="pi05"), tmp_path))
+
+    assert result == {"dispatched": "pi05"}
+    assert calls == ["pi05"]  # gr00t path untouched, in-process path never reached
+
+
+async def test_pi05_eval_gr00t_pilot_not_hijacked_by_pi05(monkeypatch, tmp_path) -> None:
+    # Reverse guard: pilot: gr00t still lands on the GR00T path (the new pi05
+    # branch must not swallow it).
+    runner = LiberoRunner()
+    calls: list[str] = []
+
+    async def _fake_pi05(context, spec):
+        calls.append("pi05")
+        return {"dispatched": "pi05"}
+
+    async def _fake_gr00t(context, spec):
+        calls.append("gr00t")
+        return {"dispatched": "gr00t"}
+
+    monkeypatch.setattr(runner, "_run_pi05_pilot", _fake_pi05)
+    monkeypatch.setattr(runner, "_run_gr00t_pilot", _fake_gr00t)
+
+    result = await runner.run(_ctx(_mission(pilot="gr00t"), tmp_path))
+
+    assert result == {"dispatched": "gr00t"}
+    assert calls == ["gr00t"]
+
+
+async def test_pi05_eval_pilot_value_is_case_insensitive(monkeypatch, tmp_path) -> None:
+    runner = LiberoRunner()
+    seen: list[str] = []
+
+    async def _fake_pi05(context, spec):
+        seen.append("pi05")
+        return {"ok": True}
+
+    monkeypatch.setattr(runner, "_run_pi05_pilot", _fake_pi05)
+    await runner.run(_ctx(_mission(pilot="PI05"), tmp_path))
+    assert seen == ["pi05"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Model-ref resolution — shared resolve_eval_checkpoint, both branches.
+# ---------------------------------------------------------------------------
+
+def test_pi05_eval_resolves_model_ref_from_config_checkpoint(tmp_path) -> None:
+    # Eval-only mission: the model-ref is a HF repo id in config.checkpoint.
+    ctx = _ctx(_mission(pilot="pi05", checkpoint=PI05_MODEL_REF), tmp_path)
+    assert resolve_eval_checkpoint(ctx) == Path(PI05_MODEL_REF)
+
+
+def test_pi05_eval_resolves_model_ref_from_trained_pilot_checkpoint(tmp_path) -> None:
+    # No config.checkpoint -> fall back to the PILOT's latest trained checkpoint.
+    mission = _mission(pilot="pi05", checkpoint=None, trained_checkpoint="/tmp/pi05-ft")
+    assert resolve_eval_checkpoint(_ctx(mission, tmp_path)) == Path("/tmp/pi05-ft")
+
+
+def test_pi05_eval_resolution_raises_without_any_checkpoint(tmp_path) -> None:
+    mission = _mission(pilot="pi05", checkpoint=None, trained_checkpoint=None)
+    with pytest.raises(ValueError, match="No completed training task"):
+        resolve_eval_checkpoint(_ctx(mission, tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# 4. build_pi05_libero_argv — launch contract + passthrough, handled keys out.
+# ---------------------------------------------------------------------------
+
+def test_pi05_eval_build_argv_contract_and_passthrough() -> None:
+    task = _eval_spec(
+        pilot="pi05",                 # handled — not forwarded
+        checkpoint=PI05_MODEL_REF,    # handled — passed explicitly as --checkpoint
+        runner="libero",              # handled — not forwarded
+        capture_video=True,           # handled — video via --video_dir
+        task_id=2,
+        host="10.0.0.2",
+        port=8000,
+        n_action_steps=10,
+    )
+    argv = build_pi05_libero_argv(
+        spec=task, checkpoint=Path(PI05_MODEL_REF), video_dir=Path("/out/videos"),
+    )
+    # Contract flags first, model-ref threaded through as --checkpoint.
+    assert argv[:6] == [
+        "--task", "libero_object", "--num_episodes", "4",
+        "--checkpoint", PI05_MODEL_REF,
+    ]
+    assert "--video_dir" in argv and "/out/videos" in argv
+    # openpi server address + chunk length pass through verbatim (snake_case).
+    assert argv[argv.index("--host") + 1] == "10.0.0.2"
+    assert argv[argv.index("--port") + 1] == "8000"
+    assert argv[argv.index("--n_action_steps") + 1] == "10"
+    assert argv[argv.index("--task_id") + 1] == "2"
+    # Keys the runner consumes itself are never forwarded as flags.
+    for handled in ("--pilot", "--runner", "--capture_video"):
+        assert handled not in argv
+
+
+def test_pi05_eval_build_argv_omits_video_dir_when_none() -> None:
+    argv = build_pi05_libero_argv(
+        spec=_eval_spec(pilot="pi05", checkpoint=PI05_MODEL_REF, task_id=1),
+        checkpoint=Path(PI05_MODEL_REF),
+        video_dir=None,
+    )
+    assert "--video_dir" not in argv
+    assert argv[argv.index("--task_id") + 1] == "1"
+
+
+def test_pi05_eval_build_argv_uses_resolved_checkpoint_not_config() -> None:
+    # The runner passes the *resolved* checkpoint (may be a trained local path);
+    # the argv --checkpoint must be that, independent of config.checkpoint.
+    task = _eval_spec(pilot="pi05", checkpoint=PI05_MODEL_REF)
+    argv = build_pi05_libero_argv(
+        spec=task, checkpoint=Path("/local/ft/pi05"), video_dir=None,
+    )
+    assert argv[argv.index("--checkpoint") + 1] == "/local/ft/pi05"
+
+
+# ---------------------------------------------------------------------------
+# 5. _run_pi05_pilot — launches the recipe + scores, with a mocked subprocess.
+# ---------------------------------------------------------------------------
+
+def _patch_bridge(monkeypatch, *, rc: int, summary: dict[str, Any]) -> dict[str, Any]:
+    """Stub the shared subprocess + scorer; capture what the runner built."""
+    captured: dict[str, Any] = {}
+
+    async def _fake_subprocess(context, process_spec):
+        captured["process_spec"] = process_spec
+        return rc
+
+    def _fake_summarize(*, collector, spec, checkpoint, eval_script):
+        captured["summarize"] = {
+            "checkpoint": checkpoint,
+            "eval_script": eval_script,
+            "collector": collector,
+        }
+        return summary
+
+    monkeypatch.setattr(
+        "odyssey.runners.evals.libero.run_training_subprocess", _fake_subprocess
+    )
+    monkeypatch.setattr("odyssey.runners.evals.libero.summarize", _fake_summarize)
+    return captured
+
+
+async def test_pi05_eval_run_pi05_pilot_launches_recipe_and_scores(
+    monkeypatch, tmp_path
+) -> None:
+    summary = {"success_rate": 0.5, "num_episodes": 4, "passed": True}
+    captured = _patch_bridge(monkeypatch, rc=0, summary=summary)
+
+    runner = LiberoRunner()
+    mission = _mission(
+        pilot="pi05", checkpoint=PI05_MODEL_REF,
+        extra_config={"capture_video": True, "n_action_steps": 10, "port": 8000},
+    )
+    result = await runner.run(_ctx(mission, tmp_path))
+
+    # The runner returned exactly what the shared scorer produced.
+    assert result is summary
+
+    spec = captured["process_spec"]
+    # Launched the π0.5 recipe (not the GR00T one) through the subprocess helper.
+    assert spec.script_path.endswith("pi05_libero_eval.py")
+    assert spec.line_parser is not None  # the shared EvalProtocolCollector.parse
+
+    argv = spec.argv_extra
+    assert argv[:6] == [
+        "--task", "libero_object", "--num_episodes", "4",
+        "--checkpoint", PI05_MODEL_REF,
+    ]
+    # capture_video -> resolved --video_dir under the task output dir.
+    assert "--video_dir" in argv
+    assert str(tmp_path) in argv[argv.index("--video_dir") + 1]
+    assert argv[argv.index("--n_action_steps") + 1] == "10"
+
+    # Scored through the shared summarize, with the resolved model-ref.
+    assert captured["summarize"]["checkpoint"] == Path(PI05_MODEL_REF)
+    assert captured["summarize"]["eval_script"].endswith("pi05_libero_eval.py")
+
+
+async def test_pi05_eval_run_pi05_pilot_raises_on_nonzero_exit(
+    monkeypatch, tmp_path
+) -> None:
+    _patch_bridge(monkeypatch, rc=3, summary={})
+    runner = LiberoRunner()
+    with pytest.raises(RuntimeError, match="pi05_libero_eval exited with code 3"):
+        await runner.run(_ctx(_mission(pilot="pi05"), tmp_path))
+
+
+async def test_pi05_eval_run_pi05_pilot_reports_cancelled(monkeypatch, tmp_path) -> None:
+    # A user cancel mid-subprocess short-circuits to a clean cancelled summary
+    # (nonzero rc from the killed child must not raise over the cancel).
+    captured: dict[str, Any] = {}
+
+    async def _fake_subprocess(context, process_spec):
+        context.request_cancel()
+        return 137  # SIGKILL-style exit from the cancelled child
+
+    monkeypatch.setattr(
+        "odyssey.runners.evals.libero.run_training_subprocess", _fake_subprocess
+    )
+    captured["hit_summarize"] = False
+
+    def _fake_summarize(**_kwargs):
+        captured["hit_summarize"] = True
+        return {}
+
+    monkeypatch.setattr("odyssey.runners.evals.libero.summarize", _fake_summarize)
+
+    runner = LiberoRunner()
+    result = await runner.run(_ctx(_mission(pilot="pi05"), tmp_path))
+    assert result == {"cancelled": True}
+    assert captured["hit_summarize"] is False  # never scored a cancelled run
+
+
+async def test_pi05_eval_run_pi05_pilot_omits_video_dir_without_capture(
+    monkeypatch, tmp_path
+) -> None:
+    captured = _patch_bridge(monkeypatch, rc=0, summary={"ok": True})
+    runner = LiberoRunner()
+    # capture_video defaults off -> no --video_dir even with an output dir.
+    await runner.run(_ctx(_mission(pilot="pi05"), tmp_path))
+    assert "--video_dir" not in captured["process_spec"].argv_extra
+
+
+# ---------------------------------------------------------------------------
+# 6. Protocol contract — π0.5 reuses the shared GR00T-LIBERO collector+scorer.
+# ---------------------------------------------------------------------------
+
+def test_pi05_eval_protocol_roundtrips_through_shared_summarize() -> None:
+    # The pi05 recipe speaks the same ODYSSEY_* protocol as GR00T/Isaac, so the
+    # runner's own collector + summarize score it unchanged (bridge reuse).
+    collector = EvalProtocolCollector()
+    for i in range(1, 5):
+        ok = i <= 2  # 2/4 pass
+        collector.parse(
+            "ODYSSEY_EPISODE "
+            + json.dumps({"index": i, "total": 4, "success": ok, "return": 1.0 if ok else 0.0})
+        )
+    collector.parse(
+        "ODYSSEY_RESULT "
+        + json.dumps({"success_rate": 0.5, "performance_score": 0.5, "metrics": {}})
+    )
+    summary = summarize(
+        collector=collector,
+        spec=_eval_spec(pilot="pi05", checkpoint=PI05_MODEL_REF),
+        checkpoint=Path(PI05_MODEL_REF),
+        eval_script="pi05_libero_eval.py",
+    )
+    assert summary["success_rate"] == 0.5
+    assert summary["num_episodes"] == 4

--- a/tests/unit/test_pi05_fast.py
+++ b/tests/unit/test_pi05_fast.py
@@ -39,7 +39,6 @@ from odyssey.runners.evals.pi05_fast import (
     unnormalize_from_unit,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fake FAST processor — a dependency-free stand-in for the HF AutoProcessor.
 #
@@ -64,7 +63,7 @@ class _FakeFastProcessor:
         self.encode_calls.append(arr)
         out: list[list[int]] = []
         for item in arr:  # (T, D)
-            out.append([int(round(v * self.SCALE)) + self.OFFSET
+            out.append([round(v * self.SCALE) + self.OFFSET
                         for v in item.reshape(-1)])
         return out
 
@@ -124,7 +123,7 @@ def test_pi05_fast_decode_of_synthetic_tokens() -> None:
     # Hand-build tokens for a known (2, 3) chunk under the fake's fixed-point scheme.
     values = np.array([[0.0, 0.5, -0.5], [0.25, -0.25, 1.0]], dtype=np.float64)
     P = _FakeFastProcessor
-    tokens = [int(round(v * P.SCALE)) + P.OFFSET for v in values.reshape(-1)]
+    tokens = [round(v * P.SCALE) + P.OFFSET for v in values.reshape(-1)]
 
     chunk = codec.decode(tokens, time_horizon=2, action_dim=3)
 

--- a/tests/unit/test_pi05_fast.py
+++ b/tests/unit/test_pi05_fast.py
@@ -1,0 +1,294 @@
+"""Tests for π0.5 FAST action de/tokenization (issue #74).
+
+FAST (Frequency-space Action Sequence Tokenization) is what turns π0.5's discrete
+action tokens back into the ``(action_horizon, action_dim)`` chunk the LIBERO eval
+consumes. The real codec is the HF ``physical-intelligence/fast`` ``AutoProcessor``
+(pulled via ``transformers`` + ``scipy``), but ``runners/evals/pi05_fast.py`` is
+pure integration glue over it, so the whole encode/decode/normalize path is
+exercisable WITHOUT a GPU, ``transformers``, or any weight download:
+
+  * a dependency-free ``_FakeFastProcessor`` stands in for the HF AutoProcessor,
+    mimicking its batched ``__call__``/``decode(..., time_horizon=, action_dim=)``
+    contract with a lossless round-trip so reconstruction is assertable;
+  * ``FastActionCodec`` (the batch-dim juggling + reshape) and the ``[-1, 1]``
+    normalization helpers are numpy-only;
+  * ``load_fast_tokenizer`` defers the ``transformers`` import, so the injection
+    path and the missing-dependency contract are both pinned without it installed.
+
+All tests are named ``test_pi05_fast_*`` (the ``-k pi05_fast`` gate — which does
+NOT match the existing ``fails_fast`` tests). No GPU, no served checkpoint, no weights.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from odyssey.runners.evals.pi05_fast import (
+    DEFAULT_FAST_TOKENIZER,
+    FastActionCodec,
+    load_fast_tokenizer,
+    normalize_to_unit,
+    unnormalize_from_unit,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake FAST processor — a dependency-free stand-in for the HF AutoProcessor.
+#
+# Faithful to the API the real codec drives (openpi's FASTTokenizer path):
+#   processor(action_data)                    -> list[batch] of list[int] tokens
+#   processor.decode(tokens, time_horizon=, action_dim=) -> (batch, T, D) array
+# The transform here is a lossless fixed-point quantizer (not a real DCT) so the
+# round-trip reconstructs within 1/SCALE — enough to test OUR wiring, not FAST.
+# ---------------------------------------------------------------------------
+
+class _FakeFastProcessor:
+    SCALE = 100_000       # quantization resolution -> ~1e-5 round-trip error
+    OFFSET = 1_000_000    # keep token ids non-negative, like real vocab ids
+
+    def __init__(self) -> None:
+        self.encode_calls: list[np.ndarray] = []
+        self.decode_calls: list[dict[str, Any]] = []
+
+    def __call__(self, action_data) -> list[list[int]]:
+        arr = np.asarray(action_data, dtype=np.float64)
+        assert arr.ndim == 3, f"FAST expects (batch, T, D), got {arr.shape}"
+        self.encode_calls.append(arr)
+        out: list[list[int]] = []
+        for item in arr:  # (T, D)
+            out.append([int(round(v * self.SCALE)) + self.OFFSET
+                        for v in item.reshape(-1)])
+        return out
+
+    def decode(self, tokens, *, time_horizon: int, action_dim: int) -> np.ndarray:
+        self.decode_calls.append(
+            {"tokens": tokens, "time_horizon": time_horizon, "action_dim": action_dim}
+        )
+        out = []
+        for toks in tokens:
+            flat = np.array([(t - self.OFFSET) / self.SCALE for t in toks],
+                            dtype=np.float64)
+            out.append(flat.reshape(time_horizon, action_dim))
+        return np.stack(out)
+
+
+def _codec(time_horizon: int = 10, action_dim: int = 32) -> FastActionCodec:
+    return FastActionCodec(
+        _FakeFastProcessor(), time_horizon=time_horizon, action_dim=action_dim
+    )
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: tokenize -> detokenize reconstructs the chunk.
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_roundtrip_reconstructs_chunk() -> None:
+    codec = _codec(time_horizon=10, action_dim=32)
+    rng = np.random.RandomState(0)
+    chunk = rng.uniform(-1.0, 1.0, size=(10, 32)).astype(np.float32)
+
+    tokens = codec.encode(chunk)
+    recovered = codec.decode(tokens)
+
+    assert recovered.shape == (10, 32)
+    np.testing.assert_allclose(recovered, chunk, atol=1e-4)
+
+
+def test_pi05_fast_roundtrip_preserves_dtype_and_horizon_one() -> None:
+    # A single flat action is treated as a horizon-1 chunk (matches openpi's
+    # actions[None] tokenize convention).
+    codec = _codec(time_horizon=1, action_dim=7)
+    action = np.linspace(-1.0, 1.0, 7, dtype=np.float32)
+
+    recovered = codec.decode(codec.encode(action))
+
+    assert recovered.shape == (1, 7)
+    assert recovered.dtype == np.float32
+    np.testing.assert_allclose(recovered[0], action, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Decode of a synthetic token stream (no encode step) reconstructs known values.
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_decode_of_synthetic_tokens() -> None:
+    codec = _codec(time_horizon=2, action_dim=3)
+    # Hand-build tokens for a known (2, 3) chunk under the fake's fixed-point scheme.
+    values = np.array([[0.0, 0.5, -0.5], [0.25, -0.25, 1.0]], dtype=np.float64)
+    P = _FakeFastProcessor
+    tokens = [int(round(v * P.SCALE)) + P.OFFSET for v in values.reshape(-1)]
+
+    chunk = codec.decode(tokens, time_horizon=2, action_dim=3)
+
+    assert chunk.shape == (2, 3)
+    np.testing.assert_allclose(chunk, values, atol=1e-6)
+
+
+def test_pi05_fast_decode_accepts_ndarray_tokens() -> None:
+    # π0.5 hands token ids out as an ndarray; decode must accept .tolist()-ables.
+    codec = _codec(time_horizon=1, action_dim=4)
+    chunk_in = np.array([[0.1, -0.2, 0.3, -0.4]], dtype=np.float32)
+    tokens = np.asarray(codec.encode(chunk_in))  # ndarray, not list
+
+    chunk = codec.decode(tokens)
+    np.testing.assert_allclose(chunk, chunk_in, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Batch-axis juggling + decode reshape are owned by the codec (single-chunk API).
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_encode_batches_and_decode_strips_batch_axis() -> None:
+    proc = _FakeFastProcessor()
+    codec = FastActionCodec(proc, time_horizon=5, action_dim=8)
+    chunk = np.zeros((5, 8), dtype=np.float32)
+
+    tokens = codec.encode(chunk)
+    # Caller passed a 2-D chunk; the codec fed the processor a batched (1, T, D).
+    assert proc.encode_calls[0].shape == (1, 5, 8)
+    # ...and encode returned that single batch item's tokens, not a length-1 list.
+    assert isinstance(tokens, list) and isinstance(tokens[0], int)
+
+    out = codec.decode(tokens)
+    # decode wrapped the tokens as a length-1 batch and stripped it back to 2-D.
+    assert proc.decode_calls[0]["tokens"] == [tokens]
+    assert out.shape == (5, 8)
+
+
+def test_pi05_fast_decode_uses_codec_horizon_and_dim_by_default() -> None:
+    proc = _FakeFastProcessor()
+    codec = FastActionCodec(proc, time_horizon=10, action_dim=32)
+    tokens = codec.encode(np.zeros((10, 32), dtype=np.float32))
+
+    codec.decode(tokens)
+    call = proc.decode_calls[0]
+    assert (call["time_horizon"], call["action_dim"]) == (10, 32)
+
+
+def test_pi05_fast_decode_overrides_horizon_and_dim_per_call() -> None:
+    proc = _FakeFastProcessor()
+    codec = FastActionCodec(proc, time_horizon=10, action_dim=32)
+    tokens = codec.encode(np.zeros((3, 7), dtype=np.float32))
+
+    out = codec.decode(tokens, time_horizon=3, action_dim=7)
+    assert out.shape == (3, 7)
+    call = proc.decode_calls[0]
+    assert (call["time_horizon"], call["action_dim"]) == (3, 7)
+
+
+def test_pi05_fast_codec_rejects_non_positive_shape() -> None:
+    with pytest.raises(ValueError, match="positive"):
+        FastActionCodec(_FakeFastProcessor(), time_horizon=0, action_dim=32)
+
+
+def test_pi05_fast_encode_rejects_3d_input() -> None:
+    codec = _codec()
+    with pytest.raises(ValueError, match="time_horizon, action_dim"):
+        codec.encode(np.zeros((2, 10, 32), dtype=np.float32))
+
+
+# ---------------------------------------------------------------------------
+# [-1, 1] normalization helpers (the only numeric integration work FAST needs).
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_normalize_roundtrip() -> None:
+    lo = np.array([-2.0, 0.0, -1.0])
+    hi = np.array([2.0, 4.0, 1.0])
+    physical = np.array([[-2.0, 4.0, 0.0], [1.0, 1.0, -0.5]])
+
+    unit = normalize_to_unit(physical, lo, hi)
+    back = unnormalize_from_unit(unit, lo, hi)
+
+    np.testing.assert_allclose(back, physical, atol=1e-9)
+
+
+def test_pi05_fast_normalize_maps_bounds_to_plus_minus_one() -> None:
+    lo, hi = -3.0, 5.0
+    np.testing.assert_allclose(normalize_to_unit(lo, lo, hi), -1.0)
+    np.testing.assert_allclose(normalize_to_unit(hi, lo, hi), 1.0)
+    np.testing.assert_allclose(normalize_to_unit((lo + hi) / 2, lo, hi), 0.0)
+
+
+def test_pi05_fast_normalize_clips_out_of_range() -> None:
+    # Values beyond [lo, hi] are clamped so FAST never sees input outside [-1, 1].
+    out = normalize_to_unit([-10.0, 10.0], lo=-1.0, hi=1.0)
+    np.testing.assert_allclose(out, [-1.0, 1.0])
+
+
+def test_pi05_fast_normalize_handles_flat_dimension() -> None:
+    # A degenerate dim (hi == lo) must not divide by zero; it maps to 0 / lo.
+    unit = normalize_to_unit([5.0], lo=[5.0], hi=[5.0])
+    np.testing.assert_allclose(unit, [0.0])
+    back = unnormalize_from_unit(unit, lo=[5.0], hi=[5.0])
+    np.testing.assert_allclose(back, [5.0])
+
+
+# ---------------------------------------------------------------------------
+# Integration: a FAST-decoded chunk feeds pi05_action_to_libero unchanged.
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_decoded_chunk_feeds_pi05_action_to_libero() -> None:
+    from odyssey.runners.evals.pi05_transforms import pi05_action_to_libero
+
+    codec = _codec(time_horizon=4, action_dim=32)
+    rng = np.random.RandomState(1)
+    chunk = rng.uniform(-1.0, 1.0, size=(4, 32)).astype(np.float32)
+    decoded = codec.decode(codec.encode(chunk))
+
+    # The detokenized chunk slices to LIBERO's 7-DoF action with no gripper fix-up.
+    action = pi05_action_to_libero({"actions": decoded}, 2)
+    assert action.shape == (7,)
+    np.testing.assert_allclose(action, chunk[2, :7], atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# load_fast_tokenizer — injection bypasses transformers; absence is contracted.
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_load_returns_injected_tokenizer() -> None:
+    sentinel = _FakeFastProcessor()
+    assert load_fast_tokenizer(tokenizer=sentinel) is sentinel
+
+
+def test_pi05_fast_default_checkpoint_is_universal_fast() -> None:
+    assert DEFAULT_FAST_TOKENIZER == "physical-intelligence/fast"
+
+
+def test_pi05_fast_load_raises_without_transformers() -> None:
+    if importlib.util.find_spec("transformers") is not None:
+        pytest.skip("transformers installed; the missing-dep path is not exercised")
+    with pytest.raises(NotImplementedError, match="transformers"):
+        load_fast_tokenizer()  # no injected tokenizer -> tries the deferred import
+
+
+# ---------------------------------------------------------------------------
+# The codec module defers heavy deps (transformers/torch/jax) — bare stdlib+numpy.
+# ---------------------------------------------------------------------------
+
+def test_pi05_fast_module_imports_without_heavy_deps() -> None:
+    heavy = ("transformers", "torch", "jax", "scipy")
+    # Fresh interpreter pointed at THIS worktree's src (it doesn't inherit pytest's
+    # `pythonpath`, and an editable-install .pth may redirect elsewhere).
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    script = (
+        "import importlib, json, sys\n"
+        f"sys.path.insert(0, {str(src_dir)!r})\n"
+        "importlib.import_module('odyssey.runners.evals.pi05_fast')\n"
+        f"print(json.dumps([m for m in {heavy!r} if m in sys.modules]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"pi05_fast module failed to import cleanly:\n{result.stderr}"
+    )
+    leaked = json.loads(result.stdout.strip().splitlines()[-1])
+    assert leaked == [], f"pi05_fast imported heavy deps at load: {leaked}"

--- a/tests/unit/test_pi05_gating.py
+++ b/tests/unit/test_pi05_gating.py
@@ -37,7 +37,6 @@ from odyssey.runners.agents.planned import (
 )
 from odyssey.runners.agents.runtime import CompletionDetector
 
-
 # ---------------------------------------------------------------------------
 # Fakes — completion detectors, both a bare callable and a CompletionDetector.
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_gating.py
+++ b/tests/unit/test_pi05_gating.py
@@ -1,0 +1,380 @@
+"""Tests for the chunk-aware completion / hand-back gate (issue #74).
+
+The completion gate is the closed-loop counterpart to the fixed-step / timeout
+phase strategies: a chunk-emitting pilot (GR00T, π0.5) replays ``n_action_steps``
+actions open-loop per query, and this gate consults a completion judge once per
+CHUNK BOUNDARY to decide when the current sub-instruction is done and control
+should be handed back (the orchestrator advances the phase).
+
+Like ``ChunkPilotAdapter``, the gate is pilot-agnostic and dependency-free — the
+completion detector is injected — so the whole thing is exercisable WITHOUT a
+GPU, a served checkpoint, or a real VLM judge:
+
+  * ``ChunkCompletionGate`` (``runners/agents/completion_gate.py``) is tested with
+    plain fake detectors (callables + ``is_complete`` objects);
+  * the orchestrator wiring (``PlannedEvalRuntime`` + ``PhaseStrategy.COMPLETION``)
+    is tested with a fake pilot + scripted detector;
+  * the shared boundary with the chunk pilots is checked against a real
+    ``ChunkPilotAdapter``'s ``n_action_steps``.
+
+All tests are named ``test_pi05_gating_*`` (the ``-k pi05_gating`` gate).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+import odyssey.engine  # noqa: F401  (avoid circular import, as in test_agent_runtimes)
+from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
+from odyssey.runners.agents.completion_gate import ChunkCompletionGate
+from odyssey.runners.agents.planned import (
+    PhaseConfig,
+    PhaseStrategy,
+    PlannedEvalRuntime,
+)
+from odyssey.runners.agents.runtime import CompletionDetector
+
+
+# ---------------------------------------------------------------------------
+# Fakes — completion detectors, both a bare callable and a CompletionDetector.
+# ---------------------------------------------------------------------------
+
+class _RecordingDetector:
+    """CompletionDetector that records every poll and replays a scripted verdict.
+
+    ``verdicts`` is consumed one per poll; once exhausted it returns ``False``
+    (never complete). Records the ``(observation, instruction)`` of each poll so
+    tests can assert the gate polls at the right cadence with the right args.
+    """
+
+    def __init__(self, verdicts: list[bool] | None = None) -> None:
+        self.calls: list[tuple[Any, str]] = []
+        self._verdicts = list(verdicts or [])
+
+    def is_complete(self, observation: Any, instruction: str) -> bool:
+        idx = len(self.calls)
+        self.calls.append((observation, instruction))
+        return self._verdicts[idx] if idx < len(self._verdicts) else False
+
+
+def _never(_obs: Any, _instr: str) -> bool:
+    return False
+
+
+def _always(_obs: Any, _instr: str) -> bool:
+    return True
+
+
+class _FakePilot:
+    """Records every (image, instruction) call and returns a fixed action."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, str]] = []
+
+    def act(self, image: Any, instruction: str) -> Any:
+        self.calls.append((image, instruction))
+        return np.zeros(7, dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# ChunkCompletionGate — polls at chunk boundaries only.
+# ---------------------------------------------------------------------------
+
+def test_pi05_gating_polls_only_at_chunk_boundary() -> None:
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=3)
+
+    # Steps 1,2 are mid-chunk: no judge call, always False.
+    assert gate.update("obs", "instr") is False
+    assert gate.update("obs", "instr") is False
+    assert det.calls == []  # detector untouched between boundaries
+
+    # Step 3 lands on the boundary -> exactly one poll.
+    gate.update("obs", "instr")
+    assert len(det.calls) == 1
+
+
+def test_pi05_gating_polls_once_per_chunk() -> None:
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=2)
+
+    for _ in range(6):  # three full chunks of 2
+        gate.update("obs", "instr")
+
+    assert len(det.calls) == 3  # one poll per drained chunk, not per step
+
+
+def test_pi05_gating_hands_back_when_detector_says_done() -> None:
+    # Complete on the SECOND boundary (first chunk NO, second chunk YES).
+    det = _RecordingDetector(verdicts=[False, True])
+    gate = ChunkCompletionGate(detector=det, n_action_steps=2)
+
+    verdicts = [gate.update("obs", "instr") for _ in range(4)]
+    # Only the 4th step (2nd boundary) hands back.
+    assert verdicts == [False, False, False, True]
+
+
+def test_pi05_gating_no_handback_when_detector_never_done() -> None:
+    gate = ChunkCompletionGate(detector=_never, n_action_steps=2)
+    assert not any(gate.update("obs", "instr") for _ in range(10))
+
+
+def test_pi05_gating_passes_observation_and_instruction_to_detector() -> None:
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=1)  # boundary every step
+
+    gate.update({"frame": 7}, "grasp the bowl")
+
+    assert det.calls == [({"frame": 7}, "grasp the bowl")]
+
+
+# ---------------------------------------------------------------------------
+# ChunkCompletionGate — warm-up and throttle.
+# ---------------------------------------------------------------------------
+
+def test_pi05_gating_min_steps_warmup_skips_early_boundary() -> None:
+    det = _RecordingDetector(verdicts=[True, True])
+    # n=2, warm up past the first boundary (step 2) — first eligible poll at step 4.
+    gate = ChunkCompletionGate(detector=det, n_action_steps=2, min_steps=4)
+
+    v = [gate.update("obs", "instr") for _ in range(4)]
+    assert v == [False, False, False, True]  # step-2 boundary suppressed by warm-up
+    assert len(det.calls) == 1  # detector only consulted once (at step 4)
+
+
+def test_pi05_gating_poll_every_chunks_throttles_detector() -> None:
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=2, poll_every_chunks=2)
+
+    for _ in range(8):  # four chunk boundaries
+        gate.update("obs", "instr")
+
+    # Polled only on the 2nd and 4th boundary.
+    assert len(det.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# ChunkCompletionGate — introspection, reset, no self-reset.
+# ---------------------------------------------------------------------------
+
+def test_pi05_gating_introspection_tracks_steps_and_chunks() -> None:
+    gate = ChunkCompletionGate(detector=_never, n_action_steps=3)
+    assert gate.n_action_steps == 3
+    assert gate.steps_in_phase == 0 and gate.chunks_completed == 0
+    assert not gate.at_chunk_boundary()
+
+    gate.update("o", "i")
+    gate.update("o", "i")
+    assert gate.steps_in_phase == 2 and not gate.at_chunk_boundary()
+
+    gate.update("o", "i")  # boundary
+    assert gate.steps_in_phase == 3 and gate.chunks_completed == 1
+    assert gate.at_chunk_boundary()
+
+
+def test_pi05_gating_reset_zeroes_counters() -> None:
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=2)
+    gate.update("o", "i")
+    gate.update("o", "i")  # boundary, 1 poll
+    assert gate.steps_in_phase == 2 and gate.chunks_completed == 1
+
+    gate.reset()
+    assert gate.steps_in_phase == 0 and gate.chunks_completed == 0
+    # A reset mid-count re-aligns the boundary: the next poll is a fresh chunk away.
+    gate.update("o", "i")
+    assert len(det.calls) == 1  # still just the pre-reset poll; no boundary yet
+    gate.update("o", "i")
+    assert len(det.calls) == 2  # new boundary after reset
+
+
+def test_pi05_gating_does_not_self_reset_on_handback() -> None:
+    # Detector says done every boundary; without a caller reset the gate keeps
+    # counting so an ignored hand-back re-fires only on the NEXT full chunk.
+    gate = ChunkCompletionGate(detector=_always, n_action_steps=2)
+    v = [gate.update("o", "i") for _ in range(4)]
+    assert v == [False, True, False, True]  # boundaries at steps 2 and 4
+    assert gate.chunks_completed == 2  # counters kept advancing (no self-reset)
+
+
+# ---------------------------------------------------------------------------
+# ChunkCompletionGate — detector shapes + validation.
+# ---------------------------------------------------------------------------
+
+def test_pi05_gating_accepts_completion_detector_object() -> None:
+    det = _RecordingDetector(verdicts=[True])
+    gate = ChunkCompletionGate(detector=det, n_action_steps=1)
+    assert gate.update("o", "i") is True  # is_complete adapted to a callable
+
+
+def test_pi05_gating_accepts_bare_callable_detector() -> None:
+    gate = ChunkCompletionGate(detector=_always, n_action_steps=1)
+    assert gate.update("o", "i") is True
+
+
+def test_pi05_gating_rejects_non_detector() -> None:
+    with pytest.raises(TypeError, match="detector"):
+        ChunkCompletionGate(detector=object(), n_action_steps=1)
+
+
+def test_pi05_gating_rejects_non_positive_n_action_steps() -> None:
+    with pytest.raises(ValueError, match="n_action_steps"):
+        ChunkCompletionGate(detector=_never, n_action_steps=0)
+
+
+def test_pi05_gating_rejects_bad_poll_every_chunks() -> None:
+    with pytest.raises(ValueError, match="poll_every_chunks"):
+        ChunkCompletionGate(detector=_never, n_action_steps=1, poll_every_chunks=0)
+
+
+def test_pi05_gating_rejects_negative_min_steps() -> None:
+    with pytest.raises(ValueError, match="min_steps"):
+        ChunkCompletionGate(detector=_never, n_action_steps=1, min_steps=-1)
+
+
+def test_pi05_gating_recording_detector_satisfies_protocol() -> None:
+    # runtime_checkable Protocol: structural match on is_complete(obs, instr).
+    assert isinstance(_RecordingDetector(), CompletionDetector)
+
+
+# ---------------------------------------------------------------------------
+# Shared boundary with the chunk pilots (GR00T / π0.5) — same n_action_steps.
+# ---------------------------------------------------------------------------
+
+def test_pi05_gating_boundary_aligns_with_chunk_pilot_requery() -> None:
+    """A gate built from the pilot's n_action_steps polls exactly at re-query."""
+    queries: list[int] = []
+
+    def predict(_wire: Any) -> dict[str, int]:
+        queries.append(1)
+        return {"q": len(queries)}
+
+    pilot = ChunkPilotAdapter(
+        predict_chunk=predict,
+        action_decoder=lambda chunk, k: (chunk, k),
+        n_action_steps=4,
+    )
+    det = _RecordingDetector()
+    gate = ChunkCompletionGate(detector=det, n_action_steps=pilot.n_action_steps)
+
+    # Drive them in lockstep: pilot.act (may re-query) then gate.update.
+    for _ in range(8):
+        pilot.act("obs", "instr")
+        gate.update("obs", "instr")
+
+    # Pilot re-queried twice (two chunks of 4); the gate polled once per chunk,
+    # i.e. exactly at the pilot's re-query points.
+    assert len(queries) == 2
+    assert len(det.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration — PlannedEvalRuntime + PhaseStrategy.COMPLETION.
+# ---------------------------------------------------------------------------
+
+def _completion_runtime(pilot: _FakePilot, det: Any, *, n_action_steps: int,
+                        steps: list[str]) -> PlannedEvalRuntime:
+    gate = ChunkCompletionGate(detector=det, n_action_steps=n_action_steps)
+    cfg = PhaseConfig(strategy=PhaseStrategy.COMPLETION)
+
+    class _Planner:
+        def plan(self, task: str, image: Any = None) -> list[str]:
+            return list(steps)
+
+    rt = PlannedEvalRuntime(pilot, _Planner(), phase_config=cfg, completion_gate=gate)
+    rt.begin_episode("task")
+    return rt
+
+
+def test_pi05_gating_runtime_advances_phase_on_handback() -> None:
+    pilot = _FakePilot()
+    # n=2: hand back on the first boundary of each phase (done at every poll).
+    rt = _completion_runtime(
+        pilot, _always, n_action_steps=2, steps=["phase-1", "phase-2", "phase-3"]
+    )
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    assert rt.current_phase_index == 0
+    rt.get_action(img)  # step 1, mid-chunk
+    assert rt.current_phase_index == 0
+    rt.get_action(img)  # step 2, boundary -> hand back
+    assert rt.current_phase_index == 1
+    assert pilot.calls[-1][1] == "phase-1"  # step 2 still ran under phase-1
+
+
+def test_pi05_gating_runtime_does_not_advance_without_completion() -> None:
+    pilot = _FakePilot()
+    rt = _completion_runtime(
+        pilot, _never, n_action_steps=2, steps=["phase-1", "phase-2"]
+    )
+    img = np.zeros((8, 8, 3), dtype=np.uint8)
+
+    for _ in range(20):
+        rt.get_action(img)
+    # Detector never completes -> stays on the first phase the whole time.
+    assert rt.current_phase_index == 0
+    assert all(instr == "phase-1" for _img, instr in pilot.calls)
+
+
+def test_pi05_gating_runtime_resets_gate_on_phase_advance() -> None:
+    pilot = _FakePilot()
+    det = _RecordingDetector()  # never completes -> we drive boundaries manually
+    gate = ChunkCompletionGate(detector=det, n_action_steps=3)
+    cfg = PhaseConfig(strategy=PhaseStrategy.COMPLETION)
+
+    class _Planner:
+        def plan(self, task: str, image: Any = None) -> list[str]:
+            return ["a", "b"]
+
+    rt = PlannedEvalRuntime(pilot, _Planner(), phase_config=cfg, completion_gate=gate)
+    rt.begin_episode("task")
+    img = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    rt.get_action(img)
+    rt.get_action(img)
+    assert gate.steps_in_phase == 2  # mid-chunk within phase "a"
+
+    rt.begin_episode("task2")  # a fresh episode must re-arm the gate
+    assert gate.steps_in_phase == 0
+    assert rt.current_phase_index == 0
+
+
+def test_pi05_gating_runtime_completion_detector_sees_current_phase() -> None:
+    pilot = _FakePilot()
+    det = _RecordingDetector(verdicts=[True, True])  # done at each phase's boundary
+    gate = ChunkCompletionGate(detector=det, n_action_steps=1)  # boundary every step
+    cfg = PhaseConfig(strategy=PhaseStrategy.COMPLETION)
+
+    class _Planner:
+        def plan(self, task: str, image: Any = None) -> list[str]:
+            return ["reach", "grasp"]
+
+    rt = PlannedEvalRuntime(pilot, _Planner(), phase_config=cfg, completion_gate=gate)
+    rt.begin_episode("task")
+    img = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    rt.get_action(img)  # phase "reach" -> boundary -> hand back
+    rt.get_action(img)  # phase "grasp" -> boundary -> hand back
+    # The judge was polled with each phase's active sub-instruction in turn.
+    assert [instr for _obs, instr in det.calls] == ["reach", "grasp"]
+
+
+def test_pi05_gating_runtime_completion_without_gate_never_advances() -> None:
+    pilot = _FakePilot()
+    cfg = PhaseConfig(strategy=PhaseStrategy.COMPLETION)
+
+    class _Planner:
+        def plan(self, task: str, image: Any = None) -> list[str]:
+            return ["only-phase", "next"]
+
+    # No completion_gate supplied: the runtime warns and runs the phase open-ended.
+    rt = PlannedEvalRuntime(pilot, _Planner(), phase_config=cfg)
+    rt.begin_episode("task")
+    img = np.zeros((4, 4, 3), dtype=np.uint8)
+
+    for _ in range(10):
+        rt.get_action(img)
+    assert rt.current_phase_index == 0

--- a/tests/unit/test_pi05_libero_eval.py
+++ b/tests/unit/test_pi05_libero_eval.py
@@ -1,0 +1,223 @@
+"""Tests for the π0.5 LIBERO eval recipe (``pi05_libero_eval.py``).
+
+The recipe is the eval script the subprocess LiberoRunner spawns for
+``pilot: pi05``. These tests pin the interop surface WITHOUT booting LIBERO or an
+openpi server (mirror ``test_gr00t_libero_eval.py``):
+
+  * the module imports under the bare stdlib (heavy deps deferred to the run path);
+  * the launch-contract argv it accepts + config passthrough (open-loop: host/port,
+    NO GR00T ``--serve_checkpoint``/``--embodiment_tag``/server flags);
+  * that its ODYSSEY_* protocol lines are consumed by the runner's own
+    EvalProtocolCollector + summarize (the real contract, shared with GR00T/Isaac);
+  * that LiberoRunner.build_pi05_libero_argv forwards config correctly and drops
+    the keys it consumes itself, and round-trips back into this parser.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.evals.isaac_lab import EvalProtocolCollector, summarize
+from odyssey.runners.evals.libero import build_pi05_libero_argv
+from odyssey.spec import EvaluationTask, EvaluationType
+
+sys.path.insert(0, os.path.join(
+    os.path.dirname(__file__), "..", "..", "src", "odyssey", "runners", "evals"))
+import pi05_libero_eval as E
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "pi05-libero-eval",
+        "evaluation_type": EvaluationType.LIBERO,
+        "benchmark_name": "libero_object",
+        "num_episodes": 4,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Heavy deps are deferred — the module imports under the bare stdlib.
+# ---------------------------------------------------------------------------
+
+def test_module_imports_without_heavy_deps() -> None:
+    evals_dir = Path(__file__).resolve().parents[2] / "src" / "odyssey" / "runners" / "evals"
+    heavy_deps = ("numpy", "libero", "openpi_client", "torch", "robosuite", "jax")
+    script = (
+        "import importlib, json, sys\n"
+        f"sys.path.insert(0, {str(evals_dir)!r})\n"
+        "importlib.import_module('pi05_libero_eval')\n"
+        f"print(json.dumps([m for m in {heavy_deps!r} if m in sys.modules]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"pi05_libero_eval failed to import in a clean interpreter:\n{result.stderr}"
+    )
+    leaked = json.loads(result.stdout)
+    assert leaked == [], f"pi05_libero_eval imported heavy deps at module load: {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# Launch contract (matches build_pi05_libero_argv in the runner)
+# ---------------------------------------------------------------------------
+
+def test_parser_accepts_contract_flags() -> None:
+    args = E.build_parser().parse_args(
+        ["--task", "libero_object", "--num_episodes", "7", "--checkpoint", "/tmp/ckpt"]
+    )
+    assert args.task == "libero_object"
+    assert args.num_episodes == 7
+    assert args.checkpoint == "/tmp/ckpt"
+    assert args.task_id == 0  # default
+
+
+def test_parser_accepts_passthrough_config() -> None:
+    args = E.build_parser().parse_args(
+        ["--task", "libero_object", "--num_episodes", "1", "--checkpoint", "/c",
+         "--task_id", "3", "--host", "10.0.0.2", "--port", "6000",
+         "--n_action_steps", "8", "--api_key", "secret"]
+    )
+    assert args.task_id == 3
+    assert args.host == "10.0.0.2"
+    assert args.port == 6000
+    assert args.n_action_steps == 8
+    assert args.api_key == "secret"
+
+
+def test_parser_defaults_are_openpi_flavoured() -> None:
+    # π0.5 defaults differ from GR00T: port 8000 (openpi) and chunk 10 (pi05_libero).
+    args = E.build_parser().parse_args(
+        ["--task", "x", "--num_episodes", "1", "--checkpoint", "/c"])
+    assert args.host == "127.0.0.1"
+    assert args.port == 8000
+    assert args.n_action_steps == 10
+    assert args.translation_only is False
+
+
+def test_parser_bool_flags_are_value_style() -> None:
+    # The runner forwards config keys as "--flag value", so booleans must parse
+    # a trailing value (not store_true).
+    args = E.build_parser().parse_args(
+        ["--task", "x", "--num_episodes", "1", "--checkpoint", "/c",
+         "--flip_images", "0", "--translation_only", "yes"]
+    )
+    assert args.flip_images is False
+    assert args.translation_only is True
+    assert E._bool("true") and E._bool("1") and E._bool("on")
+    assert not E._bool("false") and not E._bool("")
+
+
+def test_parser_has_no_gr00t_server_flags() -> None:
+    # π0.5 is open-loop (server pre-started); the GR00T auto-serve flags must not
+    # exist here (they'd silently accept config that does nothing).
+    for gr00t_only in ("--serve_checkpoint", "--embodiment_tag", "--sim_policy_wrapper"):
+        try:
+            E.build_parser().parse_args(
+                ["--task", "x", "--num_episodes", "1", "--checkpoint", "/c",
+                 gr00t_only, "true"])
+        except SystemExit:
+            continue  # unknown flag -> argparse exits, as intended
+        raise AssertionError(f"{gr00t_only} should not be a pi05 recipe flag")
+    # a plain valid parse still works
+    assert E.build_parser().parse_args(
+        ["--task", "x", "--num_episodes", "1", "--checkpoint", "/c"]) is not None
+
+
+# ---------------------------------------------------------------------------
+# Protocol emission is consumed by the runner's OWN collector + scorer.
+# ---------------------------------------------------------------------------
+
+def test_episode_and_result_lines_parsed_by_runner_collector() -> None:
+    collector = EvalProtocolCollector()
+    event = collector.parse(E.episode_line(index=3, total=10, success=True, ret=1.5))
+    assert event is not None and event["step"] == "episode_complete"
+    assert event["step_index"] == 3 and event["step_total"] == 10
+    assert collector.episodes[0]["success"] is True
+
+    collector.parse(E.result_line(success_rate=0.4, performance_score=0.4,
+                                  metrics={"successes": 4}))
+    assert collector.result["success_rate"] == 0.4
+
+
+def test_protocol_roundtrips_through_summarize() -> None:
+    collector = EvalProtocolCollector()
+    for i in range(1, 5):
+        ok = i <= 2  # 2/4 pass
+        collector.parse(E.episode_line(index=i, total=4, success=ok, ret=1.0 if ok else 0.0))
+    collector.parse(E.result_line(success_rate=0.5, performance_score=0.5, metrics={}))
+    summary = summarize(
+        collector=collector, spec=_eval_task(),
+        checkpoint=Path("lerobot/pi05_libero"), eval_script="pi05_libero_eval.py",
+    )
+    assert summary["success_rate"] == 0.5
+    assert summary["num_episodes"] == 4
+
+
+# ---------------------------------------------------------------------------
+# LiberoRunner argv builder: contract flags + passthrough, minus handled keys.
+# ---------------------------------------------------------------------------
+
+def test_build_argv_contract_and_passthrough() -> None:
+    task = _eval_task(
+        num_episodes=10,
+        config={
+            "pilot": "pi05",                 # handled — not forwarded
+            "checkpoint": "lerobot/pi05_libero",  # handled — passed explicitly
+            "runner": "libero",              # handled — not forwarded
+            "capture_video": True,           # handled — video via --video_dir
+            "task_id": 0,
+            "host": "10.0.0.9",
+            "port": 8000,
+            "n_action_steps": 10,
+        },
+    )
+    argv = build_pi05_libero_argv(
+        spec=task, checkpoint=Path("lerobot/pi05_libero"), video_dir=Path("/out/videos"),
+    )
+    # Contract flags present.
+    assert argv[:6] == [
+        "--task", "libero_object", "--num_episodes", "10",
+        "--checkpoint", "lerobot/pi05_libero",
+    ]
+    assert "--video_dir" in argv and "/out/videos" in argv
+    # Passthrough config forwarded verbatim (snake_case).
+    assert argv[argv.index("--host") + 1] == "10.0.0.9"
+    assert argv[argv.index("--port") + 1] == "8000"
+    assert argv[argv.index("--n_action_steps") + 1] == "10"
+    # Handled keys NOT forwarded as flags.
+    for handled in ("--pilot", "--runner", "--capture_video"):
+        assert handled not in argv
+
+
+def test_build_argv_omits_video_dir_when_none() -> None:
+    argv = build_pi05_libero_argv(
+        spec=_eval_task(config={"task_id": 1}), checkpoint=Path("/c"), video_dir=None,
+    )
+    assert "--video_dir" not in argv
+    assert argv[argv.index("--task_id") + 1] == "1"
+
+
+# ---------------------------------------------------------------------------
+# The parsed argv wires back into the recipe (what the runner builds, it accepts).
+# ---------------------------------------------------------------------------
+
+def test_argv_parses_back_into_the_recipe() -> None:
+    task = _eval_task(config={"task_id": 2, "host": "1.2.3.4", "port": 9000,
+                              "n_action_steps": 10, "translation_only": "true"})
+    argv = build_pi05_libero_argv(
+        spec=task, checkpoint=Path("/ckpt"), video_dir=None,
+    )
+    args = E.build_parser().parse_args(argv)
+    assert args.task == "libero_object"
+    assert args.task_id == 2
+    assert args.host == "1.2.3.4"
+    assert args.port == 9000
+    assert args.n_action_steps == 10
+    assert args.translation_only is True

--- a/tests/unit/test_pi05_norm.py
+++ b/tests/unit/test_pi05_norm.py
@@ -19,7 +19,6 @@ import pytest
 from odyssey.runners.evals import pi05_norm as n
 from odyssey.runners.evals.pi05_norm import NormStats
 
-
 # ---------------------------------------------------------------------------
 # mean/std normalization (openpi default) — matches (x-mean)/(std+eps).
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_norm.py
+++ b/tests/unit/test_pi05_norm.py
@@ -1,0 +1,178 @@
+"""Tests for π0.5's action-space normalization — the ``unnorm_key`` analog (issue #74).
+
+π0.5 has NO mission-config ``unnorm_key``: its de-normalization is baked into the
+checkpoint (``norm_stats``/``asset_id``) and openpi applies it server-side. This
+module (``runners/evals/pi05_norm.py``) mirrors that math in numpy plus the pad→32 /
+slice→7 bridge and the asset-id resolution, so the mapping is exercisable WITHOUT a
+GPU, a served checkpoint, or downloaded weights — every case here uses tiny synthetic
+vectors and hand-built ``NormStats``.
+
+All tests are named ``test_pi05_norm_*`` (the ``-k pi05_norm`` gate). See
+``docs/pi05-scoping.md`` → "Mapeo de espacio de acción".
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from odyssey.runners.evals import pi05_norm as n
+from odyssey.runners.evals.pi05_norm import NormStats
+
+
+# ---------------------------------------------------------------------------
+# mean/std normalization (openpi default) — matches (x-mean)/(std+eps).
+# ---------------------------------------------------------------------------
+
+def test_pi05_norm_mean_std_matches_openpi_formula() -> None:
+    stats = NormStats.from_mean_std(mean=[1.0, -2.0, 0.5], std=[2.0, 4.0, 0.25])
+    x = np.array([3.0, 2.0, 1.0])
+
+    got = n.normalize(x, stats)
+    expected = (x - np.array([1.0, -2.0, 0.5])) / (np.array([2.0, 4.0, 0.25]) + n.NORM_EPS)
+    np.testing.assert_allclose(got, expected, rtol=1e-9)
+
+
+def test_pi05_norm_mean_std_round_trips() -> None:
+    stats = NormStats.from_mean_std(mean=[0.3, -1.1, 5.0, 0.0], std=[1.5, 0.2, 3.0, 1.0])
+    x = np.array([0.7, -0.4, 2.2, 9.9])
+
+    round_tripped = n.unnormalize(n.normalize(x, stats), stats)
+    np.testing.assert_allclose(round_tripped, x, rtol=1e-9, atol=1e-9)
+
+
+def test_pi05_norm_unnormalize_recovers_physical_units() -> None:
+    # A zero in normalized space maps back to the mean (physical units).
+    stats = NormStats.from_mean_std(mean=[10.0, -3.0], std=[2.0, 5.0])
+    np.testing.assert_allclose(
+        n.unnormalize(np.zeros(2), stats), [10.0, -3.0], atol=1e-4
+    )
+
+
+# ---------------------------------------------------------------------------
+# quantile normalization (openpi use_quantiles) — maps [q01,q99] -> [-1,1].
+# ---------------------------------------------------------------------------
+
+def test_pi05_norm_quantile_maps_endpoints_to_pm_one() -> None:
+    stats = NormStats.from_quantiles(q01=[-1.0, 0.0], q99=[1.0, 10.0])
+    # q01 -> -1, q99 -> +1 (up to eps).
+    np.testing.assert_allclose(n.normalize([-1.0, 0.0], stats, use_quantiles=True), [-1.0, -1.0], atol=1e-5)
+    np.testing.assert_allclose(n.normalize([1.0, 10.0], stats, use_quantiles=True), [1.0, 1.0], atol=1e-5)
+
+
+def test_pi05_norm_quantile_round_trips() -> None:
+    stats = NormStats.from_quantiles(q01=[-2.0, 1.0, 0.0], q99=[2.0, 5.0, 100.0])
+    x = np.array([0.5, 3.0, 42.0])
+
+    round_tripped = n.unnormalize(
+        n.normalize(x, stats, use_quantiles=True), stats, use_quantiles=True
+    )
+    np.testing.assert_allclose(round_tripped, x, rtol=1e-6, atol=1e-6)
+
+
+def test_pi05_norm_missing_stats_for_mode_raises() -> None:
+    quant_only = NormStats.from_quantiles(q01=[0.0], q99=[1.0])
+    with pytest.raises(ValueError, match="mean_std"):
+        n.normalize([0.5], quant_only)  # default mode needs mean/std
+
+    mean_only = NormStats.from_mean_std(mean=[0.0], std=[1.0])
+    with pytest.raises(ValueError, match="quantile"):
+        n.normalize([0.5], mean_only, use_quantiles=True)
+
+
+# ---------------------------------------------------------------------------
+# pad-to-32 / slice-to-7 bridge (openpi pad_to_dim + LiberoOutputs[..., :7]).
+# ---------------------------------------------------------------------------
+
+def test_pi05_norm_pad_state_to_model_dim() -> None:
+    state8 = np.arange(8, dtype=float)
+    padded = n.pad_to_dim(state8)  # 8 -> 32
+    assert padded.shape == (n.PI0_ACTION_DIM,)
+    np.testing.assert_allclose(padded[:8], state8)
+    np.testing.assert_allclose(padded[8:], 0.0)  # tail is zero padding
+
+
+def test_pi05_norm_pad_is_noop_when_already_wide_enough() -> None:
+    x = np.arange(32, dtype=float)
+    np.testing.assert_array_equal(n.pad_to_dim(x), x)
+
+
+def test_pi05_norm_slice_action_to_seven_dof() -> None:
+    chunk32 = np.arange(3 * 32, dtype=float).reshape(3, 32)  # (horizon, 32)
+    sliced = n.slice_to_libero(chunk32)
+    assert sliced.shape == (3, n.LIBERO_ACTION_DIM)
+    np.testing.assert_allclose(sliced[0], np.arange(7))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end state/action mapping to the simulator format.
+# ---------------------------------------------------------------------------
+
+def test_pi05_norm_state_to_model_pads_then_normalizes() -> None:
+    # 8-D state, model dim 32 -> normalized 32-vector. Use unit std / zero mean so
+    # the normalized values equal the padded input (easy to assert).
+    stats = NormStats.from_mean_std(mean=np.zeros(32), std=np.ones(32))
+    state8 = np.arange(1, 9, dtype=float)
+
+    model_in = n.pi05_state_to_model(state8, stats)
+    assert model_in.shape == (32,)
+    np.testing.assert_allclose(model_in[:8], state8, atol=1e-4)
+    np.testing.assert_allclose(model_in[8:], 0.0, atol=1e-4)
+
+
+def test_pi05_norm_action_to_sim_unnormalizes_then_slices() -> None:
+    # Model emits a normalized 32-D action; unnormalize with per-dim stats, take 7-D.
+    mean = np.arange(32, dtype=float)          # physical offset per dim
+    stats = NormStats.from_mean_std(mean=mean, std=np.ones(32))
+    normalized_action = np.zeros(32)           # zero -> recovers the mean
+
+    sim_action = n.pi05_action_to_sim(normalized_action, stats)
+    assert sim_action.shape == (n.LIBERO_ACTION_DIM,)
+    # Un-normalized value at each dim is its mean; sliced to the first 7.
+    np.testing.assert_allclose(sim_action, mean[:7], atol=1e-4)
+
+
+def test_pi05_norm_action_to_sim_no_gripper_fixup() -> None:
+    # Identity stats: a gripper in [0,1] passes through un-normalized and un-touched
+    # (NO binarize/invert, unlike GR00T). Here dim 6 (gripper) stays 0.2.
+    stats = NormStats.from_mean_std(mean=np.zeros(7), std=np.ones(7))
+    action = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2])
+    sim = n.pi05_action_to_sim(action, stats)
+    assert sim[6] == pytest.approx(0.2, abs=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# The ``unnorm_key`` analog: asset_id resolution + the no-unnorm_key guard.
+# ---------------------------------------------------------------------------
+
+def test_pi05_norm_resolves_libero_asset_id() -> None:
+    # The analog of OpenVLA's unnorm_key: which baked norm_stats asset the checkpoint uses.
+    assert n.resolve_pi05_asset_id("lerobot/pi05_libero") == "physical-intelligence/libero"
+    assert (
+        n.resolve_pi05_asset_id("gs://openpi-assets/checkpoints/pi05_libero")
+        == "physical-intelligence/libero"
+    )
+
+
+def test_pi05_norm_resolve_asset_id_override_wins() -> None:
+    assert (
+        n.resolve_pi05_asset_id("lerobot/pi05_libero", override="my-org/custom")
+        == "my-org/custom"
+    )
+
+
+def test_pi05_norm_resolve_unknown_checkpoint_raises() -> None:
+    with pytest.raises(KeyError, match="pi05"):
+        n.resolve_pi05_asset_id("some/unknown_checkpoint")
+
+
+def test_pi05_norm_rejects_stray_unnorm_key_in_config() -> None:
+    # π0.5 mission configs must not carry unnorm_key (inert/misleading vs OpenVLA).
+    with pytest.raises(ValueError, match="unnorm_key"):
+        n.assert_no_unnorm_key({"pilot": "pi05", "unnorm_key": "libero_object"})
+
+
+def test_pi05_norm_accepts_config_without_unnorm_key() -> None:
+    # A clean π0.5 config passes the guard silently.
+    n.assert_no_unnorm_key({"pilot": "pi05", "checkpoint": "lerobot/pi05_libero"})
+    n.assert_no_unnorm_key(None)  # non-dict is a no-op

--- a/tests/unit/test_pi05_pilot.py
+++ b/tests/unit/test_pi05_pilot.py
@@ -30,7 +30,6 @@ from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
 from odyssey.runners.agents.runtime import PilotRuntime
 from odyssey.runners.models.pi05 import make_pi05_pilot
 
-
 # ---------------------------------------------------------------------------
 # Fakes — a chunk-emitting policy + a decoder, both dependency-free.
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_pilot.py
+++ b/tests/unit/test_pi05_pilot.py
@@ -1,0 +1,373 @@
+"""Tests for the π0.5 chunk-aware pilot adapter (issue #74).
+
+The π0.5 pilot reuses the pilot-agnostic ``ChunkPilotAdapter`` (chunk replay +
+flush-on-instruction-change gating) and thin π0.5 wire transforms, so the whole
+adapter is exercisable WITHOUT a GPU, a served checkpoint, or downloaded weights:
+
+  * the gating engine (``runners/agents/chunk_pilot.py``) carries no heavy deps —
+    tested with plain fake ``predict_chunk``/``action_decoder`` callables;
+  * the wire transforms (``runners/evals/pi05_transforms.py``) are numpy-only and
+    reuse GR00T's Franka Panda kinematics — tested against tiny arrays;
+  * ``make_pi05_pilot`` (``runners/models/pi05.py``) defers the openpi client
+    import, so we can wire it end-to-end with an injected fake client and pin the
+    missing-dependency contract without openpi installed.
+
+All tests are named ``test_pi05_pilot_*`` (the ``-k pi05_pilot`` gate).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
+from odyssey.runners.agents.runtime import PilotRuntime
+from odyssey.runners.models.pi05 import make_pi05_pilot
+
+
+# ---------------------------------------------------------------------------
+# Fakes — a chunk-emitting policy + a decoder, both dependency-free.
+# ---------------------------------------------------------------------------
+
+class _RecordingPolicy:
+    """Fake chunk-emitting policy: records every query, returns a tagged chunk."""
+
+    def __init__(self, result: Any = None) -> None:
+        self.calls: list[Any] = []
+        self._result = result
+
+    def infer(self, wire_obs: Any) -> Any:
+        self.calls.append(wire_obs)
+        # Default chunk tags each step so the decoder can prove which step it got.
+        if self._result is not None:
+            return self._result
+        return {"query": len(self.calls)}
+
+
+def _index_decoder(chunk: Any, k: int) -> tuple[Any, int]:
+    """Decode = surface (chunk, k) so tests can assert the replay cursor."""
+    return (chunk, k)
+
+
+def _make_adapter(policy: _RecordingPolicy, *, n_action_steps: int = 3,
+                  observation_builder=None) -> ChunkPilotAdapter:
+    return ChunkPilotAdapter(
+        predict_chunk=policy.infer,
+        action_decoder=_index_decoder,
+        n_action_steps=n_action_steps,
+        observation_builder=observation_builder,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ChunkPilotAdapter — chunk buffering + replay.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_replays_chunk_without_requerying() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=3)
+
+    outs = [adapter.act("obs", "pick up the cube") for _ in range(3)]
+
+    # One query filled the chunk; all 3 steps replayed from it.
+    assert len(policy.calls) == 1
+    # Cursor advanced 0,1,2 over the same (single) chunk.
+    assert [k for _chunk, k in outs] == [0, 1, 2]
+    assert all(chunk == {"query": 1} for chunk, _k in outs)
+
+
+def test_pi05_pilot_requeries_when_chunk_drains() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=2)
+
+    for _ in range(4):  # two full chunks of 2 steps
+        adapter.act("obs", "same instruction")
+
+    assert len(policy.calls) == 2  # re-queried once the first chunk was spent
+
+
+def test_pi05_pilot_decoder_cursor_resets_each_chunk() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=2)
+
+    ks = [adapter.act("obs", "instr")[1] for _ in range(4)]
+
+    assert ks == [0, 1, 0, 1]  # cursor resets to 0 on each re-query
+
+
+# ---------------------------------------------------------------------------
+# ChunkPilotAdapter — flush-on-instruction-change gating.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_flushes_on_instruction_change() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=5)
+
+    adapter.act("obs", "reach for the bowl")   # query 1
+    adapter.act("obs", "reach for the bowl")   # replay (no query)
+    assert len(policy.calls) == 1
+
+    # Instruction changes mid-chunk -> immediate re-query, stale chunk discarded.
+    _chunk, k = adapter.act("obs", "now grasp the bowl")
+    assert len(policy.calls) == 2
+    assert k == 0  # fresh chunk starts at step 0
+
+
+def test_pi05_pilot_same_instruction_does_not_flush() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=10)
+
+    for _ in range(5):
+        adapter.act("obs", "identical")
+
+    assert len(policy.calls) == 1  # never re-queried within one chunk
+
+
+def test_pi05_pilot_reset_forces_requery() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=5)
+
+    adapter.act("obs", "instr")
+    assert adapter.steps_remaining == 4
+    adapter.reset()  # per-episode flush
+    assert adapter.steps_remaining == 0
+
+    adapter.act("obs", "instr")
+    assert len(policy.calls) == 2  # reset dropped the buffer -> new query
+
+
+# ---------------------------------------------------------------------------
+# ChunkPilotAdapter — plumbing details.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_unwraps_tuple_policy_result() -> None:
+    # A policy may return (chunk, extra); the adapter uses the leading element.
+    policy = _RecordingPolicy(result=("the-chunk", {"latency_ms": 12}))
+    adapter = _make_adapter(policy, n_action_steps=1)
+
+    chunk, k = adapter.act("obs", "instr")
+    assert chunk == "the-chunk"
+    assert k == 0
+
+
+def test_pi05_pilot_observation_builder_shapes_the_wire_obs() -> None:
+    seen: list[tuple[Any, str]] = []
+
+    def builder(raw_obs: Any, instruction: str) -> Any:
+        seen.append((raw_obs, instruction))
+        return {"wire": raw_obs, "prompt": instruction}
+
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=1, observation_builder=builder)
+
+    adapter.act({"eef": 1}, "do the thing")
+
+    assert seen == [({"eef": 1}, "do the thing")]
+    # The built wire obs (not the raw obs) is what reaches the policy.
+    assert policy.calls == [{"wire": {"eef": 1}, "prompt": "do the thing"}]
+
+
+def test_pi05_pilot_passes_observation_through_without_builder() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=1, observation_builder=None)
+
+    adapter.act({"already": "wire"}, "instr")
+    assert policy.calls == [{"already": "wire"}]
+
+
+def test_pi05_pilot_introspection_tracks_buffer() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=3)
+
+    assert adapter.n_action_steps == 3
+    assert adapter.steps_remaining == 0  # nothing buffered yet
+    adapter.act("obs", "instr")
+    assert adapter.steps_remaining == 2
+    adapter.act("obs", "instr")
+    assert adapter.steps_remaining == 1
+
+
+def test_pi05_pilot_rejects_non_positive_n_action_steps() -> None:
+    with pytest.raises(ValueError, match="n_action_steps"):
+        ChunkPilotAdapter(
+            predict_chunk=lambda o: o, action_decoder=_index_decoder, n_action_steps=0,
+        )
+
+
+def test_pi05_pilot_satisfies_pilot_runtime_protocol() -> None:
+    adapter = _make_adapter(_RecordingPolicy(), n_action_steps=1)
+    # runtime_checkable Protocol: structural match on act(observation, instruction).
+    assert isinstance(adapter, PilotRuntime)
+
+
+# ---------------------------------------------------------------------------
+# π0.5 wire transforms — numpy-only, reuse GR00T's Franka Panda kinematics.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_obs_uses_openpi_keys() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    obs = t.build_pi05_libero_obs(
+        image=np.zeros((4, 4, 3), np.uint8),
+        wrist_image=np.zeros((4, 4, 3), np.uint8),
+        eef_pos=[0.1, 0.2, 0.3],
+        eef_quat_xyzw=[0.0, 0.0, 0.0, 1.0],
+        gripper_qpos=[0.01, -0.01],
+        instruction="pick up the cube",
+    )
+    assert set(obs) == {
+        "observation/image", "observation/wrist_image",
+        "observation/state", "prompt",
+    }
+    assert obs["prompt"] == "pick up the cube"
+    assert obs["observation/image"].dtype == np.uint8
+
+
+def test_pi05_pilot_state_is_eight_dim_franka_panda() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    state = t.build_pi05_libero_state(
+        eef_pos=[0.1, 0.2, 0.3],
+        eef_quat_xyzw=[0.0, 0.0, 0.0, 1.0],  # identity -> zero axis-angle
+        gripper_qpos=[0.04, -0.04],
+    )
+    assert state.shape == (8,)
+    # eef_pos(3) + axis-angle(3) + gripper qpos(2)
+    np.testing.assert_allclose(state[:3], [0.1, 0.2, 0.3], atol=1e-6)
+    np.testing.assert_allclose(state[3:6], [0.0, 0.0, 0.0], atol=1e-6)
+    np.testing.assert_allclose(state[6:8], [0.04, -0.04], atol=1e-6)
+
+
+def test_pi05_pilot_state_reuses_gr00t_axis_angle() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+    from odyssey.runners.evals.gr00t_transforms import quat_xyzw_to_axis_angle
+
+    quat = [0.0, 0.3826834, 0.0, 0.9238795]  # 45° about y
+    state = t.build_pi05_libero_state(
+        eef_pos=[0, 0, 0], eef_quat_xyzw=quat, gripper_qpos=[0, 0],
+    )
+    # The axis-angle block is byte-for-byte the shared GR00T kinematics (no dup).
+    np.testing.assert_allclose(state[3:6], quat_xyzw_to_axis_angle(quat), atol=1e-6)
+
+
+def test_pi05_pilot_action_slices_chunk_to_seven_dof() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    # openpi wire result: a (horizon, 32) chunk under "actions" (pre-slice).
+    chunk = {"actions": np.arange(10 * 32, dtype=float).reshape(10, 32)}
+    action = t.pi05_action_to_libero(chunk, 4)
+    assert action.shape == (7,)
+    np.testing.assert_allclose(action, np.arange(4 * 32, 4 * 32 + 7))
+
+
+def test_pi05_pilot_action_has_no_gripper_fixup() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    # A gripper value in [0,1]: π0.5 passes it through verbatim (NO
+    # normalize/binarize/invert), unlike gr00t_action_to_libero.
+    chunk = {"actions": np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2]])}
+    action = t.pi05_action_to_libero(chunk, 0)
+    assert action[6] == pytest.approx(0.2)  # unchanged: no fix-up
+
+
+def test_pi05_pilot_action_accepts_bare_array_chunk() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    chunk = np.arange(5 * 7, dtype=float).reshape(5, 7)  # no dict wrapper
+    action = t.pi05_action_to_libero(chunk, 1)
+    np.testing.assert_allclose(action, np.arange(7, 14))
+
+
+def test_pi05_pilot_action_translation_only_zeros_rotation() -> None:
+    np = pytest.importorskip("numpy")
+    from odyssey.runners.evals import pi05_transforms as t
+
+    chunk = {"actions": np.ones((1, 7))}
+    action = t.pi05_action_to_libero(chunk, 0, translation_only=True)
+    np.testing.assert_allclose(action[3:6], [0.0, 0.0, 0.0])  # rotation zeroed
+    assert action[6] == pytest.approx(1.0)  # gripper forced open
+
+
+# ---------------------------------------------------------------------------
+# make_pi05_pilot — end-to-end wiring with an injected fake client; and the
+# missing-openpi contract. No GPU, no served checkpoint, no weights.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_make_wires_injected_client_end_to_end() -> None:
+    np = pytest.importorskip("numpy")
+
+    # Fake openpi client: returns a (horizon, 32) chunk, records the wire obs.
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.calls: list[Any] = []
+
+        def infer(self, obs: Any) -> Any:
+            self.calls.append(obs)
+            return {"actions": np.arange(10 * 32, dtype=float).reshape(10, 32)}
+
+    client = _FakeClient()
+    pilot = make_pi05_pilot(client=client, n_action_steps=10)
+    assert isinstance(pilot, PilotRuntime)
+
+    raw_obs = {
+        "image": np.zeros((4, 4, 3), np.uint8),
+        "wrist_image": np.zeros((4, 4, 3), np.uint8),
+        "eef_pos": [0.1, 0.2, 0.3],
+        "eef_quat_xyzw": [0.0, 0.0, 0.0, 1.0],
+        "gripper_qpos": [0.01, -0.01],
+    }
+    action = pilot.act(raw_obs, "pick up the cube")
+
+    # One query; the wire obs handed to the client has openpi keys + the prompt.
+    assert len(client.calls) == 1
+    wire = client.calls[0]
+    assert set(wire) == {
+        "observation/image", "observation/wrist_image", "observation/state", "prompt",
+    }
+    assert wire["prompt"] == "pick up the cube"
+    # The decoded action is a clean 7-DoF vector.
+    assert action.shape == (7,)
+
+
+def test_pi05_pilot_make_raises_without_openpi_client() -> None:
+    if importlib.util.find_spec("openpi_client") is not None:
+        pytest.skip("openpi_client installed; the missing-dep path is not exercised")
+    with pytest.raises(NotImplementedError, match="openpi"):
+        make_pi05_pilot(host="127.0.0.1", port=8000)  # no injected client
+
+
+# ---------------------------------------------------------------------------
+# The model module defers heavy deps (openpi/numpy) — imports under bare stdlib.
+# ---------------------------------------------------------------------------
+
+def test_pi05_pilot_model_module_imports_without_heavy_deps() -> None:
+    heavy = ("numpy", "openpi_client", "torch", "jax")
+    # Point the fresh interpreter at THIS worktree's src (it doesn't inherit
+    # pytest's `pythonpath`, and an editable-install .pth may redirect elsewhere).
+    src_dir = Path(__file__).resolve().parents[2] / "src"
+    script = (
+        "import importlib, json, sys\n"
+        f"sys.path.insert(0, {str(src_dir)!r})\n"
+        "importlib.import_module('odyssey.runners.models.pi05')\n"
+        f"print(json.dumps([m for m in {heavy!r} if m in sys.modules]))\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"pi05 model module failed to import cleanly:\n{result.stderr}"
+    )
+    leaked = json.loads(result.stdout.strip().splitlines()[-1])
+    assert leaked == [], f"pi05 model module imported heavy deps at load: {leaked}"


### PR DESCRIPTION
# feat(pi05): chunk-emitting π0.5 pilot + FAST scoping (issue #74)

Integrates **Physical Intelligence π0.5 (pi05)** as the next chunk-emitting,
production-oriented generalist pilot, alongside GR00T-N1.7. Implements the
odyssey-side wiring end-to-end for a **single-agent LIBERO eval** and resolves the
open scoping questions from #74. **The GPU acceptance run has now passed on a GCP
L4 — π0.5 scores real successes on `libero_object` (see _Acceptance run_).**

Relates to #74. Reuses the chunk-aware runtime built for GR00T (PR #65) rather than
forking it.

## Design decision: server-side (option A), externally-served

π0.5 is a **flow-matching** VLA: at inference it emits **continuous** action chunks,
not FAST tokens. So the model runs out-of-process in an **openpi
`WebsocketPolicyServer`** and this repo only holds the lightweight websocket client
+ the LIBERO env. Consequences, made explicit:

- **FAST is NOT on the inference path.** FAST (de)tokenization matters only for π0.5
  *training* or for an autoregressive *π0-FAST* model. The `pi05_fast.py` codec is
  implemented + unit-tested but documented as **reserved scaffolding**, not wired.
- **Externally-served.** Unlike GR00T (which can self-serve its server in-process),
  you start the openpi server yourself and point the mission at `host:port`. A
  `_pi05_server.py` auto-serve lifecycle is intentionally deferred.

## What's in this PR

**Pilot runtime & wire glue**
- `runners/agents/chunk_pilot.py` — `ChunkPilotAdapter`: pilot-agnostic chunk
  buffer + replay + flush-on-instruction-change gating, factored out of GR00T's
  inlined loop so π0.5 reuses it (no duplicate abstraction).
- `runners/models/pi05.py` — `make_pi05_pilot()`: wraps the openpi client's
  `infer` in the adapter (lazy `openpi_client` import; injectable client for tests).
- `runners/evals/pi05_transforms.py` — openpi `observation/*` wire format + 7-DoF
  action slice, **no gripper fix-up** (contrast GR00T), reusing
  `quat_xyzw_to_axis_angle` from `gr00t_transforms`.
- `runners/evals/pi05_norm.py` — the `unnorm_key` analogue: π0.5 bakes
  `norm_stats` into the checkpoint (asset_id), so this mirrors openpi's
  Normalize/Unnormalize in numpy and rejects a stray `unnorm_key` in the config.
- `runners/evals/pi05_fast.py` — FAST codec over the HF `physical-intelligence/fast`
  tokenizer (reserved; see above).

**Eval path**
- `runners/evals/pi05_libero_eval.py` — the LIBERO eval subprocess recipe
  (`pilot: pi05`): builds the env, connects to the openpi server via the adapter,
  replays chunks (`pilot.act` per step, re-query on drain), emits the shared
  `ODYSSEY_EPISODE`/`ODYSSEY_RESULT` protocol, captures video.
- `runners/evals/libero.py` — `pilot: pi05` dispatch + `build_pi05_libero_argv`.

**Docs & example**
- `docs/pi05-scoping.md` — license/weights, FAST availability, VRAM footprint,
  action-space mapping (resolves #74 Q1–Q4 at the analysis level).
- `examples/quickstart-pi05/` — a runnable LIBERO eval-only mission + README
  (prereqs, run steps, a #74 acceptance map, and an exhaustive "not verified" list).

## Acceptance run (2026-07-29, GCP L4 `odyssey-multiagent-test`)

Ran the quickstart mission end-to-end against a live openpi `pi05_libero` server
(`gs://openpi-assets/checkpoints/pi05_libero`, served via
`serve_policy.py --env LIBERO`). **π0.5 solves the task 10/10** — every episode on
`libero_object[task=0]` (`"pick up the alphabet soup and place it in the basket"`)
completes with `return=1.000` (**`success_rate = 1.000`, grade A**, steps ~137–191),
one MP4 per episode (all `episode_NN_PASS.mp4`) written under the run's `videos/`.
This closes the acceptance gate and resolves the two flagged risks:

- ✅ **Gripper polarity** — the **no-fix-up** assumption is correct; π0.5 grasps and
  places without inversion.
- ✅ **openpi `infer` wire shape** — the server returns `{"actions": <ndarray>}` (7-D)
  as the recipe assumes; chunks decode and replay cleanly.

### Hardware bring-up fixes (needed to get the rollout running)

Four environment/compat walls surfaced on a fresh `env_pi` venv; all are fixed in
this PR (none touch the π0.5 inference logic):

| # | Symptom | Fix | Commit |
| - | ------- | --- | ------ |
| 1 | LIBERO `get_task_init_states()` crashes: `UnpicklingError` (numpy globals) | PyTorch ≥ 2.6 flipped `weights_only` to `True`; load LIBERO's trusted init-states with a contained `weights_only=False` shim in `_make_libero_env` (shared by gr00t + pi05) | `9e12598` |
| 2 | `AttributeError: 'MjData' has no attribute 'qM'` in robosuite's OSC controller | Unpinned `env_pi` resolved mujoco 3.x / numpy 2.x; pin `mujoco==2.3.2` + `numpy<2` in `quickstart-pi05/setup.sh` (robosuite 1.4 compat) | `d1b40ad` |
| 3 | Every episode fails at `steps=0` with `1011 keepalive ping timeout` | openpi's sync server blocks its handler while JAX JIT-compiles the first `infer` (minutes) → client keepalive tears the socket down; disable the client keepalive (`ping_interval=None`) in `make_pi05_pilot` | `193dea7` |
| 4 | CI strict-mypy red on the torch shim (`unused type: ignore`) | Route the `torch.load` reassignment through an `Any`-typed alias so mypy checks identically with/without torch installed | `1ba34cc` |

Also synced the branch with `develop` (merge `0572ae6`; net diff was only a
`ci.yml` bump).

### Environment caveat — render backend

This L4's NVIDIA driver was installed **compute-only** (no `libEGL_nvidia` / GLVND
vendor JSON), so hardware EGL rendering was unavailable. The rollout used
**OSMesa** (`MUJOCO_GL=osmesa`) — CPU software rendering; **π0.5 inference still ran
on the GPU** (the openpi server). This is a VM provisioning gap, not a code issue;
GPU-accelerated render for large sweeps needs `libnvidia-gl-<ver>` (or a driver
reinstall with `--opengl-libs`). See _Follow-ups_.

## Alignment with #74 acceptance

| Acceptance item | State |
| --- | --- |
| Confirm π0.5 weights + FAST availability/license (Q1/Q2) | ✅ scoping doc — Apache 2.0; FAST reusable via openpi/HF, no reimplementation |
| Shared chunk-aware `PilotRuntime` abstraction (GR00T + π0.5) | ✅ `ChunkPilotAdapter`, reused not forked |
| π0.5 runs a LIBERO eval end-to-end (single-agent) on the VM | ✅ **acceptance run passed — 10/10 success on an L4** |
| Sim embodiment / action mapping + gripper (Q4) | ✅ confirmed on hardware (no fix-up; wire shape verified) |
| Measure calls/episode + wall-clock vs OpenVLA baseline | ⬜ still to quantify |
| VRAM on a single L4 (Q3) | 🟡 single-agent runs on the L4; exact footprint not yet measured, co-residence with a SPECIALIST unconfirmed |
| Docs: pilot line-up + chunk-aware runtime notes | ✅ scoping doc + quickstart README |

## Status & limits — what is still NOT verified

The single-agent eval path is now proven on hardware. Remaining open items:

- **Latency win unquantified** — calls/episode + wall-clock vs the OpenVLA baseline
  not yet measured (the #74 motivation; expected win from chunking).
- **VRAM footprint not measured** — single-agent runs on 24 GB; multi-agent
  co-residence with a SPECIALIST is unconfirmed.
- **GPU render not exercised** — the acceptance run used OSMesa (see caveat above);
  the hardware EGL path is untested on this VM.
- **openpi is an external dependency** (separate JAX env + a served checkpoint);
  not vendored here. The openpi server half of `setup.sh` follows openpi's docs —
  confirm `serve_policy.py` flags against your openpi version.

## How to try it

Start an openpi π0.5 server (see `examples/quickstart-pi05/README.md`), then:

```bash
odyssey validate examples/quickstart-pi05/mission.yaml
odyssey run      examples/quickstart-pi05/mission.yaml
```

Headless render: `export MUJOCO_GL=egl PYOPENGL_PLATFORM=egl` (or
`MUJOCO_GL=osmesa` for a CPU fallback if the driver lacks NVIDIA EGL, as above).

## Testing

- Unit tests cover the transforms, normalization, FAST codec, `ChunkPilotAdapter`,
  the pilot factory, the eval dispatch, and the eval recipe's argv/protocol/import
  contracts — all CPU-only (no GPU, no weights, injected fakes).
- Full suite green; **CI green on Python 3.10 / 3.11 / 3.12** (ruff + strict mypy +
  pytest) at `1ba34cc`. The π0.5 openpi-boundary modules are exempt from strict
  mypy via a `tool.mypy` override, matching the existing GR00T-transforms precedent.
- **Validated end-to-end on a GCP L4 — 10/10 on `libero_object[task=0]`** (see
  _Acceptance run_).

## Follow-ups (not in this PR)

- Latency measurement vs the OpenVLA baseline (calls/episode + wall-clock).
- Install `libnvidia-gl-<ver>` on the eval VM for GPU-accelerated render (this run
  used OSMesa); measure VRAM footprint under GPU render.
- Optional `_pi05_server.py` self-serve lifecycle (currently externally-served only).
- Multi-agent arms (π0.5 PILOT + co-resident SPECIALIST) once VRAM co-residence is
  confirmed.
