### PR TITLE
chore(versioning): bump to 0.1.0a5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lovell-odyssey"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Open-source framework for defining, running, and benchmarking robot training missions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
 """Odyssey — open-source framework for robot training missions."""
 
-__version__ = "0.1.0a4"
+__version__ = "0.1.0a5"


### PR DESCRIPTION
Bumps the version to `0.1.0a5` on `develop` ahead of the release merge to `main`.

Bumps the two authoritative version strings — `pyproject.toml` and `src/odyssey/__init__.py`. The descriptive `v0.1.0-alpha.1` mentions in README/docs are left as-is (they've stayed at alpha.1 through a2/a3/a4).

## Why now

Since the a4 promotion to `main` (#85), `develop` has landed:
- π0.5 training runner (`Pi05Runner`, #90)
- `CustomEvalRunner` for `evaluation_type: custom` (#88)
- browser closed-loop eval harness + `in_well` metric (#92)
- `node_modules/` gitignore (#91)
- ur10e embodiment (#86)

These are new features under the same `0.1.0a4` string already on `main`. Bump to `a5` first (on develop, its own PR) so `main` never takes a direct version commit — then the release branch promotes develop→main as a merge commit.

Version-bump only; no code changes.