### PR TITLE
chore: ignore node_modules/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ dist/
 wheels/
 *.whl
 
+# Node deps. Example harnesses that drive a browser (puppeteer et al.) install
+# these locally; a single `npm install` is ~2,800 files, so an accidental
+# `git add -A` in an example dir swamps the repo. Lockfiles stay tracked.
+node_modules/
+
 # Virtual envs
 .venv/
 venv/


### PR DESCRIPTION
## What

Adds `node_modules/` to `.gitignore`.

## Why

The browser-driving example harnesses (`examples/ur5e-drugsort/browser_capture`, puppeteer) install node deps into the example directory. A single `npm install` there is ~2,800 files across 85 packages, so an accidental `git add -A` in an example dir swamps a commit — which is exactly what happened on a work branch, and what prompted this.

## Scope

- Nothing tracked is affected: `git ls-files | grep node_modules` on `develop` is empty.
- Lockfiles stay tracked — only the installed tree is ignored.
- Verified the rule matches: `git check-ignore -v examples/ur5e-drugsort/browser_capture/node_modules/puppeteer/package.json` → `.gitignore:22:node_modules/`.
