### PR TITLE
feat(evals): CustomEvalRunner for evaluation_type: custom (#87)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -64,6 +64,43 @@ deadlines, instruction prefixes injected into VLA prompts). Write them like
 you mean it — future-you will reread them in leaderboard submissions and
 graph queries.
 
+### Evaluation types
+
+`evaluation_type` selects the eval runner:
+
+| `evaluation_type` | Runs |
+|---|---|
+| `robosuite` | In-process rollouts in the Robosuite sim (auto-wired OpenVLA policy). |
+| `isaac_lab` | An Isaac Lab eval script under Isaac Sim's Python, over an `ODYSSEY_*` stdout protocol. |
+| `custom` | **Any eval script**, as a subprocess, decoupled from any sim. |
+
+Use `custom` when the honest metric for your task is neither Robosuite nor Isaac
+Lab — e.g. the ground-truth evals for the UR10e/UR5e GR00T pilot (open-loop:
+replay recorded observations and compare the predicted action chunk to the
+recorded expert action; closed-loop: roll out the served policy and score
+against physics ground truth). The runner owns the launch, the checkpoint path,
+cancellation, and reading metrics; the *script* owns everything domain-specific,
+including how it loads or serves the checkpoint.
+
+```yaml
+  - name: openloop-gt
+    kind: evaluation
+    evaluation_type: custom
+    benchmark_name: openloop-gt
+    config:
+      eval_script: scripts/eval_openloop_gt.py   # or $ODYSSEY_EVAL_SCRIPT
+      eval_python: /venv/gr00t/bin/python         # optional; default sys.executable
+      replay_dataset: /data/ur10e                 # extra keys pass through as --replay_dataset
+```
+
+The runner launches `<eval_python> <eval_script> --checkpoint <path> --out-json
+<path> [--<config-key> <value> …]`. The script writes its metrics to the
+`--out-json` path as a JSON object; `success_rate` (if present) yields a letter
+grade + pass/fail, otherwise the metrics are surfaced as-is (a metric-only eval
+such as per-joint MAE is not forced into a pass/fail). Without this runner,
+`evaluation_type: custom` would fall through to the fake `CPUMockRunner`. Full
+contract: `src/odyssey/runners/evals/custom.py`.
+
 ## Robots and agents
 
 In the Lovell AI architecture, a **robot** is more than an embodiment —

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -35,6 +35,7 @@ from odyssey.runners import (
     OpenVLARunner,
     RunnerRegistry,
 )
+from odyssey.runners.evals.custom import CustomEvalRunner
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.libero import LiberoRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
@@ -57,6 +58,9 @@ def _build_runners() -> RunnerRegistry:
     registry.register(RobosuiteRunner())
     registry.register(IsaacLabRunner())
     registry.register(LiberoRunner())
+    # Exact (EVALUATION, "custom") match — beats the wildcard CPU mock so a real
+    # custom eval no longer falls through to a fake one.
+    registry.register(CustomEvalRunner())
     registry.register(CPUMockRunner())
     return registry
 

--- a/src/odyssey/runners/evals/custom.py
+++ b/src/odyssey/runners/evals/custom.py
@@ -1,0 +1,269 @@
+"""Custom evaluation runner — run an arbitrary eval script as a subprocess.
+
+The runner for ``evaluation_type: custom``. It is deliberately decoupled from
+Isaac Lab / Robosuite / MuJoCo: no sim-specific argv (``--task``/``--headless``),
+no per-episode stdout protocol, and no policy-serving dependency. Odyssey owns
+the launch, the checkpoint path, cancellation, and reading a machine-readable
+metrics file; the *script* owns everything domain-specific — including how it
+loads or serves the checkpoint.
+
+Without this runner, ``evaluation_type: custom`` falls through to the wildcard
+``CPUMockRunner`` (a fake eval), so the only ways to run a real project-specific
+evaluation were to abuse the ``isaac_lab`` runner's contract or to mock it out.
+
+Launch contract::
+
+    <eval_python> <eval_script> \\
+        --checkpoint <path> --out-json <path> [--<config-key> <value> ...]
+
+* ``eval_script`` — ``task.config["eval_script"]`` or ``$ODYSSEY_EVAL_SCRIPT``
+  (required). The script that runs the evaluation.
+* ``eval_python`` — ``task.config["eval_python"]``, default ``sys.executable``.
+  Lets the script run under a separate venv (e.g. a GR00T / openpi env) without
+  Odyssey having to import those deps.
+* ``--checkpoint`` — the trained PILOT checkpoint (via ``resolve_eval_checkpoint``):
+  a local path or an HF repo id. The runner does **not** serve it — the script
+  loads/serves it however it needs (contrast the ``isaac_lab`` runner). This is
+  what keeps ``CustomEvalRunner`` free of any policy-serving dependency.
+* ``--out-json`` — a path the runner allocates under the task's output dir; the
+  script MUST write its metrics there as a JSON object (see below). This is the
+  metrics channel — there is no stdout protocol.
+* Every other ``config.*`` key passes through as ``--key value`` verbatim
+  (snake_case preserved), the same passthrough style as ``isaac_lab``.
+
+out-json contract — the script writes one JSON object; every key is optional::
+
+    {
+      "success_rate": 0.42,          # float — when present, the summary carries a
+      "performance_score": 0.7,      #   trainer letter grade + pass/fail
+      "num_episodes": 50,
+      "metrics": { ... }             # arbitrary extra metrics (e.g. per-joint MAE)
+    }
+
+Unknown top-level keys are folded into ``metrics``. When ``success_rate`` is
+absent the eval is treated as **metric-only** (e.g. the open-loop GT eval, whose
+honest metric is per-joint MAE + gripper agreement, not a success rate): the
+summary surfaces the metrics *without* fabricating a 0.0 / grade-F pass/fail.
+
+Serving is intentionally the script's job — there is no ``config.serve_checkpoint``.
+The motivating open-loop GT eval loads the checkpoint in-process, and delegating
+serving keeps this runner sim- and policy-server-agnostic. A closed-loop eval that
+needs a served policy starts (or connects to) the server from inside the script.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import Runner, TaskContext
+from odyssey.runners.evals._common import (
+    build_eval_summary,
+    resolve_eval_checkpoint,
+)
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    run_training_subprocess,
+)
+from odyssey.spec.tasks import EvaluationTask, EvaluationType, TaskKind
+
+logger = logging.getLogger(__name__)
+
+# Config keys the runner consumes itself, never forwarded as passthrough flags.
+# ``checkpoint`` is resolved by ``resolve_eval_checkpoint`` (config.checkpoint is
+# how eval-only missions name one) so it must not also appear as a flag.
+_HANDLED_CONFIG_KEYS = {"eval_script", "eval_python", "runner", "checkpoint", "out_json"}
+
+# Top-level out-json keys the runner interprets; anything else is folded into
+# ``metrics`` so a script can emit flat payloads too.
+_RESERVED_METRIC_KEYS = {"success_rate", "performance_score", "num_episodes", "metrics"}
+
+_METRICS_FILENAME = "custom_eval_metrics.json"
+
+
+def resolve_eval_script(config: dict[str, Any]) -> str:
+    """``task.config["eval_script"]`` or ``$ODYSSEY_EVAL_SCRIPT``."""
+    script = config.get("eval_script") or os.getenv("ODYSSEY_EVAL_SCRIPT")
+    if not script:
+        raise RuntimeError(
+            "Custom eval requires an eval script: set "
+            "task.config['eval_script'] (or $ODYSSEY_EVAL_SCRIPT) to a script "
+            "that accepts --checkpoint / --out-json and writes its metrics as a "
+            "JSON object. See src/odyssey/runners/evals/custom.py for the contract."
+        )
+    return str(script)
+
+
+def resolve_interpreter(config: dict[str, Any]) -> list[str]:
+    """Launcher for the eval script — ``[config['eval_python']]`` or the
+    interpreter Odyssey itself runs under (``sys.executable``)."""
+    return [str(config.get("eval_python") or sys.executable)]
+
+
+def build_custom_argv(
+    *,
+    checkpoint: Path,
+    out_json: Path,
+    config: dict[str, Any],
+) -> list[str]:
+    """Build the eval script's argv per the launch contract.
+
+    The runner owns ``--checkpoint`` and ``--out-json``; every other config key
+    passes through verbatim as ``--key value`` (snake_case preserved).
+    """
+    argv: list[str] = [
+        "--checkpoint", str(checkpoint),
+        "--out-json", str(out_json),
+    ]
+    for key, value in config.items():
+        if key in _HANDLED_CONFIG_KEYS:
+            continue
+        argv += [f"--{key}", str(value)]
+    return argv
+
+
+def read_metrics(out_json: Path) -> dict[str, Any]:
+    """Load the JSON object the script wrote to ``out_json``.
+
+    Raises when the file is missing (the script exited 0 but never wrote it),
+    isn't valid JSON, or isn't a JSON object — all script-contract violations.
+    """
+    if not out_json.is_file():
+        raise RuntimeError(
+            f"Custom eval script exited 0 but wrote no metrics file at {out_json}. "
+            "The script must write its results there as a JSON object (the "
+            "--out-json path). See src/odyssey/runners/evals/custom.py."
+        )
+    try:
+        payload = json.loads(out_json.read_text())
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"Custom eval metrics file {out_json} is not valid JSON: {e}"
+        ) from e
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"Custom eval metrics file {out_json} must contain a JSON object, "
+            f"got {type(payload).__name__}."
+        )
+    return payload
+
+
+def summarize(
+    *,
+    payload: dict[str, Any],
+    spec: EvaluationTask,
+    checkpoint: Path,
+    eval_script: str,
+) -> dict[str, Any]:
+    """Turn the script's out-json payload into a ``result_summary``.
+
+    With ``success_rate`` present, routes through ``build_eval_summary`` so the
+    summary matches every other eval runner (letter grade + pass/fail). Without
+    it, returns a metric-only summary — the metrics stand on their own rather
+    than being forced into a pass/fail the eval never measured.
+    """
+    metrics = dict(payload.get("metrics") or {})
+    for key, value in payload.items():
+        if key not in _RESERVED_METRIC_KEYS:
+            metrics.setdefault(key, value)
+    metrics.setdefault("eval_script", eval_script)
+
+    num_episodes = int(payload.get("num_episodes", spec.num_episodes))
+
+    success_rate = payload.get("success_rate")
+    if success_rate is not None:
+        success_rate = float(success_rate)
+        performance_score = float(payload.get("performance_score", success_rate))
+        return build_eval_summary(
+            num_episodes=num_episodes,
+            successes=round(success_rate * num_episodes),
+            episode_returns=[],
+            benchmark_name=spec.benchmark_name,
+            checkpoint_path=checkpoint,
+            metrics=metrics,
+            success_rate=success_rate,
+            performance_score=performance_score,
+        )
+
+    # Metric-only eval (e.g. open-loop GT MAE): no pass/fail grade to report.
+    metrics.setdefault("benchmark", spec.benchmark_name)
+    metrics.setdefault("checkpoint_path", str(checkpoint))
+    return {
+        "num_episodes": num_episodes,
+        "metrics": metrics,
+    }
+
+
+class CustomEvalRunner(Runner):
+    """Evaluation runner for ``evaluation_type: custom`` tasks."""
+
+    @property
+    def name(self) -> str:
+        return "custom"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.EVALUATION}
+
+    @property
+    def supported_types(self) -> set[str]:
+        return {EvaluationType.CUSTOM.value}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, EvaluationTask):
+            raise TypeError(
+                f"CustomEvalRunner expects EvaluationTask, got {type(spec).__name__}"
+            )
+
+        config = spec.config or {}
+        checkpoint = resolve_eval_checkpoint(context)
+        eval_script = resolve_eval_script(config)
+        interpreter = resolve_interpreter(config)
+        out_json = self._metrics_path(context)
+
+        await context.emit_progress(
+            "executing",
+            step="launch",
+            step_label=(
+                f"script={Path(eval_script).name} "
+                f"python={Path(interpreter[0]).name}"
+            ),
+        )
+
+        process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
+            script_path=eval_script,
+            launcher=interpreter,
+            argv_extra=build_custom_argv(
+                checkpoint=checkpoint, out_json=out_json, config=config
+            ),
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("Custom eval task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"Custom eval script exited with code {rc}")
+
+        payload = read_metrics(out_json)
+        return summarize(
+            payload=payload,
+            spec=spec,
+            checkpoint=checkpoint,
+            eval_script=eval_script,
+        )
+
+    @staticmethod
+    def _metrics_path(context: TaskContext) -> Path:
+        """Where the script writes its metrics — under the task output dir when
+        the engine provided one, else a temp dir (context-free test setups)."""
+        base = context.output_dir or Path(tempfile.gettempdir())
+        base.mkdir(parents=True, exist_ok=True)
+        return base / _METRICS_FILENAME

--- a/tests/unit/test_custom_eval.py
+++ b/tests/unit/test_custom_eval.py
@@ -1,0 +1,365 @@
+"""Tests for the custom evaluation runner (``evaluation_type: custom``).
+
+No GPU and no real policy here — the runner's testable pieces are the launch
+contract (argv, script/interpreter resolution), the out-json metrics parsing,
+and summary scoring for both the graded (``success_rate``) and metric-only
+paths. One integration-ish test runs a fake eval script (plain python that
+writes an out-json) through the real subprocess machinery end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.engine import TaskStatus
+from odyssey.engine.records import MissionRun
+from odyssey.runners.base import TaskContext
+from odyssey.runners.evals.custom import (
+    CustomEvalRunner,
+    build_custom_argv,
+    read_metrics,
+    resolve_eval_script,
+    resolve_interpreter,
+    summarize,
+)
+from odyssey.spec import (
+    AgentRole,
+    AgentSpec,
+    EvaluationTask,
+    EvaluationType,
+    HFModelRef,
+    Mission,
+    MissionMetadata,
+    RobotSpec,
+    TrainingTask,
+    TrainingType,
+)
+from odyssey.telemetry import EventPublisher
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "eval-custom",
+        "evaluation_type": EvaluationType.CUSTOM,
+        "benchmark_name": "openloop-gt",
+        "num_episodes": 50,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Launch contract
+# ---------------------------------------------------------------------------
+
+def test_argv_contains_owned_flags(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path / "ckpt", out_json=tmp_path / "m.json", config={}
+    )
+    assert argv[argv.index("--checkpoint") + 1] == str(tmp_path / "ckpt")
+    assert argv[argv.index("--out-json") + 1] == str(tmp_path / "m.json")
+
+
+def test_argv_passthrough_keeps_snake_case(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path,
+        out_json=tmp_path / "m.json",
+        config={"replay_dataset": "/data/ur10e", "max_frames": 200},
+    )
+    assert argv[argv.index("--replay_dataset") + 1] == "/data/ur10e"
+    assert argv[argv.index("--max_frames") + 1] == "200"
+
+
+def test_argv_omits_isaac_specific_flags(tmp_path: Path) -> None:
+    # Custom is decoupled from Isaac Lab: no --task / --headless, and
+    # num_episodes is not auto-forwarded (the script asks for what it needs).
+    argv = build_custom_argv(checkpoint=tmp_path, out_json=tmp_path / "m.json", config={})
+    assert "--task" not in argv
+    assert "--headless" not in argv
+    assert "--num_episodes" not in argv
+
+
+def test_argv_excludes_handled_keys(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path,
+        out_json=tmp_path / "m.json",
+        config={
+            "eval_script": "/x.py",
+            "eval_python": "/venv/bin/python",
+            "runner": "custom",
+            "checkpoint": "/should/not/leak",
+            "out_json": "/nope",
+        },
+    )
+    for handled in ("--eval_script", "--eval_python", "--runner", "--out_json"):
+        assert handled not in argv
+    # checkpoint is resolved by the runner; the config key must not double up
+    # as a passthrough flag pointing at a different path.
+    assert argv.count("--checkpoint") == 1
+    assert "/should/not/leak" not in argv
+
+
+def test_eval_script_from_config() -> None:
+    assert resolve_eval_script({"eval_script": "/opt/eval.py"}) == "/opt/eval.py"
+
+
+def test_eval_script_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ODYSSEY_EVAL_SCRIPT", "/env/eval.py")
+    assert resolve_eval_script({}) == "/env/eval.py"
+
+
+def test_eval_script_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ODYSSEY_EVAL_SCRIPT", raising=False)
+    with pytest.raises(RuntimeError, match="eval script"):
+        resolve_eval_script({})
+
+
+def test_interpreter_defaults_to_sys_executable() -> None:
+    assert resolve_interpreter({}) == [sys.executable]
+
+
+def test_interpreter_from_config() -> None:
+    assert resolve_interpreter({"eval_python": "/venv/bin/python"}) == ["/venv/bin/python"]
+
+
+# ---------------------------------------------------------------------------
+# Metrics parsing
+# ---------------------------------------------------------------------------
+
+def test_read_metrics_loads_object(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text(json.dumps({"success_rate": 0.4, "metrics": {"mae": 0.1}}))
+    assert read_metrics(out) == {"success_rate": 0.4, "metrics": {"mae": 0.1}}
+
+
+def test_read_metrics_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="wrote no metrics file"):
+        read_metrics(tmp_path / "absent.json")
+
+
+def test_read_metrics_invalid_json_raises(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text("{not json")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        read_metrics(out)
+
+
+def test_read_metrics_non_object_raises(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text("[1, 2, 3]")
+    with pytest.raises(RuntimeError, match="must contain a JSON object"):
+        read_metrics(out)
+
+
+# ---------------------------------------------------------------------------
+# Summary scoring
+# ---------------------------------------------------------------------------
+
+def test_summary_graded_when_success_rate_present(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={
+            "success_rate": 0.9,
+            "performance_score": 0.8,
+            "num_episodes": 20,
+            "metrics": {"lift": 18, "seat": 16},
+        },
+        spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt",
+        eval_script="/opt/eval.py",
+    )
+    assert summary["success_rate"] == 0.9
+    assert summary["performance_score"] == 0.8
+    assert summary["letter_grade"] == "A"
+    assert summary["passed"] is True
+    assert summary["num_episodes"] == 20
+    assert summary["metrics"]["lift"] == 18
+    assert summary["metrics"]["eval_script"] == "/opt/eval.py"
+
+
+def test_summary_performance_defaults_to_success_rate(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={"success_rate": 0.5},
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert summary["performance_score"] == 0.5
+
+
+def test_summary_metric_only_has_no_pass_fail(tmp_path: Path) -> None:
+    # The open-loop GT case: per-joint MAE, no success_rate. The summary must
+    # carry the metrics without fabricating a 0.0 / grade-F pass/fail.
+    summary = summarize(
+        payload={"metrics": {"joint_mae": [0.01, 0.02], "gripper_agreement": 0.97}},
+        spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt",
+        eval_script="/opt/eval_openloop_gt.py",
+    )
+    assert "letter_grade" not in summary
+    assert "passed" not in summary
+    assert "success_rate" not in summary
+    assert summary["metrics"]["gripper_agreement"] == 0.97
+    assert summary["metrics"]["benchmark"] == "openloop-gt"
+    assert summary["num_episodes"] == 50  # falls back to spec.num_episodes
+
+
+def test_summary_folds_unknown_top_level_keys_into_metrics(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={"joint_mae": 0.03, "notes": "replay of 200 frames"},
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert summary["metrics"]["joint_mae"] == 0.03
+    assert summary["metrics"]["notes"] == "replay of 200 frames"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real subprocess machinery
+# ---------------------------------------------------------------------------
+
+class _NullPublisher(EventPublisher):
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        pass
+
+
+# A fake eval script: reads --checkpoint / --out-json, writes a metrics object.
+# Mirrors what scripts/eval_openloop_gt.py does, minus the model.
+FAKE_EVAL_SCRIPT = """\
+import argparse, json
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+p.add_argument("--replay_dataset", required=True)
+args = p.parse_args()
+with open(args.out_json, "w") as f:
+    json.dump(
+        {"metrics": {"joint_mae": 0.012, "gripper_agreement": 0.98,
+                     "checkpoint_seen": args.checkpoint,
+                     "replay": args.replay_dataset}},
+        f,
+    )
+"""
+
+FAKE_EVAL_SCRIPT_GRADED = """\
+import argparse, json
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+args = p.parse_args()
+with open(args.out_json, "w") as f:
+    json.dump({"success_rate": 0.75, "num_episodes": 8}, f)
+"""
+
+FAKE_EVAL_SCRIPT_NO_OUTPUT = """\
+import argparse
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+p.parse_args()  # exits 0 but writes nothing
+"""
+
+
+def _context_for(spec_task: EvaluationTask, tmp_path: Path) -> TaskContext:
+    mission = Mission(
+        metadata=MissionMetadata(name="msn-custom"),
+        objective="objective",
+        acceptance_criteria="acceptance",
+        robot=RobotSpec(
+            embodiment="ur10e",
+            agents=[
+                AgentSpec(
+                    id="pilot",
+                    role=AgentRole.PILOT,
+                    model=HFModelRef(base="nvidia/GR00T-N1.7-3B"),
+                ),
+            ],
+        ),
+        tasks=[
+            TrainingTask(
+                name="train",
+                training_type=TrainingType.DEMONSTRATION,
+                agent_id="pilot",
+            ),
+            spec_task,
+        ],
+    )
+    run = MissionRun.from_spec(mission)
+    train_run = run.tasks[0]
+    train_run.status = TaskStatus.COMPLETED
+    train_run.result_summary = {"checkpoint_path": str(tmp_path / "ckpt")}
+    eval_run = run.tasks[1]
+    return TaskContext(
+        task=eval_run,
+        mission=run,
+        publisher=_NullPublisher(),
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_runner_end_to_end_metric_only(tmp_path: Path) -> None:
+    script = tmp_path / "fake_eval.py"
+    script.write_text(FAKE_EVAL_SCRIPT)
+    task = _eval_task(
+        config={"eval_script": str(script), "replay_dataset": "/data/ur10e"}
+    )
+    context = _context_for(task, tmp_path)
+
+    summary = asyncio.run(CustomEvalRunner().run(context))
+
+    # Metric-only: metrics captured from the out-json the script wrote, no grade.
+    assert "letter_grade" not in summary
+    assert summary["metrics"]["joint_mae"] == 0.012
+    assert summary["metrics"]["gripper_agreement"] == 0.98
+    assert summary["metrics"]["checkpoint_seen"] == str(tmp_path / "ckpt")
+    assert summary["metrics"]["replay"] == "/data/ur10e"
+
+
+def test_runner_end_to_end_graded(tmp_path: Path) -> None:
+    script = tmp_path / "fake_eval_graded.py"
+    script.write_text(FAKE_EVAL_SCRIPT_GRADED)
+    task = _eval_task(config={"eval_script": str(script)})
+    context = _context_for(task, tmp_path)
+
+    summary = asyncio.run(CustomEvalRunner().run(context))
+
+    assert summary["success_rate"] == 0.75
+    assert summary["num_episodes"] == 8
+    assert summary["letter_grade"] == "C"
+    assert summary["passed"] is True
+
+
+def test_runner_raises_when_script_writes_no_metrics(tmp_path: Path) -> None:
+    script = tmp_path / "silent_eval.py"
+    script.write_text(FAKE_EVAL_SCRIPT_NO_OUTPUT)
+    task = _eval_task(config={"eval_script": str(script)})
+    context = _context_for(task, tmp_path)
+
+    with pytest.raises(RuntimeError, match="wrote no metrics file"):
+        asyncio.run(CustomEvalRunner().run(context))
+
+
+# ---------------------------------------------------------------------------
+# Registry dispatch — the reason this runner exists
+# ---------------------------------------------------------------------------
+
+def test_custom_type_dispatches_to_custom_runner_not_mock() -> None:
+    # Acceptance criterion: `evaluation_type: custom` must resolve to the real
+    # runner, not fall through to the wildcard CPUMockRunner. Registration order
+    # mirrors _build_runners (custom before mock).
+    from odyssey.runners.cpu_mock import CPUMockRunner
+    from odyssey.runners.registry import RunnerRegistry
+
+    registry = RunnerRegistry()
+    registry.register(CustomEvalRunner())
+    registry.register(CPUMockRunner())
+
+    selected = registry.select(_eval_task())
+    assert isinstance(selected, CustomEvalRunner)
+    assert selected.name == "custom"


### PR DESCRIPTION
Closes #87.

## What

Adds **`CustomEvalRunner`**, the eval runner for `evaluation_type: custom`. It runs
an arbitrary eval script as a subprocess, decoupled from any sim.

## Why

A mission requires exactly one eval task, but only `robosuite` and `isaac_lab`
runners existed — `evaluation_type: custom` fell through to the wildcard
**`CPUMockRunner`** (a *fake* eval). There was no first-class way to run a real,
project-specific evaluation. This bites the **ur10e/ur5e drug-sort GR00T pilot**,
whose honest metrics are ground-truth evals (open-loop MAE / closed-loop lift+seat),
not a sim-to-sim gap. The only prior options were to **abuse** the `isaac_lab`
contract or to **mock** the eval — both hacks.

## Contract (the two open questions in the issue, decided + documented)

- **Serving → the script owns it.** The runner passes `--checkpoint` and never
  serves the policy. The motivating open-loop GT eval loads the checkpoint
  in-process; delegating keeps `CustomEvalRunner` free of any GR00T/openpi/Isaac/
  MuJoCo dependency. (No `config.serve_checkpoint` — a closed-loop eval starts or
  connects to a server from inside the script.)
- **Metrics → `--out-json`.** The runner allocates a path under the task output
  dir and passes `--out-json`; the script writes a JSON object there.
  `success_rate` (when present) yields a trainer letter grade + pass/fail;
  otherwise the metrics are surfaced as-is — a metric-only eval (per-joint MAE) is
  **not** forced into a fabricated `0.0 / grade-F`.

Launch: `<eval_python> <eval_script> --checkpoint <path> --out-json <path>
[--<config-key> <value> …]`. `eval_python` defaults to `sys.executable` (so the
script can run under a separate venv without Odyssey importing its deps); extra
`config.*` keys pass through verbatim, snake_case preserved — same style as
`isaac_lab`, minus the Isaac-specific `--task/--headless`.

## Changes

- `src/odyssey/runners/evals/custom.py` — new runner + `resolve_eval_script` /
  `resolve_interpreter` / `build_custom_argv` / `read_metrics` / `summarize`.
  Full contract in the module docstring.
- `src/odyssey/cli/commands/run.py` — register `CustomEvalRunner` before the CPU
  mock, so `(EVALUATION, "custom")` matches it, not the wildcard fallback.
- `tests/unit/test_custom_eval.py` — argv assembly, script/interpreter resolution,
  out-json parsing (missing / invalid / non-object), both summary paths, **registry
  dispatch (`custom` → `CustomEvalRunner`, not the mock)**, and three end-to-end
  runs through the real subprocess machinery.
- `docs/concepts.md` — eval-types table + a `custom` example.

## Test

`pytest tests/unit/test_custom_eval.py` → **21 passed**. Full suite **520 passed,
5 skipped**; `ruff` + `mypy` strict clean (the runner is a general module, so it
stays strict — no `ignore_errors` exemption).

## Acceptance criteria

- [x] `evaluation_type: custom` + `config.eval_script` runs the script, captures
  metrics into `result_summary`, and COMPLETED/FAILED by exit code — no
  `CPUMockRunner` fallback (dispatch test + e2e).
- [x] Unit tests for argv assembly + metrics parsing (no GPU), mirroring
  `test_isaac_lab.py`.
- [x] Docs: contract in the runner module docstring + `docs/concepts.md`.
- [ ] **Pending (GPU):** `scripts/eval_openloop_gt.py` (on `feat/ur10e-drugsort-finetune`)
  run end-to-end as a mission eval task against a fresh GR00T checkpoint. Kept as a
  draft until this lands on an L4.

## Notes

- Related: #86 (`ur10e` embodiment, merged) — the same pilot this eval serves.
- The `isaac_lab` runner was the closest pattern; this generalizes it and drops the
  sim-specific argv + episode stdout protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
