### PR TITLE
feat(providers): register ur10e embodiment (GR00T NEW_EMBODIMENT)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -109,7 +109,7 @@ and that `agents` contains exactly one agent.
 
 | Form | Example | What it does today |
 |---|---|---|
-| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
+| `embodiment:` | `franka_panda`, `ur5e`, `ur10e` | Names a built-in catalog embodiment. 9 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover, passed through to `robosuite.make(robots=...)` at evaluation — plus `ur10e`, driven by the **GR00T runner** (`NEW_EMBODIMENT` finetune), which Robosuite doesn't ship: it resolves and validates, but a Robosuite eval task against it raises rather than passing through. All resolved at mission-creation by `LocalRobotProvider`. |
 | `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
 | `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
 

--- a/src/odyssey/providers/local/robots.py
+++ b/src/odyssey/providers/local/robots.py
@@ -28,14 +28,19 @@ from odyssey.providers.base import ResolvedRobot, RobotProvider
 from odyssey.spec.mission import RobotSpec
 
 # Scoped to embodiments at least one shipped runner can actually drive
-# end-to-end. Today that means the arms Robosuite's built-in robot
-# models cover (``ROBOSUITE_ROBOT_NAMES`` in runners/evals/robosuite.py is the
-# matching translation table). Quadrupeds (unitree_go2/h1), mobile bases
-# (tiago, stretch3), and arms Robosuite doesn't ship (ur10e) were
-# removed in this trim — they accepted with a green spec, then produced
-# identical default-Panda eval runs that misled users about what was
-# being simulated. Re-add a name here only when a runner exists that
-# honors it; for unsupported robots, ``urdf:`` still works.
+# end-to-end. Two runners qualify a name today:
+#   * Robosuite — the arms its built-in robot models cover
+#     (``ROBOSUITE_ROBOT_NAMES`` in runners/evals/robosuite.py is the matching
+#     translation table).
+#   * the GR00T runner — arms it can finetune as a NEW_EMBODIMENT (e.g.
+#     ``ur10e``), which Robosuite doesn't ship and so stays outside
+#     ``ROBOSUITE_ROBOT_NAMES``.
+# The catalog is therefore a superset of the Robosuite-drivable names, not a
+# mirror of them. Quadrupeds (unitree_go2/h1) and mobile bases (tiago,
+# stretch3) remain excluded — with no runner that honors them they accepted
+# with a green spec, then produced identical default-Panda eval runs that
+# misled users about what was being simulated. Re-add a name here only when a
+# runner exists that drives it; for unsupported robots, ``urdf:`` still works.
 KNOWN_EMBODIMENTS: frozenset[str] = frozenset(
     {
         "franka_panda",   # alias of "panda" — common in OpenVLA / LeRobot specs

--- a/src/odyssey/providers/local/robots.py
+++ b/src/odyssey/providers/local/robots.py
@@ -45,6 +45,8 @@ KNOWN_EMBODIMENTS: frozenset[str] = frozenset(
         "jaco",
         "kinova_gen3",
         "ur5e",
+        "ur10e",          # driven by the GR00T runner (NEW_EMBODIMENT finetune),
+                          # not Robosuite — hence outside ROBOSUITE_ROBOT_NAMES.
         "baxter",
     }
 )

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -72,14 +72,16 @@ hosted Lovell embodiment whose name isn't in
 """
 
 
-# Odyssey embodiment → Robosuite robot model. The map deliberately
-# mirrors the trimmed LocalRobotProvider.KNOWN_EMBODIMENTS so the same
-# names that pass spec validation also run end-to-end.
+# Odyssey embodiment → Robosuite robot model. This map is the
+# Robosuite-drivable *subset* of LocalRobotProvider.KNOWN_EMBODIMENTS: every
+# name here passes spec validation and runs end-to-end under Robosuite, but
+# the catalog is a superset — GR00T-only targets like ``ur10e`` validate yet
+# have no entry here (they run under the GR00T runner, not Robosuite).
 #
 # Anything missing here either has no Robosuite equivalent (Unitree
-# quadrupeds, Tiago, Stretch3) or hasn't been wired yet. For those,
-# operators can use ``urdf:`` and we'll fall through to Robosuite's
-# default robot for the benchmark.
+# quadrupeds, Tiago, Stretch3; GR00T-only arms like ur10e) or hasn't been
+# wired yet. For those, operators can use ``urdf:`` and we'll fall through to
+# Robosuite's default robot for the benchmark.
 ROBOSUITE_ROBOT_NAMES: dict[str, str] = {
     "franka_panda": "Panda",
     "panda": "Panda",

--- a/tests/unit/test_local_providers.py
+++ b/tests/unit/test_local_providers.py
@@ -41,6 +41,18 @@ async def test_robot_resolves_known_embodiment() -> None:
     assert resolved.name == "franka_panda"
 
 
+async def test_robot_resolves_ur10e_embodiment() -> None:
+    # ur10e is a GR00T NEW_EMBODIMENT arm (finetune target); it must resolve
+    # through the local provider so a `robot.embodiment: ur10e` spec validates.
+    provider = LocalRobotProvider()
+    resolved = await provider.resolve(
+        RobotSpec(embodiment="ur10e", agents=_agents())
+    )
+    assert resolved.provider == "local"
+    assert resolved.embodiment == "ur10e"
+    assert resolved.name == "ur10e"
+
+
 async def test_robot_rejects_unknown_embodiment() -> None:
     provider = LocalRobotProvider()
     # model_construct bypasses spec validation — needed because we're
@@ -73,13 +85,15 @@ async def test_robot_rejects_missing_urdf(tmp_path: Path) -> None:
 
 
 def test_known_embodiments_covers_robosuite_robots() -> None:
-    # The trimmed allowlist is the set of embodiments at least one
-    # shipped runner can drive end-to-end. Robosuite is the eval
-    # runner today, so every name here must also have a translation in
-    # runners.evals.robosuite.ROBOSUITE_ROBOT_NAMES.
+    # The allowlist is the set of embodiments at least one shipped runner can
+    # drive end-to-end. Robosuite is the eval runner for most arms, so every
+    # Robosuite-translatable name must be in the catalog...
     from odyssey.runners.evals.robosuite import ROBOSUITE_ROBOT_NAMES
 
-    assert set(ROBOSUITE_ROBOT_NAMES.keys()) == KNOWN_EMBODIMENTS
+    assert set(ROBOSUITE_ROBOT_NAMES.keys()) <= KNOWN_EMBODIMENTS
+    # ...and the only names beyond Robosuite are GR00T NEW_EMBODIMENT arms
+    # (driven by the `gr00t` runner, never Robosuite) — today just ur10e.
+    assert KNOWN_EMBODIMENTS - set(ROBOSUITE_ROBOT_NAMES.keys()) == {"ur10e"}
     # franka_panda is the alias most OpenVLA / LeRobot specs use.
     assert "franka_panda" in KNOWN_EMBODIMENTS
     # Quadrupeds and mobile bases were intentionally trimmed — no

--- a/tests/unit/test_local_providers.py
+++ b/tests/unit/test_local_providers.py
@@ -53,6 +53,21 @@ async def test_robot_resolves_ur10e_embodiment() -> None:
     assert resolved.name == "ur10e"
 
 
+async def test_ur10e_resolves_then_robosuite_refuses_it() -> None:
+    # Pins the behaviour change this PR introduces: on develop, `ur10e` was
+    # rejected at spec/catalog validation; now it resolves cleanly and only a
+    # Robosuite eval task refuses it — loudly (ValueError), never a silent
+    # default-Panda substitution. ur10e is the first real catalog name that can
+    # reach `_resolve_robosuite_robot`, so no `model_construct` is needed here.
+    from odyssey.runners.evals.robosuite import _resolve_robosuite_robot
+
+    spec = RobotSpec(embodiment="ur10e", agents=_agents())
+    resolved = await LocalRobotProvider().resolve(spec)
+    assert resolved.embodiment == "ur10e"
+    with pytest.raises(ValueError, match="Robosuite has no built-in robot"):
+        _resolve_robosuite_robot(spec)
+
+
 async def test_robot_rejects_unknown_embodiment() -> None:
     provider = LocalRobotProvider()
     # model_construct bypasses spec validation — needed because we're


### PR DESCRIPTION
## What

Registers **`ur10e`** in the local robot catalog (`providers/local/robots.py`) so a
`robot.embodiment: ur10e` mission spec validates end to end.

## Why

`ur10e` is the arm for the UR10e drug-sort GR00T pilot. It is driven by the
**`gr00t` runner** (`NEW_EMBODIMENT` finetune), **not** Robosuite — which is why it
was previously excluded from the catalog (the trim note warns that Robosuite-only
arms produced misleading default-Panda eval runs). This change integrates the
embodiment **unitarily and independently** of the larger drug-sort PoC branch, so
missions can name `ur10e` without pulling in the whole pilot stack.

## Changes

- `src/odyssey/providers/local/robots.py` — add `ur10e` to `KNOWN_EMBODIMENTS`, and
  rewrite the catalog comment: the allowlist is now a **superset** of the
  Robosuite-drivable arms **plus** GR00T `NEW_EMBODIMENT` finetune targets, not a
  mirror of `ROBOSUITE_ROBOT_NAMES`.
- `tests/unit/test_local_providers.py`:
  - Evolve the catalog invariant: Robosuite-translatable names are now a
    **subset** of the catalog, and `ur10e` is the sole GR00T-only addition
    (`KNOWN_EMBODIMENTS - ROBOSUITE_ROBOT_NAMES == {"ur10e"}`).
  - Add a positive resolution test (`ur10e` resolves through `LocalRobotProvider`).
  - Add `test_ur10e_resolves_then_robosuite_refuses_it`, pinning the behaviour
    change: `ur10e` now resolves cleanly and only a Robosuite eval refuses it —
    loudly (`ValueError`), never a silent default-Panda substitution.
- `docs/concepts.md` — `embodiment:` row updated 8 → **9 names**; note that `ur10e`
  resolves and validates but a Robosuite eval task against it **raises** rather than
  passing through to `robosuite.make(robots=...)`.
- `src/odyssey/runners/evals/robosuite.py` — amend the `ROBOSUITE_ROBOT_NAMES`
  comment: it is the Robosuite-drivable **subset** of `KNOWN_EMBODIMENTS`, the
  invariant this PR deliberately breaks.

## Test

`pytest tests/unit/test_local_providers.py` → **13 passed** (incl. the two new
ur10e tests and the updated invariant). Full suite **499 passed, 5 skipped**;
`ruff check` and `mypy` strict clean on 3.10–3.12.

## Notes

- No Robosuite translation is added for `ur10e` (Robosuite doesn't ship it); the
  guard that every Robosuite name stays in the catalog is preserved as a subset.
- Scoped intentionally small: catalog + tests + docs only. The finetune mission,
  modality config, and eval live on the `feat/ur10e-drugsort-finetune` branch.
- The gate this PR actually changes is `create_mission` → `LocalRobotProvider.resolve`
  (not `odyssey validate`, which only loads the spec and never consults the catalog —
  it already printed `OK` for `embodiment: ur10e` on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
