### PR TITLE
feat(pi05): π0.5 (openpi) training runner + fine-tune example

### DIFF
--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -1,0 +1,102 @@
+# π0.5 fine-tune quickstart (training)
+
+Fine-tune a Physical Intelligence **π0.5** (openpi) checkpoint on a LeRobot-format
+demonstration set through the odyssey `pi05` training runner. The runner shells
+out to openpi's own entry points — `scripts/compute_norm_stats.py` then
+`scripts/train.py` — so the actual training happens in your openpi checkout.
+
+This is the **training** counterpart to `examples/quickstart-pi05/` (eval-only).
+
+> **Status:** the odyssey-side wiring (argv build, norm-stats + train subprocess
+> orchestration, checkpoint capture, stdout→progress parsing) is complete and
+> unit-tested on CPU. It has **not** been run end-to-end on a GPU box yet —
+> treat the openpi flag names below as the contract to confirm on the first smoke.
+
+## What you need
+
+- A GPU box (π0.5 fine-tune is memory-hungry — an 80 GB A100/H100 class card).
+- **openpi** installed and checked out:
+  ```bash
+  git clone https://github.com/Physical-Intelligence/openpi
+  cd openpi && pip install -e .
+  export OPENPI_REPO_PATH=$(pwd)      # runner defaults to /srv/openpi otherwise
+  ```
+- The LeRobot dataset unpacked on the box, e.g.
+  `/data/ur10e_drugsort_v0/ur10e_partial_cond_aug/`.
+
+## Why openpi is config-name-driven (and GR00T isn't)
+
+GR00T / OpenVLA take a flat bag of `--flag value` overrides. openpi selects a
+**registered `TrainConfig`** by name — it bundles the data transforms, the base
+weight loader and the optimizer. So fine-tuning a *new* dataset/embodiment means
+adding one config entry (the π0.5 analogue of GR00T's `modality_config_path`).
+
+### 1. Register a `TrainConfig` in openpi
+
+Add an entry to `src/openpi/training/config.py` (name it `pi05_ur10e_drugsort`, to
+match `config_name` in the mission). Base it on the shipped `pi05_libero` config,
+then point its data config at your LeRobot dataset and describe the state/action
+mapping:
+
+- **state/action**: 7-DoF (6 joints + gripper) — π0.5 pads to the model's action
+  dim; no observer-conditioned `grasp_target` channel (that's GR00T-specific —
+  drop it here).
+- **images**: map `observation.images.exterior` → `base_0_rgb` and
+  `observation.images.wrist` → `left_wrist_0_rgb` in the repack transform.
+- **repo_id**: the dataset folder name, `ur10e_partial_cond_aug`.
+
+### 2. Dataset resolution
+
+For a **local absolute** dataset ref, the runner sets `HF_LEROBOT_HOME` to the
+dataset's parent dir, so openpi's LeRobot loader resolves `data.repo_id` == the
+folder name. Keep the two in sync:
+
+```
+ref:            /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+data.repo_id:   ur10e_partial_cond_aug          # HF_LEROBOT_HOME=/data/ur10e_drugsort_v0
+```
+
+## Run
+
+```bash
+# CPU validation (no training):
+odyssey validate mission.yaml
+odyssey run mission.yaml --use-mock-runner
+
+# Real fine-tune on the GPU box:
+export OPENPI_REPO_PATH=/path/to/openpi
+odyssey run mission.yaml
+```
+
+The runner executes, in order:
+
+1. `python scripts/compute_norm_stats.py pi05_ur10e_drugsort`
+   (skip with `config: {compute_norm_stats: false}` if `./assets` already holds them)
+2. `python scripts/train.py pi05_ur10e_drugsort --exp-name finetune-pi05-ur10e --overwrite \
+      --data.repo-id ur10e_partial_cond_aug --num-train-steps 30000 --batch-size 32`
+
+Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
+and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
+captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
+
+## Config keys the runner interprets
+
+| key                  | meaning                                                            |
+|----------------------|-------------------------------------------------------------------|
+| `runner: pi05`       | routes the wildcard training task to `Pi05Runner`                 |
+| `config_name`        | **required** — the registered openpi `TrainConfig` (positional)   |
+| `exp_name`           | openpi `--exp-name`; defaults to the task name                     |
+| `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
+| `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |
+| `compute_norm_stats` | run the norm-stats pre-step (default `true`)                       |
+| *anything else*      | forwarded as a tyro override (`a_b` → `--a-b`; nested `x: {y: 1}` → `--x.y 1`; bools → `--flag` / `--no-flag`) |
+
+## Can I then evaluate on LIBERO?
+
+Not honestly with *this* checkpoint. LIBERO is a **Franka Panda** sim benchmark;
+a π0.5 fine-tuned on **UR10e** demos is a different embodiment, action space and
+task, so a LIBERO score would measure a sim-to-sim gap, not this cell. The
+`examples/quickstart-pi05/` LIBERO eval is for a **LIBERO-compatible** π0.5
+checkpoint (e.g. the shipped `pi05_libero`). For the drug-sort model, the honest
+metric is the standalone closed-loop grasp+place eval against physics ground
+truth (`meta/gt`).

--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -80,6 +80,13 @@ The runner executes, in order:
 > registered config's default `repo_id`, or step 1 writes norm stats under one
 > `repo_id` and step 2 reads another and fails (loudly, after the full dataset scan).
 
+> Norm stats are cached across runs at `~/.odyssey/pi05_assets/<config_name>/<config_name>/<repo_id>/`
+> and step 1 is skipped on a hit. The hit is keyed on `config_name` + `repo_id`
+> only — it has **no content fingerprint**, so a dataset recaptured under an
+> unchanged `repo_id` would silently reuse stale statistics. When the dataset
+> content changed, set `config: {norm_stats_cache: false}` to force a fresh
+> recompute into the per-run dir.
+
 Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
 and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
 captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
@@ -94,6 +101,7 @@ captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
 | `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
 | `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |
 | `compute_norm_stats` | run the norm-stats pre-step (default `true`)                       |
+| `norm_stats_cache`   | reuse cached norm stats across runs, keyed by `config_name`+`repo_id` (default `true`); set `false` to force a recompute when the dataset content changed under the same `repo_id` |
 | *anything else*      | forwarded as a tyro override (`a_b` → `--a-b`; nested `x: {y: 1}` → `--x.y 1`; bools → `--flag` / `--no-flag`) |
 
 ## Can I then evaluate on LIBERO?

--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -70,10 +70,15 @@ odyssey run mission.yaml
 
 The runner executes, in order:
 
-1. `python scripts/compute_norm_stats.py pi05_ur10e_drugsort`
+1. `python scripts/compute_norm_stats.py --config-name pi05_ur10e_drugsort`
    (skip with `config: {compute_norm_stats: false}` if `./assets` already holds them)
 2. `python scripts/train.py pi05_ur10e_drugsort --exp-name finetune-pi05-ur10e --overwrite \
       --data.repo-id ur10e_partial_cond_aug --num-train-steps 30000 --batch-size 32`
+
+> The norm-stats step takes no `data.*` overrides — it reads the dataset fixed by
+> the config's `data` factory. So the mission's `data.repo_id` **must equal** the
+> registered config's default `repo_id`, or step 1 writes norm stats under one
+> `repo_id` and step 2 reads another and fails (loudly, after the full dataset scan).
 
 Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
 and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
@@ -84,7 +89,7 @@ captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
 | key                  | meaning                                                            |
 |----------------------|-------------------------------------------------------------------|
 | `runner: pi05`       | routes the wildcard training task to `Pi05Runner`                 |
-| `config_name`        | **required** — the registered openpi `TrainConfig` (positional)   |
+| `config_name`        | **required** — the registered openpi `TrainConfig` (positional to `train.py`, `--config-name` flag to `compute_norm_stats.py`) |
 | `exp_name`           | openpi `--exp-name`; defaults to the task name                     |
 | `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
 | `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |

--- a/examples/quickstart-pi05-train/mission.yaml
+++ b/examples/quickstart-pi05-train/mission.yaml
@@ -1,0 +1,117 @@
+# π0.5 fine-tune quickstart (training-only).
+#
+# Fine-tunes a Physical Intelligence π0.5 (openpi) checkpoint on a LeRobot-format
+# demonstration set, via the odyssey `pi05` training runner -> openpi's
+# scripts/compute_norm_stats.py then scripts/train.py (two subprocesses).
+#
+# This base example is wired for the UR10e / Robotiq-2F85 drug-sort v0 dataset
+# (LeRobot v2.1, 60 eps, 7-DoF single-arm joint + gripper, exterior + wrist cams
+# @ 256x256) — the same demos the GR00T pilot finetunes on. Swap the dataset +
+# config_name for your own set.
+#
+# HOW openpi TRAINING WORKS (different from GR00T/OpenVLA):
+#   openpi is CONFIG-NAME-DRIVEN. Training selects a registered `TrainConfig`
+#   (here `pi05_ur10e_drugsort`) that bundles the data pipeline + weight loader +
+#   optimizer. You must ADD that config entry to openpi's
+#   src/openpi/training/config.py (the π0.5 analogue of GR00T's modality config
+#   file), with data.repo_id pointing at this dataset's folder name. Everything
+#   under `config:` below (except control keys) is forwarded as a tyro override.
+#   See examples/quickstart-pi05-train/README.md for the full recipe.
+#
+# Validate without a GPU:
+#   odyssey validate mission.yaml
+#   odyssey run mission.yaml --use-mock-runner
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: pi05-ur10e-drugsort-finetune
+  description: >-
+    Fine-tune π0.5 (openpi) on the UR10e drug-sort v0 LeRobot demos (7-DoF,
+    exterior + wrist cameras), producing a checkpoint deployable as the Pilot.
+  tags: [pi05, openpi, physical-intelligence, ur10e, robotiq, lerobot, training]
+
+objective: |
+  Fine-tune a π0.5 generalist on the browser-captured UR10e / Robotiq-2F85
+  pick-and-place demonstrations (ur10e_partial_cond_aug) so the resulting policy
+  can pick a vial and seat it in the rack.
+
+acceptance_criteria: |
+  The fine-tune produces a π0.5 checkpoint under the task output_dir
+  (checkpoints/<config_name>/<exp_name>/<step>) that loads and serves in an
+  openpi WebsocketPolicyServer. The honest task metric is the standalone
+  closed-loop grasp+place success against physics ground truth, not this run.
+
+robot:
+  # "ur10e" is not in the odyssey robot catalog; "ur5e" is and is used only for
+  # local catalog validation. The arm geometry is carried by the dataset, not
+  # this name (same convention as the GR00T ur10e mission).
+  embodiment: ur5e
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        # HF mirror of the openpi π0.5 base weights (Apache 2.0). Pilot-identity
+        # documentation only — openpi's weight_loader (inside the TrainConfig)
+        # is what actually pulls the base params for fine-tuning.
+        base: lerobot/pi05_base
+
+tasks:
+  - name: finetune-pi05-ur10e
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    dataset:
+      source: local
+      # ABSOLUTE path to the unpacked dataset ON THE TRAINING BOX (GPU VM). The
+      # pi05 runner sets HF_LEROBOT_HOME to this dir's PARENT so openpi's LeRobot
+      # loader resolves `data.repo_id` (below) == the folder name.
+      ref: /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+      format: lerobot
+    config:
+      # Routes this wildcard training task to the π0.5 runner (OpenVLA is the
+      # default; GR00T / π0.5 opt in by name).
+      runner: pi05
+      # REQUIRED: the registered openpi TrainConfig. Add this entry to openpi's
+      # src/openpi/training/config.py before running (see README).
+      config_name: pi05_ur10e_drugsort
+      # openpi computes dataset norm stats first (set false to skip if already
+      # cached under ./assets). Default is true.
+      compute_norm_stats: true
+
+      # --- tyro overrides forwarded to scripts/train.py -------------------------
+      # Nested dataclass fields use dots; underscores in a leaf become dashes
+      # (data.repo_id -> --data.repo-id). This links the config to THIS dataset's
+      # folder name (must match the HF_LEROBOT_HOME resolution above).
+      data:
+        repo_id: ur10e_partial_cond_aug
+      # Small-data fine-tune knobs — tune per your GPU / dataset size.
+      num_train_steps: 30000
+      batch_size: 32
+      # exp_name: defaults to the task name ("finetune-pi05-ur10e"); --overwrite
+      # is emitted by default so re-running clobbers the prior exp dir. Set
+      # `resume: true` to continue from the latest checkpoint instead.
+
+  # A Mission must declare exactly one evaluation task. For a UR10e-fine-tuned
+  # π0.5, LIBERO (Franka sim) is NOT an honest metric — different embodiment,
+  # action space and task. The honest metric is the STANDALONE closed-loop
+  # grasp+place success scored against physics ground truth (meta/gt), run here
+  # via `evaluation_type: custom` (the sim-agnostic CustomEvalRunner — issue #87
+  # / PR #88; falls back to the CPU mock until that runner ships on develop).
+  - name: eval-drugsort-closed-loop
+    kind: evaluation
+    evaluation_type: custom
+    benchmark_name: ur10e-drugsort-gt
+    num_episodes: 20
+    config:
+      # The eval script owns serving the fine-tuned checkpoint and scoring
+      # grasp+place against meta/gt. See the PILOT RUN_AND_EVAL.md recipe.
+      eval_script: scripts/eval_ur5e_drugsort_pi05.py
+
+leaderboard:
+  publish: false   # Backend not live yet.
+
+graph:
+  contribute: false   # Backend not live yet.

--- a/examples/quickstart-pi05-train/mission.yaml
+++ b/examples/quickstart-pi05-train/mission.yaml
@@ -44,10 +44,9 @@ acceptance_criteria: |
   closed-loop grasp+place success against physics ground truth, not this run.
 
 robot:
-  # "ur10e" is not in the odyssey robot catalog; "ur5e" is and is used only for
-  # local catalog validation. The arm geometry is carried by the dataset, not
-  # this name (same convention as the GR00T ur10e mission).
-  embodiment: ur5e
+  # ur10e is a registered embodiment (PR #86). Used for local catalog validation;
+  # the arm geometry is carried by the dataset, not this name.
+  embodiment: ur10e
   agents:
     - id: pilot
       role: PILOT

--- a/examples/quickstart-pi05-train/setup.sh
+++ b/examples/quickstart-pi05-train/setup.sh
@@ -140,7 +140,7 @@ cat <<EOF
        $OPENPI_DIR/.venv/bin/odyssey run      examples/quickstart-pi05-train/mission.yaml
 
      The runner then executes, in order:
-       python scripts/compute_norm_stats.py $CONFIG_NAME
+       python scripts/compute_norm_stats.py --config-name $CONFIG_NAME
        python scripts/train.py $CONFIG_NAME --exp-name <task> --overwrite [overrides]
      with cwd=<task output_dir>, so ./assets and ./checkpoints land under ~/.odyssey/runs.
 

--- a/examples/quickstart-pi05-train/setup.sh
+++ b/examples/quickstart-pi05-train/setup.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Setup for the π0.5 (openpi) FINE-TUNE quickstart — single-GPU box (A100/H100 class).
+#
+# It ONLY sets things up — it does NOT run a mission and does NOT train.
+#
+# ─── ONE environment, by design (opposite of the eval quickstart) ──────────────────
+#  The EVAL quickstart (examples/quickstart-pi05/) uses TWO envs wired by host:port,
+#  because π0.5 is served out-of-process. TRAINING is different: the odyssey `pi05`
+#  runner shells out to openpi's own scripts (compute_norm_stats.py, train.py) via
+#  `sys.executable` — the SAME interpreter that runs `odyssey`. So openpi and odyssey
+#  must live in ONE env. This script builds openpi's uv env, then installs odyssey
+#  INTO it, and you run training via `<openpi>/.venv/bin/odyssey` (mirrors the
+#  validated GR00T recipe: `~/Isaac-GR00T/.venv/bin/odyssey`).
+#
+# ─── ⚠️ NOT YET VALIDATED ON HARDWARE ──────────────────────────────────────────────
+#  The odyssey-side wiring is complete + unit-tested on CPU, but no end-to-end π0.5
+#  fine-tune has been run through this script. Treat the openpi steps as a best-effort
+#  scaffold — confirm the exact `train.py` / `compute_norm_stats.py` flags and the
+#  TrainConfig registration against YOUR openpi version (see README.md).
+#
+# ─── FAST note ─────────────────────────────────────────────────────────────────────
+#  Nothing to install for FAST. π0.5 training uses a FAST-tokenized objective, but it
+#  is INTERNAL to openpi's `pi05` TrainConfig/model — the runner never touches it, and
+#  odyssey's pi05_fast.py (eval-side scaffolding) is not on this path.
+#
+# Usage:
+#   bash examples/quickstart-pi05-train/setup.sh
+#   bash examples/quickstart-pi05-train/setup.sh --openpi-dir ~/openpi --dataset /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+#
+#   --openpi-dir PATH   openpi checkout / env (default: $HOME/openpi)
+#   --dataset PATH      unpacked LeRobot dataset dir (optional; sanity-checked + used
+#                       to print the HF_LEROBOT_HOME / data.repo_id linkage)
+#   --config-name NAME  openpi TrainConfig you will register (default: pi05_ur10e_drugsort)
+#   -h | --help         show this header
+#
+# Linux + NVIDIA GPU assumed. Re-runnable / idempotent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OPENPI_DIR="${OPENPI_DIR:-$HOME/openpi}"
+DATASET=""
+CONFIG_NAME="pi05_ur10e_drugsort"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --openpi-dir) OPENPI_DIR="$2"; shift 2 ;;
+    --dataset) DATASET="$2"; shift 2 ;;
+    --config-name) CONFIG_NAME="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v uv >/dev/null || {
+  echo "[setup] ERROR: 'uv' not found — install then re-run:" >&2
+  echo "  curl -LsSf https://astral.sh/uv/install.sh | sh && source ~/.bashrc" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+echo "==> [1/4] openpi checkout ($OPENPI_DIR)"
+# ---------------------------------------------------------------------------
+if [ ! -d "$OPENPI_DIR/.git" ]; then
+  echo "[setup] cloning Physical-Intelligence/openpi into $OPENPI_DIR"
+  git clone https://github.com/Physical-Intelligence/openpi.git "$OPENPI_DIR"
+else
+  echo "[setup] openpi already at $OPENPI_DIR — reusing"
+fi
+
+# ---------------------------------------------------------------------------
+echo "==> [2/4] openpi training env (uv sync — JAX/torch, the FULL openpi, GPU deps)"
+# ---------------------------------------------------------------------------
+# This is the heavy step: it builds openpi's .venv from its lockfile (large
+# JAX/CUDA download). compute_norm_stats.py + train.py run from THIS env.
+if ( cd "$OPENPI_DIR" && uv sync ); then
+  echo "[setup] openpi env synced under $OPENPI_DIR/.venv"
+else
+  echo "[setup] ERROR: 'uv sync' in $OPENPI_DIR failed — finish it per openpi's README" >&2
+  echo "        (CUDA wheels, GIT_LFS_SKIP_SMUDGE, etc. may apply) before continuing." >&2
+  exit 1
+fi
+PYBIN="$OPENPI_DIR/.venv/bin/python"
+
+# ---------------------------------------------------------------------------
+echo "==> [3/4] install odyssey INTO the openpi env (so sys.executable sees both)"
+# ---------------------------------------------------------------------------
+# Base install only (no [dev]) — the training runner is pure subprocess
+# orchestration + the pydantic spec; it needs none of the heavy test/eval extras,
+# and keeping them out avoids clashing with openpi's pinned numpy/torch.
+uv pip install --python "$PYBIN" -e "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+echo "==> [4/4] verify the combined env"
+# ---------------------------------------------------------------------------
+"$PYBIN" - <<'PY'
+import importlib.util as u, sys
+missing = [m for m in ("odyssey", "openpi") if u.find_spec(m) is None]
+print(f"[setup] odyssey : {'OK' if u.find_spec('odyssey') else 'MISSING'}")
+print(f"[setup] openpi  : {'OK' if u.find_spec('openpi') else 'MISSING'}")
+if missing:
+    print(f"[setup] VERIFY FAILED: missing {missing}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# Optional dataset sanity check + the repo_id linkage the runner relies on.
+DATA_HINT=""
+if [ -n "$DATASET" ]; then
+  if [ -f "$DATASET/meta/info.json" ]; then
+    HFLR="$(dirname "$DATASET")"
+    REPO_ID="$(basename "$DATASET")"
+    DATA_HINT=$'\n'"[setup] dataset OK: $DATASET"$'\n'"        -> runner sets HF_LEROBOT_HOME=$HFLR ; data.repo_id must be '$REPO_ID'"
+  else
+    echo "[setup] WARNING: $DATASET/meta/info.json not found — is this an unpacked LeRobot v2.1 dir?" >&2
+  fi
+fi
+
+cat <<EOF
+
+[setup] Done.${DATA_HINT}
+
+  Next — register the openpi TrainConfig (one-time), then run the fine-tune:
+
+  1) Add a TrainConfig named '$CONFIG_NAME' to:
+       $OPENPI_DIR/src/openpi/training/config.py
+     Base it on the shipped 'pi05_libero' config; point its data at your LeRobot
+     dataset (repo_id = the dataset folder name) and map the cameras
+     (observation.images.exterior -> base_0_rgb, .wrist -> left_wrist_0_rgb).
+     Drop the GR00T-only grasp_target channel. See README.md.
+
+  2) Export the checkout path so the runner finds openpi's scripts:
+       export OPENPI_REPO_PATH=$OPENPI_DIR
+
+  3) Run the mission with the openpi-env odyssey (NOT a system odyssey):
+       export OPENPI_REPO_PATH=$OPENPI_DIR
+       $OPENPI_DIR/.venv/bin/odyssey validate examples/quickstart-pi05-train/mission.yaml
+       $OPENPI_DIR/.venv/bin/odyssey run      examples/quickstart-pi05-train/mission.yaml
+
+     The runner then executes, in order:
+       python scripts/compute_norm_stats.py $CONFIG_NAME
+       python scripts/train.py $CONFIG_NAME --exp-name <task> --overwrite [overrides]
+     with cwd=<task output_dir>, so ./assets and ./checkpoints land under ~/.odyssey/runs.
+
+  First-run watch-list (see README + the PR's known gap):
+    * config_name must be registered in openpi's config.py (else train.py errors)
+    * data.repo_id in mission.yaml must equal the dataset folder name
+    * flow-matching model -> no FAST flags to pass; FAST is internal to openpi
+EOF

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -33,6 +33,7 @@ from odyssey.runners import (
     CPUMockRunner,
     GR00TRunner,
     OpenVLARunner,
+    Pi05Runner,
     RunnerRegistry,
 )
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
@@ -48,12 +49,14 @@ def _build_runners() -> RunnerRegistry:
     registry = RunnerRegistry()
     # Real runners first; CPU mock as a last-resort fallback so unfamiliar
     # task types still produce *something* instead of "no runner registered."
-    # OpenVLA and GR00T are both wildcard training runners — registration
-    # order makes OpenVLA the default; GR00T is selected per-task via
-    # ``config: {runner: gr00t}``. --use-mock-runner forces the mock
-    # through the engine's force_runner, not by thinning this registry.
+    # OpenVLA, GR00T and π0.5 are all wildcard training runners — registration
+    # order makes OpenVLA the default; GR00T / π0.5 are selected per-task via
+    # ``config: {runner: gr00t}`` / ``config: {runner: pi05}``. --use-mock-runner
+    # forces the mock through the engine's force_runner, not by thinning this
+    # registry.
     registry.register(OpenVLARunner())
     registry.register(GR00TRunner())
+    registry.register(Pi05Runner())
     registry.register(RobosuiteRunner())
     registry.register(IsaacLabRunner())
     registry.register(LiberoRunner())

--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -27,6 +27,11 @@ from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
 from odyssey.runners.models.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
 from odyssey.runners.models.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
+from odyssey.runners.models.pi05_train import (
+    Pi05Runner,
+    build_pi05_train_argv,
+    parse_pi05_train_line,
+)
 from odyssey.runners.registry import RunnerRegistry
 from odyssey.runners.subprocess import (
     LineParser,
@@ -41,6 +46,7 @@ __all__ = [
     "IsaacLabRunner",
     "LineParser",
     "OpenVLARunner",
+    "Pi05Runner",
     "RobosuiteRunner",
     "Runner",
     "RunnerRegistry",
@@ -48,7 +54,9 @@ __all__ = [
     "TrainingProcessSpec",
     "build_gr00t_argv",
     "build_openvla_argv",
+    "build_pi05_train_argv",
     "parse_gr00t_line",
     "parse_openvla_line",
+    "parse_pi05_train_line",
     "run_training_subprocess",
 ]

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -14,8 +14,11 @@ name (e.g. ``pi05_libero``) that bundles the data pipeline, weight loader and
 optimizer, and CLI ``--overrides`` (parsed by *tyro*) tweak individual fields.
 So the mission's ``config:`` here carries:
 
-  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig`` (positional
-    arg to both scripts). Fine-tuning a *new* embodiment/dataset means adding a
+  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig``. It reaches
+    the two scripts differently (see the argv builders): ``train.py`` takes it
+    **positionally** (``overridable_config_cli`` makes it a subcommand), while
+    ``compute_norm_stats.py`` takes it as a ``--config-name`` flag (plain
+    ``tyro.cli``). Fine-tuning a *new* embodiment/dataset means adding a
     config entry to openpi's ``src/openpi/training/config.py`` (the π0.5 analogue
     of GR00T's ``modality_config_path`` file) whose ``data.repo_id`` points at the
     LeRobot dataset — see ``examples/quickstart-pi05-train/README.md``.
@@ -25,8 +28,8 @@ So the mission's ``config:`` here carries:
 
 Two subprocesses, in order (openpi requires norm stats before training):
 
-  1. ``scripts/compute_norm_stats.py <config_name>`` — computes dataset
-     normalization statistics into ``assets/`` (skippable via
+  1. ``scripts/compute_norm_stats.py --config-name <config_name>`` — computes
+     dataset normalization statistics into ``assets/`` (skippable via
      ``config: {compute_norm_stats: false}`` when they already exist).
   2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
 

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -1,0 +1,338 @@
+"""π0.5 (openpi) training runner.
+
+Fine-tunes a Physical Intelligence π0.5 checkpoint by shelling out to the
+upstream **openpi** training entry points — the openpi package must be
+installed and its repo checked out on disk (``pip install -e`` of
+https://github.com/Physical-Intelligence/openpi), pointed at via
+``$OPENPI_REPO_PATH`` (default ``/srv/openpi``).
+
+Why this looks different from the GR00T / OpenVLA runners
+--------------------------------------------------------
+GR00T and OpenVLA take a flat bag of ``--flag value`` overrides. openpi is
+**config-name-driven**: training is selected by a registered ``TrainConfig``
+name (e.g. ``pi05_libero``) that bundles the data pipeline, weight loader and
+optimizer, and CLI ``--overrides`` (parsed by *tyro*) tweak individual fields.
+So the mission's ``config:`` here carries:
+
+  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig`` (positional
+    arg to both scripts). Fine-tuning a *new* embodiment/dataset means adding a
+    config entry to openpi's ``src/openpi/training/config.py`` (the π0.5 analogue
+    of GR00T's ``modality_config_path`` file) whose ``data.repo_id`` points at the
+    LeRobot dataset — see ``examples/quickstart-pi05-train/README.md``.
+  * everything else — passed through as tyro overrides (``num_train_steps`` →
+    ``--num-train-steps``, ``data.repo_id`` → ``--data.repo-id``). Booleans become
+    tyro flags (``--overwrite`` / ``--no-overwrite``), NOT ``--flag True``.
+
+Two subprocesses, in order (openpi requires norm stats before training):
+
+  1. ``scripts/compute_norm_stats.py <config_name>`` — computes dataset
+     normalization statistics into ``assets/`` (skippable via
+     ``config: {compute_norm_stats: false}`` when they already exist).
+  2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
+
+Both run with ``cwd = <task output_dir>`` so openpi's cwd-relative ``./assets``
+and ``./checkpoints`` land under the Odyssey task dir (no guessing an upstream
+``--checkpoint-base-dir`` flag name). openpi is import-resolved from the installed
+package, so the cwd only steers where artifacts are written.
+
+Routing: registered behind OpenVLA's wildcard training slot, reached via the
+task-level ``config: {runner: pi05}`` override — same mechanism as ``gr00t``.
+
+Licensing note: π0.5 weights are distributed under Physical Intelligence's terms.
+This runner contains no openpi code — it shells out to the user's own checkout.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import (
+    WILDCARD_TYPE,
+    Runner,
+    TaskContext,
+)
+
+# Shared flatten helper (dotted keys for nested dicts).
+from odyssey.runners.models.openvla import _flatten_config
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    output_path,
+    run_training_subprocess,
+)
+from odyssey.spec.refs import DatasetSource
+from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_REPO_PATH = "/srv/openpi"
+_TRAIN_SCRIPT_REL = "scripts/train.py"
+_NORM_STATS_SCRIPT_REL = "scripts/compute_norm_stats.py"
+
+# Config keys the runner consumes directly — never forwarded as tyro overrides.
+_CONTROL_KEYS = frozenset(
+    {"config_name", "runner", "exp_name", "overwrite", "resume", "compute_norm_stats"}
+)
+
+# openpi's train loop logs metrics dicts and a tqdm bar, e.g.:
+#   "step=1000 loss=0.234 grad_norm=1.2"
+#   "Step 1000: {'loss': 0.234, 'learning_rate': 1e-05}"
+#   " 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]"
+#   "Saving checkpoint to ./checkpoints/pi05_libero/exp/1000"
+_PI05_LOSS_RE = re.compile(r"(?:'loss':|\bloss=)\s*([\d.eE+-]+)")
+_PI05_STEP_RE = re.compile(r"(?:'step':|\bstep=|\bStep\s+)\s*(\d+)", re.IGNORECASE)
+_PI05_TQDM_RE = re.compile(r"\b(\d+)/(\d+)\s*\[")
+_PI05_SAVE_RE = re.compile(r"(?i)\b(saving|saved|wrote)\b.*\bcheckpoint\b")
+_PI05_NORM_RE = re.compile(r"(?i)\b(computing|writing)\b.*\bnorm(alization)?\s*stat")
+_PI05_DATASET_RE = re.compile(r"(?i)\b(loading|building)\b.*\b(dataset|lerobot)\b")
+
+
+def parse_pi05_train_line(line: str) -> dict[str, Any] | None:
+    """Extract a progress-event dict from an openpi train/norm-stats stdout line.
+
+    Public for tests and for users embedding openpi stdout parsing in a custom
+    runner. Precedence mirrors the GR00T parser: a metric line (loss / step)
+    wins over the coarse phase markers.
+    """
+    loss_match = _PI05_LOSS_RE.search(line)
+    step_match = _PI05_STEP_RE.search(line)
+    if loss_match or step_match:
+        payload: dict[str, Any] = {"stage": "executing", "step": "training_step"}
+        if step_match:
+            payload["step_index"] = int(step_match.group(1))
+        if loss_match:
+            payload["step_label"] = f"loss={loss_match.group(1)}"
+        return payload
+    tqdm_match = _PI05_TQDM_RE.search(line)
+    if tqdm_match:
+        return {
+            "stage": "executing",
+            "step": "training_step",
+            "step_index": int(tqdm_match.group(1)),
+            "step_total": int(tqdm_match.group(2)),
+        }
+    if _PI05_SAVE_RE.search(line):
+        return {"stage": "checkpoint_saving"}
+    if _PI05_NORM_RE.search(line):
+        return {"stage": "dataset_loading", "step": "compute_norm_stats"}
+    if _PI05_DATASET_RE.search(line):
+        return {"stage": "dataset_loading"}
+    return None
+
+
+def _resolve_openpi_script(rel: str) -> str:
+    """Absolute path to an openpi script under ``$OPENPI_REPO_PATH``.
+
+    Raises a runner-actionable error (not a bare FileNotFoundError) when the
+    checkout is missing, matching the OpenVLA runner's contract.
+    """
+    repo_path = os.getenv("OPENPI_REPO_PATH", _DEFAULT_REPO_PATH)
+    script_path = os.path.join(repo_path, rel)
+    if not os.path.isfile(script_path):
+        raise RuntimeError(
+            f"openpi script not found at {script_path!r}; clone "
+            "https://github.com/Physical-Intelligence/openpi and set "
+            "OPENPI_REPO_PATH (or place it at /srv/openpi)."
+        )
+    return script_path
+
+
+def _tyro_overrides(config: dict[str, Any]) -> list[str]:
+    """Flatten ``config`` into tyro CLI overrides, skipping control keys.
+
+    Nested dicts become dotted flags (``data.repo_id`` → ``--data.repo-id``);
+    booleans become tyro toggle flags (``--overwrite`` / ``--no-overwrite``)
+    rather than ``--flag True`` (which tyro rejects for bool fields).
+    """
+    argv: list[str] = []
+    for key, value in _flatten_config(config):
+        # _flatten_config yields the dotted path; only the LEAF may be a control
+        # key (nested overrides like data.repo_id are always forwarded).
+        if "." not in key and key in _CONTROL_KEYS:
+            continue
+        flag = f"--{key.replace('_', '-')}"
+        if isinstance(value, bool):
+            argv.append(flag if value else f"--no-{key.replace('_', '-')}")
+        else:
+            argv += [flag, str(value)]
+    return argv
+
+
+def build_pi05_train_argv(*, task: TrainingTask, exp_name: str) -> list[str]:
+    """Build the openpi ``scripts/train.py`` argv.
+
+    Shape: ``<config_name> --exp-name <name> [--overwrite|--resume] [overrides…]``.
+    ``config_name`` is REQUIRED — it selects the registered openpi ``TrainConfig``.
+    ``--overwrite`` is emitted by default (re-running a mission clobbers the prior
+    exp dir); set ``config: {overwrite: false}`` to keep it, or ``resume: true`` to
+    continue from the latest checkpoint instead.
+    """
+    config = task.config or {}
+    config_name = config.get("config_name")
+    if not config_name:
+        raise RuntimeError(
+            "π0.5 runner: config['config_name'] is required — it names the "
+            "registered openpi TrainConfig (e.g. 'pi05_libero'). Add a config "
+            "entry to openpi's src/openpi/training/config.py for a custom dataset."
+        )
+
+    argv: list[str] = [str(config_name), "--exp-name", exp_name]
+    if config.get("resume"):
+        argv.append("--resume")
+    elif config.get("overwrite", True):
+        argv.append("--overwrite")
+    argv += _tyro_overrides(config)
+    return argv
+
+
+def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
+    """Build the openpi ``scripts/compute_norm_stats.py`` argv.
+
+    Only the positional ``config_name`` is required; the dataset it reads is fixed
+    by the config's ``data`` factory.
+    """
+    config = task.config or {}
+    config_name = config.get("config_name")
+    if not config_name:
+        raise RuntimeError(
+            "π0.5 runner: config['config_name'] is required for norm-stats."
+        )
+    return [str(config_name)]
+
+
+def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
+    """Env overlay so openpi's LeRobot loader finds a LOCAL dataset.
+
+    openpi resolves ``data.repo_id`` against ``HF_LEROBOT_HOME`` (default
+    ``~/.cache/huggingface/lerobot``). For an absolute local dataset dir we point
+    that at the PARENT so ``repo_id`` == the dataset folder name resolves. HF/hub
+    refs and relative paths are left to the config to interpret.
+    """
+    if task.dataset is None:
+        return {}
+    ref = task.dataset.ref
+    if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
+        parent = os.path.dirname(os.path.normpath(ref))
+        # Set both the current and legacy var names — openpi/lerobot have used
+        # HF_LEROBOT_HOME and LEROBOT_HOME across versions.
+        return {"HF_LEROBOT_HOME": parent, "LEROBOT_HOME": parent}
+    return {}
+
+
+def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
+    """Locate the trained checkpoint under ``<output_dir>/checkpoints``.
+
+    openpi writes ``checkpoints/<config_name>/<exp_name>/<step>/`` (step is an
+    integer dir holding ``params/``). Return the highest-numbered step dir; None
+    if training wrote nothing.
+    """
+    checkpoints_root = output_dir / "checkpoints"
+    if not checkpoints_root.is_dir():
+        return None
+    best: tuple[int, Path] | None = None
+    for entry in checkpoints_root.rglob("*"):
+        if entry.is_dir() and entry.name.isdigit():
+            step = int(entry.name)
+            if best is None or step > best[0]:
+                best = (step, entry)
+    return best[1] if best is not None else None
+
+
+class Pi05Runner(Runner):
+    """Fine-tune a π0.5 model. Subprocess-based — actual training happens in
+    openpi's ``scripts/compute_norm_stats.py`` then ``scripts/train.py``."""
+
+    @property
+    def name(self) -> str:
+        return "pi05"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING}
+
+    @property
+    def supported_types(self) -> set[str]:
+        # Registered behind OpenVLA's wildcard; reached via the task-level
+        # ``config: {runner: pi05}`` override (same pattern as GR00T).
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, TrainingTask):
+            raise TypeError(
+                f"Pi05Runner expects TrainingTask, got {type(spec).__name__}"
+            )
+        if context.agent is None:
+            raise RuntimeError(
+                "Pi05Runner: TaskContext.agent is None — training tasks must be "
+                "invoked through the engine, which resolves the agent from "
+                "spec.robot.agents[task.agent_id]."
+            )
+
+        output_dir = output_path(context)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        config = dict(spec.config)
+        exp_name = str(config.get("exp_name") or spec.name)
+        timeout = getattr(spec, "timeout_seconds", None)
+        child_env = _lerobot_env_for_dataset(spec)
+
+        # Step 1: normalization statistics (openpi requires them before training).
+        if config.get("compute_norm_stats", True):
+            await context.emit_progress(
+                "dataset_loading", step="compute_norm_stats", step_label=exp_name
+            )
+            norm_spec = TrainingProcessSpec(
+                timeout_seconds=timeout,
+                script_path=_resolve_openpi_script(_NORM_STATS_SCRIPT_REL),
+                argv_extra=build_pi05_norm_stats_argv(task=spec),
+                env=child_env,
+                cwd=str(output_dir),
+                line_parser=parse_pi05_train_line,
+            )
+            rc = await run_training_subprocess(context, norm_spec)
+            if context.cancelled():
+                logger.info("π0.5 task %s cancelled during norm-stats", context.task.id)
+                return {"cancelled": True}
+            if rc != 0:
+                raise RuntimeError(
+                    f"openpi compute_norm_stats exited with code {rc}"
+                )
+
+        # Step 2: fine-tune.
+        train_spec = TrainingProcessSpec(
+            timeout_seconds=timeout,
+            script_path=_resolve_openpi_script(_TRAIN_SCRIPT_REL),
+            argv_extra=build_pi05_train_argv(task=spec, exp_name=exp_name),
+            env=child_env,
+            cwd=str(output_dir),
+            line_parser=parse_pi05_train_line,
+        )
+        rc = await run_training_subprocess(context, train_spec)
+        if context.cancelled():
+            logger.info("π0.5 task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"openpi train.py exited with code {rc}")
+
+        checkpoint = _resolve_output_checkpoint(output_dir)
+        if checkpoint is None:
+            raise RuntimeError(
+                f"openpi train.py finished but no checkpoint found under "
+                f"{output_dir / 'checkpoints'!r}"
+            )
+        return {
+            "checkpoint_path": str(checkpoint),
+            "agent_id": context.agent.id,
+            "exp_name": exp_name,
+            "config_name": config.get("config_name"),
+            "training_config": spec.config,
+            "training_type": (
+                spec.training_type.value
+                if isinstance(spec.training_type, TrainingType)
+                else spec.training_type
+            ),
+        }

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -30,7 +30,10 @@ Two subprocesses, in order (openpi requires norm stats before training):
 
   1. ``scripts/compute_norm_stats.py --config-name <config_name>`` — computes
      dataset normalization statistics into ``assets/`` (skippable via
-     ``config: {compute_norm_stats: false}`` when they already exist).
+     ``config: {compute_norm_stats: false}`` when they already exist). Results are
+     cached across runs per ``<config_name>/<repo_id>``; set
+     ``config: {norm_stats_cache: false}`` to force a recompute when a dataset's
+     content changed under an unchanged ``repo_id``.
   2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
 
 Both run with ``cwd = <task output_dir>`` so openpi's cwd-relative ``./assets``
@@ -78,7 +81,15 @@ _NORM_STATS_SCRIPT_REL = "scripts/compute_norm_stats.py"
 
 # Config keys the runner consumes directly — never forwarded as tyro overrides.
 _CONTROL_KEYS = frozenset(
-    {"config_name", "runner", "exp_name", "overwrite", "resume", "compute_norm_stats"}
+    {
+        "config_name",
+        "runner",
+        "exp_name",
+        "overwrite",
+        "resume",
+        "compute_norm_stats",
+        "norm_stats_cache",
+    }
 )
 
 # openpi's train loop logs metrics dicts and a tqdm bar, e.g.:
@@ -248,7 +259,27 @@ def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
     return best[1] if best is not None else None
 
 
-def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | None, bool]:
+def _dataset_repo_id(task: TrainingTask) -> str:
+    """The LeRobot ``repo_id`` openpi keys norm stats by.
+
+    openpi writes ``assets/<config_name>/<repo_id>/norm_stats.json``. ``repo_id``
+    is the mission's ``data.repo_id`` tyro override when present, else the local
+    dataset folder name (same source as ``_lerobot_env_for_dataset``). Empty when
+    neither is set — the registered config's *default* repo_id is then not known
+    to the runner, so the cache cannot be pinned and must recompute.
+    """
+    config = task.config or {}
+    data = config.get("data")
+    if isinstance(data, dict) and data.get("repo_id"):
+        return str(data["repo_id"])
+    if task.dataset is not None and task.dataset.ref:
+        return os.path.basename(os.path.normpath(task.dataset.ref))
+    return ""
+
+
+def _link_norm_stats_cache(
+    output_dir: Path, config_name: str, repo_id: str
+) -> tuple[Path | None, bool]:
     """Point openpi's cwd-relative ``./assets`` at a STABLE per-config cache.
 
     openpi writes norm stats into ``./assets`` relative to cwd (= the per-run
@@ -257,6 +288,15 @@ def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | N
     ``output_dir/assets`` at a stable cache keyed by ``config_name`` so the stats
     persist and are reused across runs; checkpoints still land in the per-run
     ``output_dir/checkpoints`` (only ``./assets`` is redirected).
+
+    The cache-hit test is keyed on the EXACT ``<config_name>/<repo_id>`` path
+    openpi writes, not a recursive glob: one registered config can hold stats for
+    several datasets (iterating datasets against one config is the intended
+    workflow, and what the shipped example does via ``data.repo_id``), so a glob
+    would report a hit for *any* dataset under the config, skip the step, and then
+    ``train.py`` dies looking for the ``repo_id`` it actually needs. An empty
+    ``repo_id`` (config default, unknown here) recomputes rather than risk a wrong
+    hit.
 
     Returns ``(cache_dir, already_has_norm_stats)``; ``(None, False)`` when there
     is no config_name to key the cache on.
@@ -268,7 +308,9 @@ def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | N
     link = output_dir / "assets"
     if not link.is_symlink() and not link.exists():
         link.symlink_to(cache, target_is_directory=True)
-    cached = any(cache.rglob("norm_stats.json"))
+    cached = bool(repo_id) and (
+        cache / config_name / repo_id / "norm_stats.json"
+    ).is_file()
     return cache, cached
 
 
@@ -312,8 +354,24 @@ class Pi05Runner(Runner):
         child_env = _lerobot_env_for_dataset(spec)
 
         # Redirect openpi's ./assets at a stable per-config cache so norm stats are
-        # computed once and reused, not recomputed on every fresh output_dir.
-        assets_cache, norm_cached = _link_norm_stats_cache(output_dir, config_name)
+        # computed once and reused, not recomputed on every fresh output_dir. The
+        # hit is keyed on the exact dataset (config_name + repo_id). Escape hatch:
+        # the cache has no content-fingerprint, so a dataset recaptured under the
+        # SAME repo_id would silently reuse stale stats — set
+        # ``config: {norm_stats_cache: false}`` to force a fresh recompute into the
+        # per-run dir (no shared cache) when the dataset content has changed.
+        if config.get("norm_stats_cache", True):
+            repo_id = _dataset_repo_id(spec)
+            assets_cache, norm_cached = _link_norm_stats_cache(
+                output_dir, config_name, repo_id
+            )
+        else:
+            logger.warning(
+                "π0.5 task %s: norm-stats cache disabled (norm_stats_cache=false)"
+                " — recomputing statistics into the per-run assets dir.",
+                context.task.id,
+            )
+            assets_cache, norm_cached = None, False
 
         # Step 1: normalization statistics (openpi requires them before training).
         # Skip when a prior run already cached them for this config.

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -192,8 +192,10 @@ def build_pi05_train_argv(*, task: TrainingTask, exp_name: str) -> list[str]:
 def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
     """Build the openpi ``scripts/compute_norm_stats.py`` argv.
 
-    Only the positional ``config_name`` is required; the dataset it reads is fixed
-    by the config's ``data`` factory.
+    Unlike ``train.py`` (positional config name via ``overridable_config_cli``),
+    ``compute_norm_stats.py`` is a plain ``tyro.cli(main)`` whose ``config_name``
+    parameter is exposed as a REQUIRED ``--config-name`` flag. The dataset it reads
+    is fixed by the config's ``data`` factory.
     """
     config = task.config or {}
     config_name = config.get("config_name")
@@ -201,7 +203,7 @@ def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
         raise RuntimeError(
             "π0.5 runner: config['config_name'] is required for norm-stats."
         )
-    return [str(config_name)]
+    return ["--config-name", str(config_name)]
 
 
 def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -248,6 +248,30 @@ def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
     return best[1] if best is not None else None
 
 
+def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | None, bool]:
+    """Point openpi's cwd-relative ``./assets`` at a STABLE per-config cache.
+
+    openpi writes norm stats into ``./assets`` relative to cwd (= the per-run
+    output_dir), so a fresh output_dir every run recomputes the *deterministic*
+    stats from scratch — a multi-minute full-dataset scan each time. Symlink
+    ``output_dir/assets`` at a stable cache keyed by ``config_name`` so the stats
+    persist and are reused across runs; checkpoints still land in the per-run
+    ``output_dir/checkpoints`` (only ``./assets`` is redirected).
+
+    Returns ``(cache_dir, already_has_norm_stats)``; ``(None, False)`` when there
+    is no config_name to key the cache on.
+    """
+    if not config_name:
+        return None, False
+    cache = Path.home() / ".odyssey" / "pi05_assets" / config_name
+    cache.mkdir(parents=True, exist_ok=True)
+    link = output_dir / "assets"
+    if not link.is_symlink() and not link.exists():
+        link.symlink_to(cache, target_is_directory=True)
+    cached = any(cache.rglob("norm_stats.json"))
+    return cache, cached
+
+
 class Pi05Runner(Runner):
     """Fine-tune a π0.5 model. Subprocess-based — actual training happens in
     openpi's ``scripts/compute_norm_stats.py`` then ``scripts/train.py``."""
@@ -282,12 +306,18 @@ class Pi05Runner(Runner):
         output_dir = output_path(context)
         output_dir.mkdir(parents=True, exist_ok=True)
         config = dict(spec.config)
+        config_name = str(config.get("config_name") or "")
         exp_name = str(config.get("exp_name") or spec.name)
         timeout = getattr(spec, "timeout_seconds", None)
         child_env = _lerobot_env_for_dataset(spec)
 
+        # Redirect openpi's ./assets at a stable per-config cache so norm stats are
+        # computed once and reused, not recomputed on every fresh output_dir.
+        assets_cache, norm_cached = _link_norm_stats_cache(output_dir, config_name)
+
         # Step 1: normalization statistics (openpi requires them before training).
-        if config.get("compute_norm_stats", True):
+        # Skip when a prior run already cached them for this config.
+        if config.get("compute_norm_stats", True) and not norm_cached:
             await context.emit_progress(
                 "dataset_loading", step="compute_norm_stats", step_label=exp_name
             )
@@ -307,6 +337,15 @@ class Pi05Runner(Runner):
                 raise RuntimeError(
                     f"openpi compute_norm_stats exited with code {rc}"
                 )
+        elif norm_cached:
+            logger.info(
+                "π0.5 task %s: reusing cached norm stats at %s",
+                context.task.id,
+                assets_cache,
+            )
+            await context.emit_progress(
+                "dataset_loading", step="norm_stats_cached", step_label=exp_name
+            )
 
         # Step 2: fine-tune.
         train_spec = TrainingProcessSpec(

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -217,9 +217,10 @@ def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
     ref = task.dataset.ref
     if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
         parent = os.path.dirname(os.path.normpath(ref))
-        # Set both the current and legacy var names — openpi/lerobot have used
-        # HF_LEROBOT_HOME and LEROBOT_HOME across versions.
-        return {"HF_LEROBOT_HOME": parent, "LEROBOT_HOME": parent}
+        # Only HF_LEROBOT_HOME — do NOT also set the legacy LEROBOT_HOME. Recent
+        # lerobot HARD-FAILS at import (raises ValueError) if the deprecated
+        # LEROBOT_HOME var is present, which killed compute_norm_stats.
+        return {"HF_LEROBOT_HOME": parent}
     return {}
 
 

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -151,7 +151,8 @@ def test_lerobot_env_points_at_parent_for_absolute_local() -> None:
     )
     env = _lerobot_env_for_dataset(task)
     assert env["HF_LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
-    assert env["LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+    # The deprecated LEROBOT_HOME must NOT be set — recent lerobot hard-fails on it.
+    assert "LEROBOT_HOME" not in env
 
 
 def test_lerobot_env_empty_for_hf_dataset() -> None:

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -129,9 +129,11 @@ def test_train_argv_excludes_control_keys() -> None:
 # norm-stats argv builder
 # ---------------------------------------------------------------------------
 
-def test_norm_stats_argv_is_config_name_only() -> None:
+def test_norm_stats_argv_uses_config_name_flag() -> None:
+    # compute_norm_stats.py exposes config_name as a --config-name flag (tyro.cli),
+    # NOT positional like train.py.
     task = _task(config={"config_name": "pi05_libero", "num_train_steps": 10})
-    assert build_pi05_norm_stats_argv(task=task) == ["pi05_libero"]
+    assert build_pi05_norm_stats_argv(task=task) == ["--config-name", "pi05_libero"]
 
 
 def test_norm_stats_argv_requires_config_name() -> None:

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from odyssey.runners.models.pi05_train import (
+    _dataset_repo_id,
     _lerobot_env_for_dataset,
     _link_norm_stats_cache,
     _resolve_output_checkpoint,
@@ -190,34 +191,96 @@ def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
 # norm-stats cache
 # ---------------------------------------------------------------------------
 
+_CFG = "pi05_ur10e_drugsort"
+
+
 def test_link_norm_stats_cache_symlinks_and_reuses(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     run1 = tmp_path / "run1"
     run1.mkdir()
-    cache, cached = _link_norm_stats_cache(run1, "pi05_ur10e_drugsort")
+    cache, cached = _link_norm_stats_cache(run1, _CFG, "ur10e")
     assert cache is not None
     # ./assets in the run dir is a symlink to the stable per-config cache.
     assert (run1 / "assets").is_symlink()
     assert (run1 / "assets").resolve() == cache.resolve()
     assert cached is False  # nothing cached yet
 
-    # Simulate openpi writing norm stats into the cache; a fresh run reuses them.
-    (cache / "ur10e").mkdir(parents=True)
-    (cache / "ur10e" / "norm_stats.json").write_text("{}")
+    # Simulate openpi writing stats at assets/<config_name>/<repo_id>/; a fresh run
+    # for the SAME dataset reuses them.
+    (cache / _CFG / "ur10e").mkdir(parents=True)
+    (cache / _CFG / "ur10e" / "norm_stats.json").write_text("{}")
     run2 = tmp_path / "run2"
     run2.mkdir()
-    _, cached2 = _link_norm_stats_cache(run2, "pi05_ur10e_drugsort")
+    _, cached2 = _link_norm_stats_cache(run2, _CFG, "ur10e")
     assert cached2 is True
+
+
+def test_link_norm_stats_cache_hit_is_keyed_by_dataset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached dataset must NOT satisfy a run for a *different* dataset under the
+    same config — openpi keys norm stats by repo_id, so a glob would wrongly hit
+    and train.py would then die looking for the repo_id it actually needs."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run1 = tmp_path / "run1"
+    run1.mkdir()
+    cache, _ = _link_norm_stats_cache(run1, _CFG, "dataset_A")
+    assert cache is not None
+    (cache / _CFG / "dataset_A").mkdir(parents=True)
+    (cache / _CFG / "dataset_A" / "norm_stats.json").write_text("{}")
+
+    run2 = tmp_path / "run2"
+    run2.mkdir()
+    _, cached_b = _link_norm_stats_cache(run2, _CFG, "dataset_B")  # different dataset
+    assert cached_b is False
+
+
+def test_link_norm_stats_cache_empty_repo_id_recomputes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown repo_id (config default) is never a hit — recompute over a wrong
+    guess. Any stray stats under the config must not count."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run = tmp_path / "run"
+    run.mkdir()
+    cache, _ = _link_norm_stats_cache(run, _CFG, "")
+    assert cache is not None
+    (cache / _CFG / "whatever").mkdir(parents=True)
+    (cache / _CFG / "whatever" / "norm_stats.json").write_text("{}")
+    _, cached = _link_norm_stats_cache(run, _CFG, "")
+    assert cached is False
 
 
 def test_link_norm_stats_cache_no_config_name(tmp_path: Path) -> None:
     run = tmp_path / "run"
     run.mkdir()
-    cache, cached = _link_norm_stats_cache(run, "")
+    cache, cached = _link_norm_stats_cache(run, "", "ur10e")
     assert cache is None
     assert cached is False
+
+
+def test_dataset_repo_id_prefers_data_override() -> None:
+    task = _task(
+        config={"config_name": _CFG, "data": {"repo_id": "ur10e_partial_cond_aug"}},
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="/data/some_other_folder"
+        ),
+    )
+    assert _dataset_repo_id(task) == "ur10e_partial_cond_aug"
+
+
+def test_dataset_repo_id_falls_back_to_dataset_folder() -> None:
+    task = _task(
+        config={"config_name": _CFG},
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/ur10e_v0/"),
+    )
+    assert _dataset_repo_id(task) == "ur10e_v0"
+
+
+def test_dataset_repo_id_empty_when_unknown() -> None:
+    assert _dataset_repo_id(_task(config={"config_name": _CFG})) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -17,6 +17,7 @@ import pytest
 
 from odyssey.runners.models.pi05_train import (
     _lerobot_env_for_dataset,
+    _link_norm_stats_cache,
     _resolve_output_checkpoint,
     build_pi05_norm_stats_argv,
     build_pi05_train_argv,
@@ -183,6 +184,40 @@ def test_resolve_output_checkpoint_picks_highest_step(tmp_path: Path) -> None:
 
 def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
     assert _resolve_output_checkpoint(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# norm-stats cache
+# ---------------------------------------------------------------------------
+
+def test_link_norm_stats_cache_symlinks_and_reuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run1 = tmp_path / "run1"
+    run1.mkdir()
+    cache, cached = _link_norm_stats_cache(run1, "pi05_ur10e_drugsort")
+    assert cache is not None
+    # ./assets in the run dir is a symlink to the stable per-config cache.
+    assert (run1 / "assets").is_symlink()
+    assert (run1 / "assets").resolve() == cache.resolve()
+    assert cached is False  # nothing cached yet
+
+    # Simulate openpi writing norm stats into the cache; a fresh run reuses them.
+    (cache / "ur10e").mkdir(parents=True)
+    (cache / "ur10e" / "norm_stats.json").write_text("{}")
+    run2 = tmp_path / "run2"
+    run2.mkdir()
+    _, cached2 = _link_norm_stats_cache(run2, "pi05_ur10e_drugsort")
+    assert cached2 is True
+
+
+def test_link_norm_stats_cache_no_config_name(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    cache, cached = _link_norm_stats_cache(run, "")
+    assert cache is None
+    assert cached is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -1,0 +1,232 @@
+"""Tests for the π0.5 (openpi) training runner's argv builders, env overlay,
+checkpoint resolution and stdout parser.
+
+We don't invoke the real openpi ``scripts/train.py`` — that needs the openpi
+package, JAX/torch with CUDA, a GPU and a registered ``TrainConfig``. The
+testable pieces are the pure functions that shape the two subprocess argvs from
+a ``TrainingTask`` spec, the LeRobot env overlay, the checkpoint locator, and the
+parser that turns openpi stdout into progress events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.runners.models.pi05_train import (
+    _lerobot_env_for_dataset,
+    _resolve_output_checkpoint,
+    build_pi05_norm_stats_argv,
+    build_pi05_train_argv,
+    parse_pi05_train_line,
+)
+from odyssey.spec import DatasetRef, DatasetSource, TrainingTask, TrainingType
+
+
+def _task(**overrides: Any) -> TrainingTask:
+    fields: dict[str, Any] = {
+        "name": "finetune-pi05",
+        "training_type": TrainingType.DEMONSTRATION,
+        "agent_id": "pilot",
+    }
+    fields.update(overrides)
+    return TrainingTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# train argv builder
+# ---------------------------------------------------------------------------
+
+def test_train_argv_requires_config_name() -> None:
+    with pytest.raises(RuntimeError, match="config_name"):
+        build_pi05_train_argv(task=_task(), exp_name="exp")
+
+
+def test_train_argv_positional_config_name_first() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert argv[0] == "pi05_libero"
+
+
+def test_train_argv_includes_exp_name() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="my-exp")
+    idx = argv.index("--exp-name")
+    assert argv[idx + 1] == "my-exp"
+
+
+def test_train_argv_defaults_to_overwrite() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--overwrite" in argv
+
+
+def test_train_argv_overwrite_false_omits_flag() -> None:
+    task = _task(config={"config_name": "pi05_libero", "overwrite": False})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--overwrite" not in argv
+
+
+def test_train_argv_resume_replaces_overwrite() -> None:
+    task = _task(config={"config_name": "pi05_libero", "resume": True})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--resume" in argv
+    assert "--overwrite" not in argv
+
+
+def test_train_argv_passthrough_is_kebab_case() -> None:
+    task = _task(config={"config_name": "pi05_libero", "num_train_steps": 30000})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    idx = argv.index("--num-train-steps")
+    assert argv[idx + 1] == "30000"
+
+
+def test_train_argv_nested_config_becomes_dotted_flag() -> None:
+    # tyro overrides address nested dataclass fields via dots; underscores in a
+    # leaf still become dashes (data.repo_id -> --data.repo-id).
+    task = _task(
+        config={"config_name": "pi05_ur10e", "data": {"repo_id": "ur10e_partial_cond_aug"}}
+    )
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    idx = argv.index("--data.repo-id")
+    assert argv[idx + 1] == "ur10e_partial_cond_aug"
+
+
+def test_train_argv_bool_true_is_bare_flag() -> None:
+    task = _task(config={"config_name": "c", "wandb_enabled": True})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--wandb-enabled" in argv
+    # A bare flag carries no value token after it.
+    assert "True" not in argv
+
+
+def test_train_argv_bool_false_is_no_flag() -> None:
+    task = _task(config={"config_name": "c", "wandb_enabled": False})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--no-wandb-enabled" in argv
+
+
+def test_train_argv_excludes_control_keys() -> None:
+    task = _task(
+        config={
+            "config_name": "c",
+            "runner": "pi05",
+            "exp_name": "ignored",
+            "compute_norm_stats": False,
+        }
+    )
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--runner" not in argv
+    assert "--config-name" not in argv
+    assert "--compute-norm-stats" not in argv
+    # exp_name is supplied via the dedicated flag, not passed through twice.
+    assert argv.count("--exp-name") == 1
+
+
+# ---------------------------------------------------------------------------
+# norm-stats argv builder
+# ---------------------------------------------------------------------------
+
+def test_norm_stats_argv_is_config_name_only() -> None:
+    task = _task(config={"config_name": "pi05_libero", "num_train_steps": 10})
+    assert build_pi05_norm_stats_argv(task=task) == ["pi05_libero"]
+
+
+def test_norm_stats_argv_requires_config_name() -> None:
+    with pytest.raises(RuntimeError, match="config_name"):
+        build_pi05_norm_stats_argv(task=_task())
+
+
+# ---------------------------------------------------------------------------
+# LeRobot env overlay
+# ---------------------------------------------------------------------------
+
+def test_lerobot_env_points_at_parent_for_absolute_local() -> None:
+    task = _task(
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="/data/ur10e_drugsort_v0/ur10e_partial_cond_aug"
+        ),
+    )
+    env = _lerobot_env_for_dataset(task)
+    assert env["HF_LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+    assert env["LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+
+
+def test_lerobot_env_empty_for_hf_dataset() -> None:
+    task = _task(
+        dataset=DatasetRef(source=DatasetSource.HUGGINGFACE, ref="org/some-lerobot"),
+    )
+    assert _lerobot_env_for_dataset(task) == {}
+
+
+def test_lerobot_env_empty_when_no_dataset() -> None:
+    assert _lerobot_env_for_dataset(_task()) == {}
+
+
+# ---------------------------------------------------------------------------
+# checkpoint resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_output_checkpoint_picks_highest_step(tmp_path: Path) -> None:
+    root = tmp_path / "checkpoints" / "pi05_ur10e" / "exp"
+    for step in (1000, 5000, 2000):
+        (root / str(step) / "params").mkdir(parents=True)
+    resolved = _resolve_output_checkpoint(tmp_path)
+    assert resolved is not None
+    assert resolved.name == "5000"
+
+
+def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
+    assert _resolve_output_checkpoint(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# stdout parser
+# ---------------------------------------------------------------------------
+
+def test_parse_loss_and_step_line() -> None:
+    event = parse_pi05_train_line("step=1000 loss=0.234 grad_norm=1.2")
+    assert event is not None
+    assert event["stage"] == "executing"
+    assert event["step"] == "training_step"
+    assert event["step_index"] == 1000
+    assert "loss=0.234" in event["step_label"]
+
+
+def test_parse_dict_style_metric_line() -> None:
+    event = parse_pi05_train_line("Step 1000: {'loss': 0.234, 'learning_rate': 1e-05}")
+    assert event is not None
+    assert event["step_index"] == 1000
+    assert "loss=0.234" in event["step_label"]
+
+
+def test_parse_tqdm_progress_line() -> None:
+    event = parse_pi05_train_line(" 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]")
+    assert event is not None
+    assert event["step_index"] == 100
+    assert event["step_total"] == 1000
+
+
+def test_parse_checkpoint_save_line() -> None:
+    event = parse_pi05_train_line("Saving checkpoint to ./checkpoints/pi05_libero/exp/1000")
+    assert event is not None
+    assert event["stage"] == "checkpoint_saving"
+
+
+def test_parse_norm_stats_line() -> None:
+    event = parse_pi05_train_line("Computing normalization statistics for pi05_ur10e")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+    assert event["step"] == "compute_norm_stats"
+
+
+def test_parse_dataset_loading_line() -> None:
+    event = parse_pi05_train_line("Loading LeRobot dataset ur10e_partial_cond_aug")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+
+
+def test_parse_unrelated_line_returns_none() -> None:
+    assert parse_pi05_train_line("nothing interesting here") is None


### PR DESCRIPTION
Closes #74 — the last leg of the π0.5 pilot integration (pilot + eval landed in #81; this adds fine-tuning). Merging this closes the issue.

## What

Adds `Pi05Runner`, the **fine-tuning** counterpart to the existing π0.5 inference/eval path (issue #74). π0.5 now covers training + eval + inference in Odyssey.

## Why openpi looks different from GR00T/OpenVLA

GR00T and OpenVLA take a flat bag of `--flag value` overrides. **openpi is config-name-driven**: training selects a registered `TrainConfig` (bundling data pipeline + weight loader + optimizer), and CLI `--overrides` (tyro) tweak fields. So the runner:

- shells out to **two openpi entry points in order** — `scripts/compute_norm_stats.py` then `scripts/train.py` (openpi requires norm stats before training; skippable via `compute_norm_stats: false`);
- runs both with `cwd = <task output_dir>` so openpi's cwd-relative `./assets` and `./checkpoints` land under the Odyssey task dir (no guessing an upstream `--checkpoint-base-dir` flag);
- forwards mission `config:` as tyro overrides — nested dotted flags (`data.repo_id` → `--data.repo-id`), **booleans as toggle flags** (`--overwrite` / `--no-overwrite`), not `--flag True`;
- for a **local absolute** dataset ref, sets `HF_LEROBOT_HOME` to the parent dir so openpi's LeRobot loader resolves `data.repo_id` == the folder name.

Routing: registered behind OpenVLA's wildcard training slot, reached via `config: {runner: pi05}` — same mechanism as `gr00t`.

## Changes

- `src/odyssey/runners/models/pi05_train.py` — `Pi05Runner` + `build_pi05_train_argv` / `build_pi05_norm_stats_argv` / `_lerobot_env_for_dataset` / `_resolve_output_checkpoint` / `parse_pi05_train_line`. Kept **strict-clean in a new module** (not in the mypy-exempt `pi05.py` pilot file) since it's pure subprocess glue with no openpi imports.
- Registered in `runners/__init__.py` + `cli/commands/run.py`.
- `examples/quickstart-pi05-train/` — base fine-tune mission wired for the UR10e drug-sort v0 LeRobot demos (7-DoF, exterior + wrist cams) + README with the openpi `TrainConfig` recipe. Eval task is `custom` (honest closed-loop vs `meta/gt`); README explains why LIBERO is **not** an honest metric for a UR10e-fine-tuned model.
- `tests/unit/test_pi05_train.py` — 25 tests (argv builders, env overlay, checkpoint resolver, stdout parser).

## Verification

- ruff clean · mypy strict clean (79 files) · **525 passed, 4 skipped**
- `odyssey validate` + `odyssey run --use-mock-runner` pass end-to-end on the new example.

## Known gap

A first GPU run surfaced the openpi CLI-contract fixes now on this branch (the `compute_norm_stats.py --config-name` flag vs `train.py`'s positional `config_name`, `--data.repo-id`, cwd-relative `./assets`/`./checkpoints`) — those are verified against upstream source. **Still to confirm on GPU:** a full fine-tune-to-convergence run end-to-end. Same posture as the π0.5 eval path landed with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
