### PR TITLE
release: v0.1.0a5 (develop → main)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ dist/
 wheels/
 *.whl
 
+# Node deps. Example harnesses that drive a browser (puppeteer et al.) install
+# these locally; a single `npm install` is ~2,800 files, so an accidental
+# `git add -A` in an example dir swamps the repo. Lockfiles stay tracked.
+node_modules/
+
 # Virtual envs
 .venv/
 venv/

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -109,7 +109,7 @@ and that `agents` contains exactly one agent.
 
 | Form | Example | What it does today |
 |---|---|---|
-| `embodiment:` | `franka_panda`, `ur5e`, `sawyer` | Names a built-in catalog embodiment. 8 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover. Resolved at mission-creation by `LocalRobotProvider`; passed through to `robosuite.make(robots=...)` at evaluation. |
+| `embodiment:` | `franka_panda`, `ur5e`, `ur10e` | Names a built-in catalog embodiment. 9 names accepted: `franka_panda`, `panda`, `sawyer`, `iiwa`, `jaco`, `kinova_gen3`, `ur5e`, `baxter` — the arms Robosuite's built-in robot models cover, passed through to `robosuite.make(robots=...)` at evaluation — plus `ur10e`, driven by the **GR00T runner** (`NEW_EMBODIMENT` finetune), which Robosuite doesn't ship: it resolves and validates, but a Robosuite eval task against it raises rather than passing through. All resolved at mission-creation by `LocalRobotProvider`. |
 | `urdf:` | `./arms/my_arm.urdf` | Names a local URDF/xacro path. Existence-checked at mission-creation. No robot pass-through to Robosuite — falls back to the env's default robot. |
 | `id:` | `rob_01HQR...` | Reserved for a robot registered in your Lovell account. When the Lovell provider ships, this will fetch the loadout from the account rather than requiring an inline `agents:` block. Requires `odyssey login`, not yet shipped. |
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -64,6 +64,43 @@ deadlines, instruction prefixes injected into VLA prompts). Write them like
 you mean it — future-you will reread them in leaderboard submissions and
 graph queries.
 
+### Evaluation types
+
+`evaluation_type` selects the eval runner:
+
+| `evaluation_type` | Runs |
+|---|---|
+| `robosuite` | In-process rollouts in the Robosuite sim (auto-wired OpenVLA policy). |
+| `isaac_lab` | An Isaac Lab eval script under Isaac Sim's Python, over an `ODYSSEY_*` stdout protocol. |
+| `custom` | **Any eval script**, as a subprocess, decoupled from any sim. |
+
+Use `custom` when the honest metric for your task is neither Robosuite nor Isaac
+Lab — e.g. the ground-truth evals for the UR10e/UR5e GR00T pilot (open-loop:
+replay recorded observations and compare the predicted action chunk to the
+recorded expert action; closed-loop: roll out the served policy and score
+against physics ground truth). The runner owns the launch, the checkpoint path,
+cancellation, and reading metrics; the *script* owns everything domain-specific,
+including how it loads or serves the checkpoint.
+
+```yaml
+  - name: openloop-gt
+    kind: evaluation
+    evaluation_type: custom
+    benchmark_name: openloop-gt
+    config:
+      eval_script: scripts/eval_openloop_gt.py   # or $ODYSSEY_EVAL_SCRIPT
+      eval_python: /venv/gr00t/bin/python         # optional; default sys.executable
+      replay_dataset: /data/ur10e                 # extra keys pass through as --replay_dataset
+```
+
+The runner launches `<eval_python> <eval_script> --checkpoint <path> --out-json
+<path> [--<config-key> <value> …]`. The script writes its metrics to the
+`--out-json` path as a JSON object; `success_rate` (if present) yields a letter
+grade + pass/fail, otherwise the metrics are surfaced as-is (a metric-only eval
+such as per-joint MAE is not forced into a pass/fail). Without this runner,
+`evaluation_type: custom` would fall through to the fake `CPUMockRunner`. Full
+contract: `src/odyssey/runners/evals/custom.py`.
+
 ## Robots and agents
 
 In the Lovell AI architecture, a **robot** is more than an embodiment —

--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -1,0 +1,102 @@
+# π0.5 fine-tune quickstart (training)
+
+Fine-tune a Physical Intelligence **π0.5** (openpi) checkpoint on a LeRobot-format
+demonstration set through the odyssey `pi05` training runner. The runner shells
+out to openpi's own entry points — `scripts/compute_norm_stats.py` then
+`scripts/train.py` — so the actual training happens in your openpi checkout.
+
+This is the **training** counterpart to `examples/quickstart-pi05/` (eval-only).
+
+> **Status:** the odyssey-side wiring (argv build, norm-stats + train subprocess
+> orchestration, checkpoint capture, stdout→progress parsing) is complete and
+> unit-tested on CPU. It has **not** been run end-to-end on a GPU box yet —
+> treat the openpi flag names below as the contract to confirm on the first smoke.
+
+## What you need
+
+- A GPU box (π0.5 fine-tune is memory-hungry — an 80 GB A100/H100 class card).
+- **openpi** installed and checked out:
+  ```bash
+  git clone https://github.com/Physical-Intelligence/openpi
+  cd openpi && pip install -e .
+  export OPENPI_REPO_PATH=$(pwd)      # runner defaults to /srv/openpi otherwise
+  ```
+- The LeRobot dataset unpacked on the box, e.g.
+  `/data/ur10e_drugsort_v0/ur10e_partial_cond_aug/`.
+
+## Why openpi is config-name-driven (and GR00T isn't)
+
+GR00T / OpenVLA take a flat bag of `--flag value` overrides. openpi selects a
+**registered `TrainConfig`** by name — it bundles the data transforms, the base
+weight loader and the optimizer. So fine-tuning a *new* dataset/embodiment means
+adding one config entry (the π0.5 analogue of GR00T's `modality_config_path`).
+
+### 1. Register a `TrainConfig` in openpi
+
+Add an entry to `src/openpi/training/config.py` (name it `pi05_ur10e_drugsort`, to
+match `config_name` in the mission). Base it on the shipped `pi05_libero` config,
+then point its data config at your LeRobot dataset and describe the state/action
+mapping:
+
+- **state/action**: 7-DoF (6 joints + gripper) — π0.5 pads to the model's action
+  dim; no observer-conditioned `grasp_target` channel (that's GR00T-specific —
+  drop it here).
+- **images**: map `observation.images.exterior` → `base_0_rgb` and
+  `observation.images.wrist` → `left_wrist_0_rgb` in the repack transform.
+- **repo_id**: the dataset folder name, `ur10e_partial_cond_aug`.
+
+### 2. Dataset resolution
+
+For a **local absolute** dataset ref, the runner sets `HF_LEROBOT_HOME` to the
+dataset's parent dir, so openpi's LeRobot loader resolves `data.repo_id` == the
+folder name. Keep the two in sync:
+
+```
+ref:            /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+data.repo_id:   ur10e_partial_cond_aug          # HF_LEROBOT_HOME=/data/ur10e_drugsort_v0
+```
+
+## Run
+
+```bash
+# CPU validation (no training):
+odyssey validate mission.yaml
+odyssey run mission.yaml --use-mock-runner
+
+# Real fine-tune on the GPU box:
+export OPENPI_REPO_PATH=/path/to/openpi
+odyssey run mission.yaml
+```
+
+The runner executes, in order:
+
+1. `python scripts/compute_norm_stats.py pi05_ur10e_drugsort`
+   (skip with `config: {compute_norm_stats: false}` if `./assets` already holds them)
+2. `python scripts/train.py pi05_ur10e_drugsort --exp-name finetune-pi05-ur10e --overwrite \
+      --data.repo-id ur10e_partial_cond_aug --num-train-steps 30000 --batch-size 32`
+
+Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
+and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
+captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
+
+## Config keys the runner interprets
+
+| key                  | meaning                                                            |
+|----------------------|-------------------------------------------------------------------|
+| `runner: pi05`       | routes the wildcard training task to `Pi05Runner`                 |
+| `config_name`        | **required** — the registered openpi `TrainConfig` (positional)   |
+| `exp_name`           | openpi `--exp-name`; defaults to the task name                     |
+| `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
+| `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |
+| `compute_norm_stats` | run the norm-stats pre-step (default `true`)                       |
+| *anything else*      | forwarded as a tyro override (`a_b` → `--a-b`; nested `x: {y: 1}` → `--x.y 1`; bools → `--flag` / `--no-flag`) |
+
+## Can I then evaluate on LIBERO?
+
+Not honestly with *this* checkpoint. LIBERO is a **Franka Panda** sim benchmark;
+a π0.5 fine-tuned on **UR10e** demos is a different embodiment, action space and
+task, so a LIBERO score would measure a sim-to-sim gap, not this cell. The
+`examples/quickstart-pi05/` LIBERO eval is for a **LIBERO-compatible** π0.5
+checkpoint (e.g. the shipped `pi05_libero`). For the drug-sort model, the honest
+metric is the standalone closed-loop grasp+place eval against physics ground
+truth (`meta/gt`).

--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -80,6 +80,13 @@ The runner executes, in order:
 > registered config's default `repo_id`, or step 1 writes norm stats under one
 > `repo_id` and step 2 reads another and fails (loudly, after the full dataset scan).
 
+> Norm stats are cached across runs at `~/.odyssey/pi05_assets/<config_name>/<config_name>/<repo_id>/`
+> and step 1 is skipped on a hit. The hit is keyed on `config_name` + `repo_id`
+> only — it has **no content fingerprint**, so a dataset recaptured under an
+> unchanged `repo_id` would silently reuse stale statistics. When the dataset
+> content changed, set `config: {norm_stats_cache: false}` to force a fresh
+> recompute into the per-run dir.
+
 Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
 and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
 captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
@@ -94,6 +101,7 @@ captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
 | `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
 | `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |
 | `compute_norm_stats` | run the norm-stats pre-step (default `true`)                       |
+| `norm_stats_cache`   | reuse cached norm stats across runs, keyed by `config_name`+`repo_id` (default `true`); set `false` to force a recompute when the dataset content changed under the same `repo_id` |
 | *anything else*      | forwarded as a tyro override (`a_b` → `--a-b`; nested `x: {y: 1}` → `--x.y 1`; bools → `--flag` / `--no-flag`) |
 
 ## Can I then evaluate on LIBERO?

--- a/examples/quickstart-pi05-train/README.md
+++ b/examples/quickstart-pi05-train/README.md
@@ -70,10 +70,15 @@ odyssey run mission.yaml
 
 The runner executes, in order:
 
-1. `python scripts/compute_norm_stats.py pi05_ur10e_drugsort`
+1. `python scripts/compute_norm_stats.py --config-name pi05_ur10e_drugsort`
    (skip with `config: {compute_norm_stats: false}` if `./assets` already holds them)
 2. `python scripts/train.py pi05_ur10e_drugsort --exp-name finetune-pi05-ur10e --overwrite \
       --data.repo-id ur10e_partial_cond_aug --num-train-steps 30000 --batch-size 32`
+
+> The norm-stats step takes no `data.*` overrides — it reads the dataset fixed by
+> the config's `data` factory. So the mission's `data.repo_id` **must equal** the
+> registered config's default `repo_id`, or step 1 writes norm stats under one
+> `repo_id` and step 2 reads another and fails (loudly, after the full dataset scan).
 
 Both run with `cwd` = the task's `output_dir`, so openpi's cwd-relative `./assets`
 and `./checkpoints` land under the odyssey run dir. The trained checkpoint is
@@ -84,7 +89,7 @@ captured from `checkpoints/<config_name>/<exp_name>/<step>/` (highest step).
 | key                  | meaning                                                            |
 |----------------------|-------------------------------------------------------------------|
 | `runner: pi05`       | routes the wildcard training task to `Pi05Runner`                 |
-| `config_name`        | **required** — the registered openpi `TrainConfig` (positional)   |
+| `config_name`        | **required** — the registered openpi `TrainConfig` (positional to `train.py`, `--config-name` flag to `compute_norm_stats.py`) |
 | `exp_name`           | openpi `--exp-name`; defaults to the task name                     |
 | `overwrite`          | emit `--overwrite` (default `true`); clobbers the prior exp dir    |
 | `resume`             | emit `--resume` instead of `--overwrite`; continue latest ckpt    |

--- a/examples/quickstart-pi05-train/mission.yaml
+++ b/examples/quickstart-pi05-train/mission.yaml
@@ -1,0 +1,117 @@
+# π0.5 fine-tune quickstart (training-only).
+#
+# Fine-tunes a Physical Intelligence π0.5 (openpi) checkpoint on a LeRobot-format
+# demonstration set, via the odyssey `pi05` training runner -> openpi's
+# scripts/compute_norm_stats.py then scripts/train.py (two subprocesses).
+#
+# This base example is wired for the UR10e / Robotiq-2F85 drug-sort v0 dataset
+# (LeRobot v2.1, 60 eps, 7-DoF single-arm joint + gripper, exterior + wrist cams
+# @ 256x256) — the same demos the GR00T pilot finetunes on. Swap the dataset +
+# config_name for your own set.
+#
+# HOW openpi TRAINING WORKS (different from GR00T/OpenVLA):
+#   openpi is CONFIG-NAME-DRIVEN. Training selects a registered `TrainConfig`
+#   (here `pi05_ur10e_drugsort`) that bundles the data pipeline + weight loader +
+#   optimizer. You must ADD that config entry to openpi's
+#   src/openpi/training/config.py (the π0.5 analogue of GR00T's modality config
+#   file), with data.repo_id pointing at this dataset's folder name. Everything
+#   under `config:` below (except control keys) is forwarded as a tyro override.
+#   See examples/quickstart-pi05-train/README.md for the full recipe.
+#
+# Validate without a GPU:
+#   odyssey validate mission.yaml
+#   odyssey run mission.yaml --use-mock-runner
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: pi05-ur10e-drugsort-finetune
+  description: >-
+    Fine-tune π0.5 (openpi) on the UR10e drug-sort v0 LeRobot demos (7-DoF,
+    exterior + wrist cameras), producing a checkpoint deployable as the Pilot.
+  tags: [pi05, openpi, physical-intelligence, ur10e, robotiq, lerobot, training]
+
+objective: |
+  Fine-tune a π0.5 generalist on the browser-captured UR10e / Robotiq-2F85
+  pick-and-place demonstrations (ur10e_partial_cond_aug) so the resulting policy
+  can pick a vial and seat it in the rack.
+
+acceptance_criteria: |
+  The fine-tune produces a π0.5 checkpoint under the task output_dir
+  (checkpoints/<config_name>/<exp_name>/<step>) that loads and serves in an
+  openpi WebsocketPolicyServer. The honest task metric is the standalone
+  closed-loop grasp+place success against physics ground truth, not this run.
+
+robot:
+  # "ur10e" is not in the odyssey robot catalog; "ur5e" is and is used only for
+  # local catalog validation. The arm geometry is carried by the dataset, not
+  # this name (same convention as the GR00T ur10e mission).
+  embodiment: ur5e
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        # HF mirror of the openpi π0.5 base weights (Apache 2.0). Pilot-identity
+        # documentation only — openpi's weight_loader (inside the TrainConfig)
+        # is what actually pulls the base params for fine-tuning.
+        base: lerobot/pi05_base
+
+tasks:
+  - name: finetune-pi05-ur10e
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    dataset:
+      source: local
+      # ABSOLUTE path to the unpacked dataset ON THE TRAINING BOX (GPU VM). The
+      # pi05 runner sets HF_LEROBOT_HOME to this dir's PARENT so openpi's LeRobot
+      # loader resolves `data.repo_id` (below) == the folder name.
+      ref: /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+      format: lerobot
+    config:
+      # Routes this wildcard training task to the π0.5 runner (OpenVLA is the
+      # default; GR00T / π0.5 opt in by name).
+      runner: pi05
+      # REQUIRED: the registered openpi TrainConfig. Add this entry to openpi's
+      # src/openpi/training/config.py before running (see README).
+      config_name: pi05_ur10e_drugsort
+      # openpi computes dataset norm stats first (set false to skip if already
+      # cached under ./assets). Default is true.
+      compute_norm_stats: true
+
+      # --- tyro overrides forwarded to scripts/train.py -------------------------
+      # Nested dataclass fields use dots; underscores in a leaf become dashes
+      # (data.repo_id -> --data.repo-id). This links the config to THIS dataset's
+      # folder name (must match the HF_LEROBOT_HOME resolution above).
+      data:
+        repo_id: ur10e_partial_cond_aug
+      # Small-data fine-tune knobs — tune per your GPU / dataset size.
+      num_train_steps: 30000
+      batch_size: 32
+      # exp_name: defaults to the task name ("finetune-pi05-ur10e"); --overwrite
+      # is emitted by default so re-running clobbers the prior exp dir. Set
+      # `resume: true` to continue from the latest checkpoint instead.
+
+  # A Mission must declare exactly one evaluation task. For a UR10e-fine-tuned
+  # π0.5, LIBERO (Franka sim) is NOT an honest metric — different embodiment,
+  # action space and task. The honest metric is the STANDALONE closed-loop
+  # grasp+place success scored against physics ground truth (meta/gt), run here
+  # via `evaluation_type: custom` (the sim-agnostic CustomEvalRunner — issue #87
+  # / PR #88; falls back to the CPU mock until that runner ships on develop).
+  - name: eval-drugsort-closed-loop
+    kind: evaluation
+    evaluation_type: custom
+    benchmark_name: ur10e-drugsort-gt
+    num_episodes: 20
+    config:
+      # The eval script owns serving the fine-tuned checkpoint and scoring
+      # grasp+place against meta/gt. See the PILOT RUN_AND_EVAL.md recipe.
+      eval_script: scripts/eval_ur5e_drugsort_pi05.py
+
+leaderboard:
+  publish: false   # Backend not live yet.
+
+graph:
+  contribute: false   # Backend not live yet.

--- a/examples/quickstart-pi05-train/mission.yaml
+++ b/examples/quickstart-pi05-train/mission.yaml
@@ -44,10 +44,9 @@ acceptance_criteria: |
   closed-loop grasp+place success against physics ground truth, not this run.
 
 robot:
-  # "ur10e" is not in the odyssey robot catalog; "ur5e" is and is used only for
-  # local catalog validation. The arm geometry is carried by the dataset, not
-  # this name (same convention as the GR00T ur10e mission).
-  embodiment: ur5e
+  # ur10e is a registered embodiment (PR #86). Used for local catalog validation;
+  # the arm geometry is carried by the dataset, not this name.
+  embodiment: ur10e
   agents:
     - id: pilot
       role: PILOT

--- a/examples/quickstart-pi05-train/setup.sh
+++ b/examples/quickstart-pi05-train/setup.sh
@@ -140,7 +140,7 @@ cat <<EOF
        $OPENPI_DIR/.venv/bin/odyssey run      examples/quickstart-pi05-train/mission.yaml
 
      The runner then executes, in order:
-       python scripts/compute_norm_stats.py $CONFIG_NAME
+       python scripts/compute_norm_stats.py --config-name $CONFIG_NAME
        python scripts/train.py $CONFIG_NAME --exp-name <task> --overwrite [overrides]
      with cwd=<task output_dir>, so ./assets and ./checkpoints land under ~/.odyssey/runs.
 

--- a/examples/quickstart-pi05-train/setup.sh
+++ b/examples/quickstart-pi05-train/setup.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+#
+# Setup for the π0.5 (openpi) FINE-TUNE quickstart — single-GPU box (A100/H100 class).
+#
+# It ONLY sets things up — it does NOT run a mission and does NOT train.
+#
+# ─── ONE environment, by design (opposite of the eval quickstart) ──────────────────
+#  The EVAL quickstart (examples/quickstart-pi05/) uses TWO envs wired by host:port,
+#  because π0.5 is served out-of-process. TRAINING is different: the odyssey `pi05`
+#  runner shells out to openpi's own scripts (compute_norm_stats.py, train.py) via
+#  `sys.executable` — the SAME interpreter that runs `odyssey`. So openpi and odyssey
+#  must live in ONE env. This script builds openpi's uv env, then installs odyssey
+#  INTO it, and you run training via `<openpi>/.venv/bin/odyssey` (mirrors the
+#  validated GR00T recipe: `~/Isaac-GR00T/.venv/bin/odyssey`).
+#
+# ─── ⚠️ NOT YET VALIDATED ON HARDWARE ──────────────────────────────────────────────
+#  The odyssey-side wiring is complete + unit-tested on CPU, but no end-to-end π0.5
+#  fine-tune has been run through this script. Treat the openpi steps as a best-effort
+#  scaffold — confirm the exact `train.py` / `compute_norm_stats.py` flags and the
+#  TrainConfig registration against YOUR openpi version (see README.md).
+#
+# ─── FAST note ─────────────────────────────────────────────────────────────────────
+#  Nothing to install for FAST. π0.5 training uses a FAST-tokenized objective, but it
+#  is INTERNAL to openpi's `pi05` TrainConfig/model — the runner never touches it, and
+#  odyssey's pi05_fast.py (eval-side scaffolding) is not on this path.
+#
+# Usage:
+#   bash examples/quickstart-pi05-train/setup.sh
+#   bash examples/quickstart-pi05-train/setup.sh --openpi-dir ~/openpi --dataset /data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+#
+#   --openpi-dir PATH   openpi checkout / env (default: $HOME/openpi)
+#   --dataset PATH      unpacked LeRobot dataset dir (optional; sanity-checked + used
+#                       to print the HF_LEROBOT_HOME / data.repo_id linkage)
+#   --config-name NAME  openpi TrainConfig you will register (default: pi05_ur10e_drugsort)
+#   -h | --help         show this header
+#
+# Linux + NVIDIA GPU assumed. Re-runnable / idempotent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+OPENPI_DIR="${OPENPI_DIR:-$HOME/openpi}"
+DATASET=""
+CONFIG_NAME="pi05_ur10e_drugsort"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --openpi-dir) OPENPI_DIR="$2"; shift 2 ;;
+    --dataset) DATASET="$2"; shift 2 ;;
+    --config-name) CONFIG_NAME="$2"; shift 2 ;;
+    -h|--help) grep '^#' "$0" | grep -v '^#!' | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "unknown arg: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+command -v uv >/dev/null || {
+  echo "[setup] ERROR: 'uv' not found — install then re-run:" >&2
+  echo "  curl -LsSf https://astral.sh/uv/install.sh | sh && source ~/.bashrc" >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+echo "==> [1/4] openpi checkout ($OPENPI_DIR)"
+# ---------------------------------------------------------------------------
+if [ ! -d "$OPENPI_DIR/.git" ]; then
+  echo "[setup] cloning Physical-Intelligence/openpi into $OPENPI_DIR"
+  git clone https://github.com/Physical-Intelligence/openpi.git "$OPENPI_DIR"
+else
+  echo "[setup] openpi already at $OPENPI_DIR — reusing"
+fi
+
+# ---------------------------------------------------------------------------
+echo "==> [2/4] openpi training env (uv sync — JAX/torch, the FULL openpi, GPU deps)"
+# ---------------------------------------------------------------------------
+# This is the heavy step: it builds openpi's .venv from its lockfile (large
+# JAX/CUDA download). compute_norm_stats.py + train.py run from THIS env.
+if ( cd "$OPENPI_DIR" && uv sync ); then
+  echo "[setup] openpi env synced under $OPENPI_DIR/.venv"
+else
+  echo "[setup] ERROR: 'uv sync' in $OPENPI_DIR failed — finish it per openpi's README" >&2
+  echo "        (CUDA wheels, GIT_LFS_SKIP_SMUDGE, etc. may apply) before continuing." >&2
+  exit 1
+fi
+PYBIN="$OPENPI_DIR/.venv/bin/python"
+
+# ---------------------------------------------------------------------------
+echo "==> [3/4] install odyssey INTO the openpi env (so sys.executable sees both)"
+# ---------------------------------------------------------------------------
+# Base install only (no [dev]) — the training runner is pure subprocess
+# orchestration + the pydantic spec; it needs none of the heavy test/eval extras,
+# and keeping them out avoids clashing with openpi's pinned numpy/torch.
+uv pip install --python "$PYBIN" -e "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+echo "==> [4/4] verify the combined env"
+# ---------------------------------------------------------------------------
+"$PYBIN" - <<'PY'
+import importlib.util as u, sys
+missing = [m for m in ("odyssey", "openpi") if u.find_spec(m) is None]
+print(f"[setup] odyssey : {'OK' if u.find_spec('odyssey') else 'MISSING'}")
+print(f"[setup] openpi  : {'OK' if u.find_spec('openpi') else 'MISSING'}")
+if missing:
+    print(f"[setup] VERIFY FAILED: missing {missing}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+# Optional dataset sanity check + the repo_id linkage the runner relies on.
+DATA_HINT=""
+if [ -n "$DATASET" ]; then
+  if [ -f "$DATASET/meta/info.json" ]; then
+    HFLR="$(dirname "$DATASET")"
+    REPO_ID="$(basename "$DATASET")"
+    DATA_HINT=$'\n'"[setup] dataset OK: $DATASET"$'\n'"        -> runner sets HF_LEROBOT_HOME=$HFLR ; data.repo_id must be '$REPO_ID'"
+  else
+    echo "[setup] WARNING: $DATASET/meta/info.json not found — is this an unpacked LeRobot v2.1 dir?" >&2
+  fi
+fi
+
+cat <<EOF
+
+[setup] Done.${DATA_HINT}
+
+  Next — register the openpi TrainConfig (one-time), then run the fine-tune:
+
+  1) Add a TrainConfig named '$CONFIG_NAME' to:
+       $OPENPI_DIR/src/openpi/training/config.py
+     Base it on the shipped 'pi05_libero' config; point its data at your LeRobot
+     dataset (repo_id = the dataset folder name) and map the cameras
+     (observation.images.exterior -> base_0_rgb, .wrist -> left_wrist_0_rgb).
+     Drop the GR00T-only grasp_target channel. See README.md.
+
+  2) Export the checkout path so the runner finds openpi's scripts:
+       export OPENPI_REPO_PATH=$OPENPI_DIR
+
+  3) Run the mission with the openpi-env odyssey (NOT a system odyssey):
+       export OPENPI_REPO_PATH=$OPENPI_DIR
+       $OPENPI_DIR/.venv/bin/odyssey validate examples/quickstart-pi05-train/mission.yaml
+       $OPENPI_DIR/.venv/bin/odyssey run      examples/quickstart-pi05-train/mission.yaml
+
+     The runner then executes, in order:
+       python scripts/compute_norm_stats.py $CONFIG_NAME
+       python scripts/train.py $CONFIG_NAME --exp-name <task> --overwrite [overrides]
+     with cwd=<task output_dir>, so ./assets and ./checkpoints land under ~/.odyssey/runs.
+
+  First-run watch-list (see README + the PR's known gap):
+    * config_name must be registered in openpi's config.py (else train.py errors)
+    * data.repo_id in mission.yaml must equal the dataset folder name
+    * flow-matching model -> no FAST flags to pass; FAST is internal to openpi
+EOF

--- a/examples/ur5e-drugsort/browser_capture/README.md
+++ b/examples/ur5e-drugsort/browser_capture/README.md
@@ -1,0 +1,67 @@
+# Browser closed-loop eval harness
+
+`eval_browser_groot.js` scores a pick-and-place policy in the deployment
+renderer rather than in a native physics viewer, because the two do not agree:
+policies score differently the moment the pixels come from a different
+renderer, so the eval has to run where the policy will run.
+
+It drives a headless Chrome against the served scene, replays a frozen seeded
+fold of object start poses, queries the policy over HTTP, and writes a summary
+plus per-episode telemetry.
+
+## Prerequisites
+
+This harness is the scoring half of a stack it does not contain:
+
+| Needs | Provided by |
+|---|---|
+| The scene served over HTTP on `$PORT` | the deployment renderer app (external) |
+| `plans_eval.json` — the frozen fold | `precompute_plans.py --seed <fold>` |
+| A policy endpoint | your serving stack |
+| `puppeteer-core` + a Chrome binary | `npm install`; `$CHROME` |
+
+Run `npm install` in this directory — `node_modules/` is gitignored and must
+never be committed.
+
+## Configuration
+
+All via environment: `PLANS`, `OUT`, `PORT`, `AGENTS` (`groot` |
+`groot-observer`), `N`, `N_ACTION_STEPS`, `MAX_TICKS`, `CHROME`, `ARM`,
+`RAW_DUMP=1` to dump policy frames and ground truth for observer retraining.
+
+## Placement metrics — read this before quoting a number
+
+The harness emits three placement criteria per episode. They are not
+interchangeable, and the difference is large enough to invert a conclusion.
+
+| Field | Criterion | Use |
+|---|---|---|
+| `success` | lifted, then released near the target | coarse |
+| `seated` | within 5 cm laterally | **legacy — loose** |
+| `in_well` | within 4 mm laterally, base below the rim, upright | **the task** |
+
+`seated` was the historical criterion and it overstates placement badly: a
+5 cm tolerance passes an object resting on the rack surface next to the hole.
+Re-scoring one campaign against `in_well` moved it from 62.5% to 17.5%. Quote
+`in_well`; `seated` is retained only so older results remain comparable.
+
+`reltilt` is measured **at release**, not at rest — an object that lands
+upright after toppling off a rim is not a successful placement, and measuring
+at rest hides the cause. `tilt_ok` compares it against the geometric budget:
+past that angle the object's silhouette is wider than the opening and entry is
+impossible regardless of aim.
+
+## Physics overrides
+
+The harness mutates the physics at runtime — it disables collision on the arm
+and gripper geoms except the pads, and raises the solver's no-slip iterations.
+Neither is recorded in the scene file, so the scene on disk describes a
+different world than the numbers came from (issue #89).
+
+Every summary now carries a `physics_overrides` block naming exactly what was
+changed, also logged as `PHYSICS_OVERRIDES` on stdout. This makes the current
+behaviour honest; it does not remove the override. The eval still cannot
+observe arm self-collision or arm-environment contact, so a defect in the
+scene's arm collision geometry is invisible here and will only show up in
+native physics. Removing the override is a cross-repo change and #89 stays
+open for it.

--- a/examples/ur5e-drugsort/browser_capture/eval_browser_groot.js
+++ b/examples/ur5e-drugsort/browser_capture/eval_browser_groot.js
@@ -1,0 +1,320 @@
+// In-browser closed-loop GR00T eval for the render-gap close.
+//
+// Drives the REAL deployment path: loads the Lovell AI Robot Playground in headless
+// Chrome and, per attempt, POSTs the exterior+wrist Three.js frames + proprio to the
+// SAME same-origin proxy the deployed ?agents=groot pilot uses
+// (/api/groot/get_action -> agent-service -> GR00T HTTP/ZMQ bridge -> served
+// checkpoint), applies the returned absolute joint-target chunk, and scores
+// grasp+place success from the MuJoCo-WASM GT vial/pocket pose. Each attempt starts
+// from a randomized vial pose (from the eval plans.json) so baseline and new
+// checkpoint see the SAME initial poses -> a fair success RATE.
+//
+// This is the measurement that matters: the NEW in-browser success rate after
+// training on deployment-matched Three.js frames, vs the ~0 render-gap baseline.
+//
+// SAFE: own Chrome, UNIQUE --user-data-dir, PID captured + cleaned by PID. Read-only
+// page load; the only network write is the deployment proxy (exactly what deploy does).
+//
+// Env: PLANS OUT PORT(8021) AGENTS(groot|groot-observer) N N_ACTION_STEPS(8)
+//      MAX_TICKS(1000) CHROME PUPPETEER_CORE DISPLAY
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require(process.env.PUPPETEER_CORE || 'puppeteer-core');
+
+const PLANS = JSON.parse(fs.readFileSync(process.env.PLANS || 'plans_eval.json', 'utf8'));
+const OUT = process.env.OUT || path.resolve('eval_out');
+const RAW_DUMP = process.env.RAW_DUMP === '1';   // dump policy frames+GT for Observer retrain
+const RAW = path.join(OUT, 'raw');
+const PORT = process.env.PORT || '8021';
+const AGENTS = process.env.AGENTS || 'groot';                 // groot | groot-observer
+const N = process.env.N ? parseInt(process.env.N) : PLANS.plans.length;
+const N_ACTION_STEPS = process.env.N_ACTION_STEPS ? parseInt(process.env.N_ACTION_STEPS) : 8;
+const MAX_TICKS = process.env.MAX_TICKS ? parseInt(process.env.MAX_TICKS) : 900;
+const CHROME = process.env.CHROME || '/usr/bin/google-chrome-stable';
+const PROFILE = path.join(OUT, 'chrome-udd-eval-' + Date.now());
+const GL_ARGS = ['--use-gl=angle', '--use-angle=gl-egl', '--ignore-gpu-blocklist', '--enable-webgl', '--enable-gpu-rasterization'];
+// Solver no-slip iterations the eval RAISES at reset. This is a runtime physics
+// override NOT recorded in the scene XML (issue #89); pass it into RUN_ATTEMPT and
+// record it in the summary so a reader knows which physics produced the numbers.
+const NOSLIP_ITERATIONS = 20;
+const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+fs.mkdirSync(OUT, { recursive: true });
+
+// One-time page setup (mirrors browser_harness SETUP): ids, free arm collision,
+// deployment sensor cameras + capture, disable the rAF auto-stepper.
+const SETUP = () => {
+  const v = window.viewer, pm = v.physics, mj = pm.mj, m = pm.mjModel;
+  pm.enabled = false;
+  const OBJ_BODY = 1, OBJ_JNT = 3, OBJ_ACT = 19, OBJ_SITE = 6, OBJ_GEOM = 5, OBJ_KEY = 24;
+  const ANAMES = ['shoulder_pan', 'shoulder_lift', 'elbow', 'wrist_1', 'wrist_2', 'wrist_3'];
+  const armAct = ANAMES.map(n => mj.mj_name2id(m, OBJ_ACT, n));
+  const gripAct = mj.mj_name2id(m, OBJ_ACT, 'gr_fingers_actuator');
+  const armQadr = ANAMES.map(n => { const j = mj.mj_name2id(m, OBJ_JNT, n + '_joint'); return j >= 0 ? m.jnt_qposadr[j] : -1; });
+  const gj = mj.mj_name2id(m, OBJ_JNT, 'gr_right_driver_joint');
+  const gripQadr = gj >= 0 ? m.jnt_qposadr[gj] : -1;
+  const vialBody = mj.mj_name2id(m, OBJ_BODY, 'vial_0');
+  let vialQ = -1, vialDof = -1;
+  for (let j = 0; j < m.njnt; j++) { if (m.jnt_bodyid[j] === vialBody && m.jnt_type[j] === 0) { vialQ = m.jnt_qposadr[j]; vialDof = m.jnt_dofadr[j]; break; } }
+  const pocketSite = mj.mj_name2id(m, OBJ_SITE, 'pocket_0');
+  const pinchSite = mj.mj_name2id(m, OBJ_SITE, 'gr_pinch');   // near-miss telemetry (as probe_browser_groot.js)
+  const homeKey = mj.mj_name2id(m, OBJ_KEY, 'home');
+  const ARM_BODIES = new Set(['base', 'shoulder_link', 'upper_arm_link', 'forearm_link', 'wrist_1_link', 'wrist_2_link', 'wrist_3_link']);
+  // PHYSICS OVERRIDE (issue #89): disable contacts on every arm+gripper geom except
+  // the pads. This is a RUNTIME mutation NOT recorded in the scene XML, so the eval
+  // cannot observe arm self-collision or arm-vs-environment contact (e.g. the UR10e
+  // shoulder_link capsule through the ground plane is silently absent). Capture the
+  // pre-override no-slip default and exactly which bodies/geoms were freed so the
+  // summary is honest about the physics that produced the numbers.
+  const noslip_iterations_default = m.opt.noslip_iterations;
+  const contactDisabledBodies = new Set();
+  let contactDisabledGeoms = 0;
+  for (let g = 0; g < m.ngeom; g++) {
+    const bn = mj.mj_id2name(m, OBJ_BODY, m.geom_bodyid[g]) || '';
+    const gn = mj.mj_id2name(m, OBJ_GEOM, g) || '';
+    if ((ARM_BODIES.has(bn) || bn.startsWith('gr_')) && !gn.includes('pad')) {
+      m.geom_contype[g] = 0; m.geom_conaffinity[g] = 0;
+      contactDisabledBodies.add(bn); contactDisabledGeoms++;
+    }
+  }
+  const G = window.MultiAgentGroot;
+  const camExt = G.makeMjCamera(pm, mj, 'room');
+  const camWrist = G.makeMjCamera(pm, mj, 'wrist');
+  const cap = G.makeCapture(v.renderer);
+  window.__ev = { armAct, gripAct, armQadr, gripQadr, vialBody, vialQ, vialDof, pocketSite, pinchSite, homeKey, camExt, camWrist, cap };
+  return {
+    armAct, gripAct, vialBody, vialQ, pocketSite, pinchSite, homeKey,
+    physics_overrides: {
+      contact_disabled_bodies: Array.from(contactDisabledBodies).sort(),
+      contact_disabled_geoms: contactDisabledGeoms,
+      noslip_iterations_default,
+    },
+  };
+};
+
+// One in-browser GR00T attempt: randomized start -> closed-loop query/act -> score.
+const RUN_ATTEMPT = async (vialQpos, homeQ, cfg) => {
+  const H = window.__ev, v = window.viewer, pm = v.physics, mj = pm.mj, m = pm.mjModel, G = window.MultiAgentGroot;
+  const GRIP_CLOSE = 255, GRIP_RANGE = 0.8, SETTLE = 180;
+  const GRIP_HELD = 0.5, HOLD_M = 0.06;   // the 'still held' predicate
+  const setArm = q => { const c = pm.mjData.ctrl; for (let i = 0; i < 6; i++) if (H.armAct[i] >= 0) c[H.armAct[i]] = q[i]; };
+  const setGrip = g => { if (H.gripAct >= 0) pm.mjData.ctrl[H.gripAct] = g; };   // g in 0..255
+  const readArm = () => H.armQadr.map(a => a >= 0 ? pm.mjData.qpos[a] : 0);
+  const vialPose = () => { const b = H.vialBody, x = pm.mjData.xpos, q = pm.mjData.xquat; return [x[b * 3], x[b * 3 + 1], x[b * 3 + 2], q ? q[b * 4] : 1, q ? q[b * 4 + 1] : 0, q ? q[b * 4 + 2] : 0, q ? q[b * 4 + 3] : 0]; };
+  const pocketPose = () => { const s = H.pocketSite, sp = pm.mjData.site_xpos; return [sp[s * 3], sp[s * 3 + 1], sp[s * 3 + 2]]; };
+  // Telemetry-only (same as probe_browser_groot.js): closest gr_pinch approach to the vial.
+  const pinchPos = () => { const s = H.pinchSite, sp = pm.mjData.site_xpos; return s >= 0 ? [sp[s * 3], sp[s * 3 + 1], sp[s * 3 + 2]] : null; };
+  const dist3 = (a, b) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
+  const decim = Math.max(1, Math.round((1 / 20) / (m.opt.timestep || 0.002)));
+
+  // Randomized reset (same override the data-gen harness uses).
+  mj.mj_resetDataKeyframe(m, pm.mjData, H.homeKey);
+  { const qp = pm.mjData.qpos; for (let i = 0; i < 7; i++) qp[H.vialQ + i] = vialQpos[i]; }
+  { const dv = pm.mjData.qvel; for (let i = 0; i < 6; i++) dv[H.vialDof + i] = 0; }
+  // PHYSICS OVERRIDE (issue #89): raise the solver's no-slip iterations. Runtime
+  // mutation NOT in the scene XML; value comes from cfg.noslipIterations (recorded
+  // in the summary) so the numbers are traceable to the physics that produced them.
+  m.opt.noslip_iterations = (cfg && cfg.noslipIterations != null) ? cfg.noslipIterations : 20;
+  mj.mj_forward(m, pm.mjData);
+  for (let k = 0; k < SETTLE; k++) { setArm(homeQ); setGrip(0); mj.mj_step(m, pm.mjData); }
+
+  const z0 = vialPose()[2];
+  let zMax = z0, ticks = 0, queries = 0, gripCmd = 0, gripMax = 0, err = null, minPad = Infinity;
+  let relPose = null;   // vial pose at the last instant it was held
+  const url = cfg.agents === 'groot-observer' ? '/api/groot/get_action_observer' : '/api/groot/get_action';
+  // ALWAYS send a fresh per-episode session id: the sidecar keys its per-session
+  // state (phase machine, hold-last Observer target, v0.1 t_norm tick counter)
+  // by sid — without one, all 15 episodes share "default" and state leaks across
+  // episode boundaries (found in the Stage-B A/B).
+  const sid = (cfg.agents === 'groot-observer' ? 'obs-' : 'ep-') + Date.now() + '-' + Math.floor(Math.random() * 1e6);
+
+  // RAW_DUMP: capture the POLICY's own frame distribution (states + GT vial) for
+  // the Observer playground-retrain, so train-dist == inference-dist. Same format
+  // as browser_harness (perception_from_browser reads states + gt).
+  const DUMP = !!cfg.rawDump; const st_d = [], gt_d = []; let fi = 0, qc = 0;
+
+  while (ticks < cfg.maxTicks) {
+    const measured = readArm();
+    const state = [measured[0], measured[1], measured[2], measured[3], measured[4], measured[5], Math.max(0, Math.min(1, gripCmd))];
+    if (pm.syncVisuals) pm.syncVisuals();
+    const img = H.cap(v.scene, H.camExt.cam);
+    G.syncMjCamera(H.camWrist.cam, pm, mj, H.camWrist.id);
+    const imgWrist = H.cap(v.scene, H.camWrist.cam);
+    if (DUMP && (qc % 3 === 0)) {
+      const pad = String(fi).padStart(4, '0');
+      await window.__saveFrameEval(cfg.epRel + '/exterior/f' + pad + '.png', img.replace(/^data:image\/png;base64,/, ''));
+      await window.__saveFrameEval(cfg.epRel + '/wrist/f' + pad + '.png', imgWrist.replace(/^data:image\/png;base64,/, ''));
+      st_d.push([measured[0], measured[1], measured[2], measured[3], measured[4], measured[5], state[6]]);
+      gt_d.push({ vial: vialPose(), pocket: pocketPose(), phase: 'policy' });
+      fi++;
+    }
+    qc++;
+    const body = { image_b64: img, state, instruction: 'pick up the vial and place it in the rack', image_b64_wrist: imgWrist };
+    if (sid) body.sid = sid;
+    let res;
+    try {
+      const resp = await fetch(url, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) });
+      if (!resp.ok) { err = 'proxy ' + resp.status + ': ' + (await resp.text()).slice(0, 120); break; }
+      res = await resp.json();
+    } catch (e) { err = String(e); break; }
+    queries++;
+    const chunkQ = (res.chunk_q && res.chunk_q.length) ? res.chunk_q : [res.q];
+    const chunkG = (res.chunk_grip && res.chunk_grip.length) ? res.chunk_grip : [res.grip];
+    const n = Math.min(cfg.nActionSteps, chunkQ.length);
+    for (let i = 0; i < n; i++) {
+      gripCmd = Math.max(0, Math.min(1, chunkG[i]));
+      gripMax = Math.max(gripMax, gripCmd);
+      setArm(chunkQ[i]); setGrip(gripCmd * GRIP_CLOSE);
+      // Hold the action target for `decim` (=25) physics steps = one 20 Hz control
+      // step (mujoco-wasm mj_step takes no nstep arg, so loop explicitly — matches
+      // browser_harness + the deploy bridge.step(decim)).
+      for (let s = 0; s < decim; s++) mj.mj_step(m, pm.mjData);
+      const vz = vialPose()[2]; if (vz > zMax) zMax = vz;
+      const pinch = pinchPos(); if (pinch) { const d = dist3(pinch, vialPose()); if (d < minPad) minPad = d; }
+      // RELEASE POSE. The last instant the vial was actually held: gripper closed
+      // AND the vial still within HOLD_M of the pinch. Same predicate the offline
+      // trace analysis uses, so the two are comparable.
+      //
+      // This exists because reporting the FINAL tilt was useless. A vial that
+      // fails and topples reads ~90 deg however it was released, so the number was
+      // dominated by the outcome and could not say anything about the cause. The
+      // actionable quantity is the attitude at the moment the fingers open --
+      // past 12.1 deg an 18x40 mm vial is wider than the 26 mm hole and cannot
+      // enter it no matter how well aimed.
+      if (pinch && gripCmd > GRIP_HELD && dist3(pinch, vialPose()) < HOLD_M) relPose = vialPose();
+      ticks++;
+      if (ticks >= cfg.maxTicks) break;
+    }
+  }
+  const vp = vialPose(), pp = pocketPose();
+  const placeDist = Math.hypot(vp[0] - pp[0], vp[1] - pp[1]);
+  const lifted = (zMax - z0) > 0.02;
+  const seated = placeDist < 0.05 && vp[2] > 0.20;
+  // `seated` is a 5 cm test. The well it is meant to measure has 26 mm of inner
+  // span around an 18 mm vial, so the real constraint is 4 mm -- 12x tighter --
+  // and a vial balanced on the rim passes `seated` comfortably. Measured over
+  // the 40-episode GT set: seated 25/40, actually in the well 7/40.
+  //
+  // Geometry read off the single-pocket cell XML, not assumed:
+  //   vial  <geom size="0.009 0.02" cylinder>  r 9 mm, half-height 20 mm
+  //   well  walls +/-16 mm, 3 mm thick         inner span 26 mm, centred on pocket_0
+  //         pos z 0.0055, half-height 0.0175   top at +23 mm (rack frame)
+  //   site  pocket_0 at z 0.016                so the rim is pocket_z + 7 mm
+  //
+  // Two guards, because "below the rim" alone is satisfiable by accident: 14 of
+  // those 40 episodes end with the vial on the FLOOR (246 mm down), and the
+  // median final vial is tilted ~50 deg, i.e. lying on its side. Bound the depth
+  // and require it upright so the metric cannot be won by knocking the vial off
+  // the bench.
+  //
+  // ADDITIVE ONLY: `seated` and `success` keep their exact meaning so every
+  // historical fold number stays comparable. This is reported alongside them.
+  const baseAboveRim = (vp[2] - 0.020) - (pp[2] + 0.007);
+  const upright = 1 - 2 * (vp[4] * vp[4] + vp[5] * vp[5]);   // cos(tilt) vs world +z
+  const inWell = placeDist <= 0.004 && baseAboveRim < 0 && baseAboveRim > -0.050 && upright >= 0.90;
+  // LAYER 2: orientation, reported. Until now every stage of this stack treated
+  // the vial as a POINT -- the observer localises a position, the servo drives a
+  // position, and the success test checked a position -- so which way up it was
+  // pointing was invisible everywhere. That let a 40 deg tilt survive weeks of
+  // tuning: an 18x40 mm vial past 12.1 deg presents a silhouette wider than the
+  // 26 mm hole, so 90% of placements were geometrically impossible on arrival
+  // and no amount of aiming could have helped.
+  //
+  // TILT_BUDGET_DEG is derived, not measured by hand -- see task_spec.py, which
+  // computes it from the object's collision geoms and a ray-cast of the opening.
+  // Re-derive it for a new cell rather than editing it here.
+  const TILT_BUDGET_DEG = 12.1;
+  const tiltDeg = Math.acos(Math.max(-1, Math.min(1, upright))) * 180 / Math.PI;
+  // the one that can actually be acted on
+  const relUp = relPose ? 1 - 2 * (relPose[4] * relPose[4] + relPose[5] * relPose[5]) : null;
+  const relTiltDeg = relPose === null ? null
+    : Math.acos(Math.max(-1, Math.min(1, relUp))) * 180 / Math.PI;
+  // widest horizontal extent of the tilted vial: 2*(r*cos + h*sin)
+  const silhouetteMm = 2 * (0.009 * Math.cos(tiltDeg * Math.PI / 180)
+                          + 0.020 * Math.sin(tiltDeg * Math.PI / 180)) * 1000;
+  // scored on the RELEASE attitude, not where it ended up
+  const tiltOk = relTiltDeg !== null && relTiltDeg <= TILT_BUDGET_DEG;
+  return { success: (lifted && seated), lifted, seated, in_well: inWell, base_above_rim: baseAboveRim, upright, tilt_deg: tiltDeg, release_tilt_deg: relTiltDeg, tilt_ok: tiltOk, silhouette_mm: silhouetteMm, lift_height: zMax - z0, place_dist: placeDist, gripMax, queries, ticks, min_pad_to_vial: (minPad === Infinity ? null : minPad), error: err, states_d: st_d, gt_d: gt_d };
+};
+
+(async () => {
+  const browser = await puppeteer.launch({
+    executablePath: CHROME, headless: true, userDataDir: PROFILE, protocolTimeout: 900000,
+    env: { ...process.env, DISPLAY: process.env.DISPLAY || ':1' },
+    args: ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu-sandbox', '--window-size=1400,950', ...GL_ARGS],
+  });
+  const pid = browser.process().pid;
+  fs.writeFileSync(path.join(OUT, 'eval_pid.txt'), String(pid));
+  console.log('EVAL_CHROME_PID=' + pid + ' agents=' + AGENTS + ' port=' + PORT + ' N=' + N);
+  const page = await browser.newPage();
+  await page.setViewport({ width: 1400, height: 950 });
+  page.on('console', m => { const t = m.text(); if (/\[groot\]|error|observer/i.test(t)) console.log('  [page]', t.slice(0, 160)); });
+  // Load WITHOUT &agents= so the page's own runGrootAgents() never auto-fires; our
+  // RUN_ATTEMPT drives the /api/groot proxy directly (AGENTS only selects the endpoint).
+  const url = `http://localhost:${PORT}/robot-playground.html?demo=drugsorting${process.env.ARM ? `&arm=${process.env.ARM}` : ``}`;
+  console.log('GOTO', url);
+  await page.goto(url, { waitUntil: 'load', timeout: 120000 });
+  await page.waitForFunction(() => window.viewer && window.viewer.physics && window.viewer.physics.mj && window.viewer.physics.mjModel, { timeout: 120000 });
+  await page.waitForFunction(() => {
+    const pm = window.viewer.physics, mj = pm.mj; if (!pm.mjModel) return false;
+    return mj.mj_name2id(pm.mjModel, 1, 'vial_0') >= 0 && !!window.MultiAgentGroot;
+  }, { timeout: 120000 });
+  await sleep(1200);
+  const setupInfo = await page.evaluate(SETUP);
+
+  // Runtime physics mutations this harness applies that are NOT in the scene XML
+  // (issue #89): analysis against the cell XML studies a different world than these
+  // numbers came from. Record them so every summary is self-documenting.
+  const physicsOverrides = {
+    note: 'Runtime physics mutations applied by the eval harness that are NOT recorded in the scene XML (issue #89).',
+    contact_disabled_bodies: setupInfo.physics_overrides.contact_disabled_bodies,
+    contact_disabled_geoms: setupInfo.physics_overrides.contact_disabled_geoms,
+    noslip_iterations: NOSLIP_ITERATIONS,
+    noslip_iterations_default: setupInfo.physics_overrides.noslip_iterations_default,
+  };
+  console.log('PHYSICS_OVERRIDES ' + JSON.stringify(physicsOverrides));
+
+  // Confirm the deployment proxy is reachable/healthy before scoring.
+  const health = await page.evaluate(async () => { try { const r = await fetch('/api/groot/health'); return await r.json(); } catch (e) { return { error: String(e) }; } });
+  console.log('HEALTH ' + JSON.stringify(health));
+
+  if (RAW_DUMP) {
+    await page.exposeFunction('__saveFrameEval', (rel, b64) => {
+      const fp = path.join(RAW, rel); fs.mkdirSync(path.dirname(fp), { recursive: true });
+      fs.writeFileSync(fp, Buffer.from(b64, 'base64'));
+    });
+  }
+  const results = [];
+  const t0all = Date.now();
+  const plans = PLANS.plans.slice(0, N);
+  for (const plan of plans) {
+    const t0 = Date.now();
+    const epRel = 'ep' + String(plan.episode).padStart(3, '0');
+    const r = await page.evaluate(RUN_ATTEMPT, plan.vial_qpos, plan.home_q, { maxTicks: MAX_TICKS, nActionSteps: N_ACTION_STEPS, agents: AGENTS, rawDump: RAW_DUMP, epRel, noslipIterations: NOSLIP_ITERATIONS });
+    if (RAW_DUMP && r.states_d && r.states_d.length) {
+      fs.writeFileSync(path.join(RAW, epRel, 'meta.json'), JSON.stringify({ episode: plan.episode, success: r.success ? 1 : 0, states: r.states_d, gt: r.gt_d, actions: [] }));
+    }
+    delete r.states_d; delete r.gt_d;
+    const secs = (Date.now() - t0) / 1000;
+    results.push({ episode: plan.episode, ...r, seconds: +secs.toFixed(1) });
+    console.log(`ATT ep${String(plan.episode).padStart(3, '0')}: ${r.success ? 'SUCCESS' : (r.error ? 'ERROR:' + r.error : 'fail')} lifted=${r.lifted} seated=${r.seated} in_well=${r.in_well} reltilt=${r.release_tilt_deg===null?'n/a':r.release_tilt_deg.toFixed(1)+'deg'}${r.tilt_ok?'':'(OVER)'} endtilt=${r.tilt_deg.toFixed(1)}deg lift=${(r.lift_height * 100).toFixed(1)}cm place=${(r.place_dist * 100).toFixed(1)}cm rim=${(r.base_above_rim * 1000).toFixed(1)}mm pad=${r.min_pad_to_vial == null ? 'n/a' : (r.min_pad_to_vial * 100).toFixed(1) + 'cm'} grip=${r.gripMax.toFixed(2)} q=${r.queries} ${secs.toFixed(1)}s`);
+  }
+  const nSucc = results.filter(r => r.success).length;
+  const nLift = results.filter(r => r.lifted).length;
+  const nSeat = results.filter(r => r.seated).length;
+  const nWell = results.filter(r => r.in_well).length;
+  const nTiltOk = results.filter(r => r.tilt_ok).length;
+  const relTilts = results.map(r => r.release_tilt_deg).filter(v => v !== null).sort((a, b) => a - b);
+  const medRelTilt = relTilts.length ? relTilts[Math.floor(relTilts.length / 2)] : null;
+  const summary = {
+    agents: AGENTS, port: PORT, n_action_steps: N_ACTION_STEPS, max_ticks: MAX_TICKS,
+    n_attempts: results.length, n_success: nSucc, n_lifted: nLift, n_seated: nSeat, n_in_well: nWell, n_tilt_ok: nTiltOk, median_release_tilt_deg: medRelTilt,
+    success_rate: +(nSucc / results.length).toFixed(3), success: `${nSucc}/${results.length}`,
+    physics_overrides: physicsOverrides,
+    total_seconds: +((Date.now() - t0all) / 1000).toFixed(1), results,
+  };
+  fs.writeFileSync(path.join(OUT, `eval_${AGENTS}.json`), JSON.stringify(summary, null, 2));
+  console.log('EVAL_SUMMARY ' + JSON.stringify({ agents: AGENTS, success: summary.success, rate: summary.success_rate, lifted: nLift, seated: nSeat, in_well: nWell, tilt_ok: nTiltOk, med_reltilt: medRelTilt === null ? null : +medRelTilt.toFixed(1) }));
+  await browser.close();
+  try { fs.rmSync(PROFILE, { recursive: true, force: true }); } catch (e) {}
+  console.log('EVAL_DONE');
+})().catch(e => { console.error('EVAL_ERROR', e && e.stack || e); process.exit(1); });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "lovell-odyssey"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Open-source framework for defining, running, and benchmarking robot training missions."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/odyssey/__init__.py
+++ b/src/odyssey/__init__.py
@@ -1,3 +1,3 @@
 """Odyssey — open-source framework for robot training missions."""
 
-__version__ = "0.1.0a4"
+__version__ = "0.1.0a5"

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -35,6 +35,7 @@ from odyssey.runners import (
     OpenVLARunner,
     RunnerRegistry,
 )
+from odyssey.runners.evals.custom import CustomEvalRunner
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.libero import LiberoRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
@@ -57,6 +58,9 @@ def _build_runners() -> RunnerRegistry:
     registry.register(RobosuiteRunner())
     registry.register(IsaacLabRunner())
     registry.register(LiberoRunner())
+    # Exact (EVALUATION, "custom") match — beats the wildcard CPU mock so a real
+    # custom eval no longer falls through to a fake one.
+    registry.register(CustomEvalRunner())
     registry.register(CPUMockRunner())
     return registry
 

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -33,6 +33,7 @@ from odyssey.runners import (
     CPUMockRunner,
     GR00TRunner,
     OpenVLARunner,
+    Pi05Runner,
     RunnerRegistry,
 )
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
@@ -48,12 +49,14 @@ def _build_runners() -> RunnerRegistry:
     registry = RunnerRegistry()
     # Real runners first; CPU mock as a last-resort fallback so unfamiliar
     # task types still produce *something* instead of "no runner registered."
-    # OpenVLA and GR00T are both wildcard training runners — registration
-    # order makes OpenVLA the default; GR00T is selected per-task via
-    # ``config: {runner: gr00t}``. --use-mock-runner forces the mock
-    # through the engine's force_runner, not by thinning this registry.
+    # OpenVLA, GR00T and π0.5 are all wildcard training runners — registration
+    # order makes OpenVLA the default; GR00T / π0.5 are selected per-task via
+    # ``config: {runner: gr00t}`` / ``config: {runner: pi05}``. --use-mock-runner
+    # forces the mock through the engine's force_runner, not by thinning this
+    # registry.
     registry.register(OpenVLARunner())
     registry.register(GR00TRunner())
+    registry.register(Pi05Runner())
     registry.register(RobosuiteRunner())
     registry.register(IsaacLabRunner())
     registry.register(LiberoRunner())

--- a/src/odyssey/providers/local/robots.py
+++ b/src/odyssey/providers/local/robots.py
@@ -28,14 +28,19 @@ from odyssey.providers.base import ResolvedRobot, RobotProvider
 from odyssey.spec.mission import RobotSpec
 
 # Scoped to embodiments at least one shipped runner can actually drive
-# end-to-end. Today that means the arms Robosuite's built-in robot
-# models cover (``ROBOSUITE_ROBOT_NAMES`` in runners/evals/robosuite.py is the
-# matching translation table). Quadrupeds (unitree_go2/h1), mobile bases
-# (tiago, stretch3), and arms Robosuite doesn't ship (ur10e) were
-# removed in this trim — they accepted with a green spec, then produced
-# identical default-Panda eval runs that misled users about what was
-# being simulated. Re-add a name here only when a runner exists that
-# honors it; for unsupported robots, ``urdf:`` still works.
+# end-to-end. Two runners qualify a name today:
+#   * Robosuite — the arms its built-in robot models cover
+#     (``ROBOSUITE_ROBOT_NAMES`` in runners/evals/robosuite.py is the matching
+#     translation table).
+#   * the GR00T runner — arms it can finetune as a NEW_EMBODIMENT (e.g.
+#     ``ur10e``), which Robosuite doesn't ship and so stays outside
+#     ``ROBOSUITE_ROBOT_NAMES``.
+# The catalog is therefore a superset of the Robosuite-drivable names, not a
+# mirror of them. Quadrupeds (unitree_go2/h1) and mobile bases (tiago,
+# stretch3) remain excluded — with no runner that honors them they accepted
+# with a green spec, then produced identical default-Panda eval runs that
+# misled users about what was being simulated. Re-add a name here only when a
+# runner exists that drives it; for unsupported robots, ``urdf:`` still works.
 KNOWN_EMBODIMENTS: frozenset[str] = frozenset(
     {
         "franka_panda",   # alias of "panda" — common in OpenVLA / LeRobot specs

--- a/src/odyssey/providers/local/robots.py
+++ b/src/odyssey/providers/local/robots.py
@@ -45,6 +45,8 @@ KNOWN_EMBODIMENTS: frozenset[str] = frozenset(
         "jaco",
         "kinova_gen3",
         "ur5e",
+        "ur10e",          # driven by the GR00T runner (NEW_EMBODIMENT finetune),
+                          # not Robosuite — hence outside ROBOSUITE_ROBOT_NAMES.
         "baxter",
     }
 )

--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -27,6 +27,11 @@ from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
 from odyssey.runners.models.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
 from odyssey.runners.models.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
+from odyssey.runners.models.pi05_train import (
+    Pi05Runner,
+    build_pi05_train_argv,
+    parse_pi05_train_line,
+)
 from odyssey.runners.registry import RunnerRegistry
 from odyssey.runners.subprocess import (
     LineParser,
@@ -41,6 +46,7 @@ __all__ = [
     "IsaacLabRunner",
     "LineParser",
     "OpenVLARunner",
+    "Pi05Runner",
     "RobosuiteRunner",
     "Runner",
     "RunnerRegistry",
@@ -48,7 +54,9 @@ __all__ = [
     "TrainingProcessSpec",
     "build_gr00t_argv",
     "build_openvla_argv",
+    "build_pi05_train_argv",
     "parse_gr00t_line",
     "parse_openvla_line",
+    "parse_pi05_train_line",
     "run_training_subprocess",
 ]

--- a/src/odyssey/runners/evals/custom.py
+++ b/src/odyssey/runners/evals/custom.py
@@ -1,0 +1,269 @@
+"""Custom evaluation runner — run an arbitrary eval script as a subprocess.
+
+The runner for ``evaluation_type: custom``. It is deliberately decoupled from
+Isaac Lab / Robosuite / MuJoCo: no sim-specific argv (``--task``/``--headless``),
+no per-episode stdout protocol, and no policy-serving dependency. Odyssey owns
+the launch, the checkpoint path, cancellation, and reading a machine-readable
+metrics file; the *script* owns everything domain-specific — including how it
+loads or serves the checkpoint.
+
+Without this runner, ``evaluation_type: custom`` falls through to the wildcard
+``CPUMockRunner`` (a fake eval), so the only ways to run a real project-specific
+evaluation were to abuse the ``isaac_lab`` runner's contract or to mock it out.
+
+Launch contract::
+
+    <eval_python> <eval_script> \\
+        --checkpoint <path> --out-json <path> [--<config-key> <value> ...]
+
+* ``eval_script`` — ``task.config["eval_script"]`` or ``$ODYSSEY_EVAL_SCRIPT``
+  (required). The script that runs the evaluation.
+* ``eval_python`` — ``task.config["eval_python"]``, default ``sys.executable``.
+  Lets the script run under a separate venv (e.g. a GR00T / openpi env) without
+  Odyssey having to import those deps.
+* ``--checkpoint`` — the trained PILOT checkpoint (via ``resolve_eval_checkpoint``):
+  a local path or an HF repo id. The runner does **not** serve it — the script
+  loads/serves it however it needs (contrast the ``isaac_lab`` runner). This is
+  what keeps ``CustomEvalRunner`` free of any policy-serving dependency.
+* ``--out-json`` — a path the runner allocates under the task's output dir; the
+  script MUST write its metrics there as a JSON object (see below). This is the
+  metrics channel — there is no stdout protocol.
+* Every other ``config.*`` key passes through as ``--key value`` verbatim
+  (snake_case preserved), the same passthrough style as ``isaac_lab``.
+
+out-json contract — the script writes one JSON object; every key is optional::
+
+    {
+      "success_rate": 0.42,          # float — when present, the summary carries a
+      "performance_score": 0.7,      #   trainer letter grade + pass/fail
+      "num_episodes": 50,
+      "metrics": { ... }             # arbitrary extra metrics (e.g. per-joint MAE)
+    }
+
+Unknown top-level keys are folded into ``metrics``. When ``success_rate`` is
+absent the eval is treated as **metric-only** (e.g. the open-loop GT eval, whose
+honest metric is per-joint MAE + gripper agreement, not a success rate): the
+summary surfaces the metrics *without* fabricating a 0.0 / grade-F pass/fail.
+
+Serving is intentionally the script's job — there is no ``config.serve_checkpoint``.
+The motivating open-loop GT eval loads the checkpoint in-process, and delegating
+serving keeps this runner sim- and policy-server-agnostic. A closed-loop eval that
+needs a served policy starts (or connects to) the server from inside the script.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import Runner, TaskContext
+from odyssey.runners.evals._common import (
+    build_eval_summary,
+    resolve_eval_checkpoint,
+)
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    run_training_subprocess,
+)
+from odyssey.spec.tasks import EvaluationTask, EvaluationType, TaskKind
+
+logger = logging.getLogger(__name__)
+
+# Config keys the runner consumes itself, never forwarded as passthrough flags.
+# ``checkpoint`` is resolved by ``resolve_eval_checkpoint`` (config.checkpoint is
+# how eval-only missions name one) so it must not also appear as a flag.
+_HANDLED_CONFIG_KEYS = {"eval_script", "eval_python", "runner", "checkpoint", "out_json"}
+
+# Top-level out-json keys the runner interprets; anything else is folded into
+# ``metrics`` so a script can emit flat payloads too.
+_RESERVED_METRIC_KEYS = {"success_rate", "performance_score", "num_episodes", "metrics"}
+
+_METRICS_FILENAME = "custom_eval_metrics.json"
+
+
+def resolve_eval_script(config: dict[str, Any]) -> str:
+    """``task.config["eval_script"]`` or ``$ODYSSEY_EVAL_SCRIPT``."""
+    script = config.get("eval_script") or os.getenv("ODYSSEY_EVAL_SCRIPT")
+    if not script:
+        raise RuntimeError(
+            "Custom eval requires an eval script: set "
+            "task.config['eval_script'] (or $ODYSSEY_EVAL_SCRIPT) to a script "
+            "that accepts --checkpoint / --out-json and writes its metrics as a "
+            "JSON object. See src/odyssey/runners/evals/custom.py for the contract."
+        )
+    return str(script)
+
+
+def resolve_interpreter(config: dict[str, Any]) -> list[str]:
+    """Launcher for the eval script — ``[config['eval_python']]`` or the
+    interpreter Odyssey itself runs under (``sys.executable``)."""
+    return [str(config.get("eval_python") or sys.executable)]
+
+
+def build_custom_argv(
+    *,
+    checkpoint: Path,
+    out_json: Path,
+    config: dict[str, Any],
+) -> list[str]:
+    """Build the eval script's argv per the launch contract.
+
+    The runner owns ``--checkpoint`` and ``--out-json``; every other config key
+    passes through verbatim as ``--key value`` (snake_case preserved).
+    """
+    argv: list[str] = [
+        "--checkpoint", str(checkpoint),
+        "--out-json", str(out_json),
+    ]
+    for key, value in config.items():
+        if key in _HANDLED_CONFIG_KEYS:
+            continue
+        argv += [f"--{key}", str(value)]
+    return argv
+
+
+def read_metrics(out_json: Path) -> dict[str, Any]:
+    """Load the JSON object the script wrote to ``out_json``.
+
+    Raises when the file is missing (the script exited 0 but never wrote it),
+    isn't valid JSON, or isn't a JSON object — all script-contract violations.
+    """
+    if not out_json.is_file():
+        raise RuntimeError(
+            f"Custom eval script exited 0 but wrote no metrics file at {out_json}. "
+            "The script must write its results there as a JSON object (the "
+            "--out-json path). See src/odyssey/runners/evals/custom.py."
+        )
+    try:
+        payload = json.loads(out_json.read_text())
+    except json.JSONDecodeError as e:
+        raise RuntimeError(
+            f"Custom eval metrics file {out_json} is not valid JSON: {e}"
+        ) from e
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"Custom eval metrics file {out_json} must contain a JSON object, "
+            f"got {type(payload).__name__}."
+        )
+    return payload
+
+
+def summarize(
+    *,
+    payload: dict[str, Any],
+    spec: EvaluationTask,
+    checkpoint: Path,
+    eval_script: str,
+) -> dict[str, Any]:
+    """Turn the script's out-json payload into a ``result_summary``.
+
+    With ``success_rate`` present, routes through ``build_eval_summary`` so the
+    summary matches every other eval runner (letter grade + pass/fail). Without
+    it, returns a metric-only summary — the metrics stand on their own rather
+    than being forced into a pass/fail the eval never measured.
+    """
+    metrics = dict(payload.get("metrics") or {})
+    for key, value in payload.items():
+        if key not in _RESERVED_METRIC_KEYS:
+            metrics.setdefault(key, value)
+    metrics.setdefault("eval_script", eval_script)
+
+    num_episodes = int(payload.get("num_episodes", spec.num_episodes))
+
+    success_rate = payload.get("success_rate")
+    if success_rate is not None:
+        success_rate = float(success_rate)
+        performance_score = float(payload.get("performance_score", success_rate))
+        return build_eval_summary(
+            num_episodes=num_episodes,
+            successes=round(success_rate * num_episodes),
+            episode_returns=[],
+            benchmark_name=spec.benchmark_name,
+            checkpoint_path=checkpoint,
+            metrics=metrics,
+            success_rate=success_rate,
+            performance_score=performance_score,
+        )
+
+    # Metric-only eval (e.g. open-loop GT MAE): no pass/fail grade to report.
+    metrics.setdefault("benchmark", spec.benchmark_name)
+    metrics.setdefault("checkpoint_path", str(checkpoint))
+    return {
+        "num_episodes": num_episodes,
+        "metrics": metrics,
+    }
+
+
+class CustomEvalRunner(Runner):
+    """Evaluation runner for ``evaluation_type: custom`` tasks."""
+
+    @property
+    def name(self) -> str:
+        return "custom"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.EVALUATION}
+
+    @property
+    def supported_types(self) -> set[str]:
+        return {EvaluationType.CUSTOM.value}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, EvaluationTask):
+            raise TypeError(
+                f"CustomEvalRunner expects EvaluationTask, got {type(spec).__name__}"
+            )
+
+        config = spec.config or {}
+        checkpoint = resolve_eval_checkpoint(context)
+        eval_script = resolve_eval_script(config)
+        interpreter = resolve_interpreter(config)
+        out_json = self._metrics_path(context)
+
+        await context.emit_progress(
+            "executing",
+            step="launch",
+            step_label=(
+                f"script={Path(eval_script).name} "
+                f"python={Path(interpreter[0]).name}"
+            ),
+        )
+
+        process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
+            script_path=eval_script,
+            launcher=interpreter,
+            argv_extra=build_custom_argv(
+                checkpoint=checkpoint, out_json=out_json, config=config
+            ),
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("Custom eval task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"Custom eval script exited with code {rc}")
+
+        payload = read_metrics(out_json)
+        return summarize(
+            payload=payload,
+            spec=spec,
+            checkpoint=checkpoint,
+            eval_script=eval_script,
+        )
+
+    @staticmethod
+    def _metrics_path(context: TaskContext) -> Path:
+        """Where the script writes its metrics — under the task output dir when
+        the engine provided one, else a temp dir (context-free test setups)."""
+        base = context.output_dir or Path(tempfile.gettempdir())
+        base.mkdir(parents=True, exist_ok=True)
+        return base / _METRICS_FILENAME

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -72,14 +72,16 @@ hosted Lovell embodiment whose name isn't in
 """
 
 
-# Odyssey embodiment → Robosuite robot model. The map deliberately
-# mirrors the trimmed LocalRobotProvider.KNOWN_EMBODIMENTS so the same
-# names that pass spec validation also run end-to-end.
+# Odyssey embodiment → Robosuite robot model. This map is the
+# Robosuite-drivable *subset* of LocalRobotProvider.KNOWN_EMBODIMENTS: every
+# name here passes spec validation and runs end-to-end under Robosuite, but
+# the catalog is a superset — GR00T-only targets like ``ur10e`` validate yet
+# have no entry here (they run under the GR00T runner, not Robosuite).
 #
 # Anything missing here either has no Robosuite equivalent (Unitree
-# quadrupeds, Tiago, Stretch3) or hasn't been wired yet. For those,
-# operators can use ``urdf:`` and we'll fall through to Robosuite's
-# default robot for the benchmark.
+# quadrupeds, Tiago, Stretch3; GR00T-only arms like ur10e) or hasn't been
+# wired yet. For those, operators can use ``urdf:`` and we'll fall through to
+# Robosuite's default robot for the benchmark.
 ROBOSUITE_ROBOT_NAMES: dict[str, str] = {
     "franka_panda": "Panda",
     "panda": "Panda",

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -14,8 +14,11 @@ name (e.g. ``pi05_libero``) that bundles the data pipeline, weight loader and
 optimizer, and CLI ``--overrides`` (parsed by *tyro*) tweak individual fields.
 So the mission's ``config:`` here carries:
 
-  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig`` (positional
-    arg to both scripts). Fine-tuning a *new* embodiment/dataset means adding a
+  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig``. It reaches
+    the two scripts differently (see the argv builders): ``train.py`` takes it
+    **positionally** (``overridable_config_cli`` makes it a subcommand), while
+    ``compute_norm_stats.py`` takes it as a ``--config-name`` flag (plain
+    ``tyro.cli``). Fine-tuning a *new* embodiment/dataset means adding a
     config entry to openpi's ``src/openpi/training/config.py`` (the π0.5 analogue
     of GR00T's ``modality_config_path`` file) whose ``data.repo_id`` points at the
     LeRobot dataset — see ``examples/quickstart-pi05-train/README.md``.
@@ -25,8 +28,8 @@ So the mission's ``config:`` here carries:
 
 Two subprocesses, in order (openpi requires norm stats before training):
 
-  1. ``scripts/compute_norm_stats.py <config_name>`` — computes dataset
-     normalization statistics into ``assets/`` (skippable via
+  1. ``scripts/compute_norm_stats.py --config-name <config_name>`` — computes
+     dataset normalization statistics into ``assets/`` (skippable via
      ``config: {compute_norm_stats: false}`` when they already exist).
   2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
 

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -1,0 +1,338 @@
+"""π0.5 (openpi) training runner.
+
+Fine-tunes a Physical Intelligence π0.5 checkpoint by shelling out to the
+upstream **openpi** training entry points — the openpi package must be
+installed and its repo checked out on disk (``pip install -e`` of
+https://github.com/Physical-Intelligence/openpi), pointed at via
+``$OPENPI_REPO_PATH`` (default ``/srv/openpi``).
+
+Why this looks different from the GR00T / OpenVLA runners
+--------------------------------------------------------
+GR00T and OpenVLA take a flat bag of ``--flag value`` overrides. openpi is
+**config-name-driven**: training is selected by a registered ``TrainConfig``
+name (e.g. ``pi05_libero``) that bundles the data pipeline, weight loader and
+optimizer, and CLI ``--overrides`` (parsed by *tyro*) tweak individual fields.
+So the mission's ``config:`` here carries:
+
+  * ``config_name`` — REQUIRED, the registered openpi ``TrainConfig`` (positional
+    arg to both scripts). Fine-tuning a *new* embodiment/dataset means adding a
+    config entry to openpi's ``src/openpi/training/config.py`` (the π0.5 analogue
+    of GR00T's ``modality_config_path`` file) whose ``data.repo_id`` points at the
+    LeRobot dataset — see ``examples/quickstart-pi05-train/README.md``.
+  * everything else — passed through as tyro overrides (``num_train_steps`` →
+    ``--num-train-steps``, ``data.repo_id`` → ``--data.repo-id``). Booleans become
+    tyro flags (``--overwrite`` / ``--no-overwrite``), NOT ``--flag True``.
+
+Two subprocesses, in order (openpi requires norm stats before training):
+
+  1. ``scripts/compute_norm_stats.py <config_name>`` — computes dataset
+     normalization statistics into ``assets/`` (skippable via
+     ``config: {compute_norm_stats: false}`` when they already exist).
+  2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
+
+Both run with ``cwd = <task output_dir>`` so openpi's cwd-relative ``./assets``
+and ``./checkpoints`` land under the Odyssey task dir (no guessing an upstream
+``--checkpoint-base-dir`` flag name). openpi is import-resolved from the installed
+package, so the cwd only steers where artifacts are written.
+
+Routing: registered behind OpenVLA's wildcard training slot, reached via the
+task-level ``config: {runner: pi05}`` override — same mechanism as ``gr00t``.
+
+Licensing note: π0.5 weights are distributed under Physical Intelligence's terms.
+This runner contains no openpi code — it shells out to the user's own checkout.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import (
+    WILDCARD_TYPE,
+    Runner,
+    TaskContext,
+)
+
+# Shared flatten helper (dotted keys for nested dicts).
+from odyssey.runners.models.openvla import _flatten_config
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    output_path,
+    run_training_subprocess,
+)
+from odyssey.spec.refs import DatasetSource
+from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_REPO_PATH = "/srv/openpi"
+_TRAIN_SCRIPT_REL = "scripts/train.py"
+_NORM_STATS_SCRIPT_REL = "scripts/compute_norm_stats.py"
+
+# Config keys the runner consumes directly — never forwarded as tyro overrides.
+_CONTROL_KEYS = frozenset(
+    {"config_name", "runner", "exp_name", "overwrite", "resume", "compute_norm_stats"}
+)
+
+# openpi's train loop logs metrics dicts and a tqdm bar, e.g.:
+#   "step=1000 loss=0.234 grad_norm=1.2"
+#   "Step 1000: {'loss': 0.234, 'learning_rate': 1e-05}"
+#   " 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]"
+#   "Saving checkpoint to ./checkpoints/pi05_libero/exp/1000"
+_PI05_LOSS_RE = re.compile(r"(?:'loss':|\bloss=)\s*([\d.eE+-]+)")
+_PI05_STEP_RE = re.compile(r"(?:'step':|\bstep=|\bStep\s+)\s*(\d+)", re.IGNORECASE)
+_PI05_TQDM_RE = re.compile(r"\b(\d+)/(\d+)\s*\[")
+_PI05_SAVE_RE = re.compile(r"(?i)\b(saving|saved|wrote)\b.*\bcheckpoint\b")
+_PI05_NORM_RE = re.compile(r"(?i)\b(computing|writing)\b.*\bnorm(alization)?\s*stat")
+_PI05_DATASET_RE = re.compile(r"(?i)\b(loading|building)\b.*\b(dataset|lerobot)\b")
+
+
+def parse_pi05_train_line(line: str) -> dict[str, Any] | None:
+    """Extract a progress-event dict from an openpi train/norm-stats stdout line.
+
+    Public for tests and for users embedding openpi stdout parsing in a custom
+    runner. Precedence mirrors the GR00T parser: a metric line (loss / step)
+    wins over the coarse phase markers.
+    """
+    loss_match = _PI05_LOSS_RE.search(line)
+    step_match = _PI05_STEP_RE.search(line)
+    if loss_match or step_match:
+        payload: dict[str, Any] = {"stage": "executing", "step": "training_step"}
+        if step_match:
+            payload["step_index"] = int(step_match.group(1))
+        if loss_match:
+            payload["step_label"] = f"loss={loss_match.group(1)}"
+        return payload
+    tqdm_match = _PI05_TQDM_RE.search(line)
+    if tqdm_match:
+        return {
+            "stage": "executing",
+            "step": "training_step",
+            "step_index": int(tqdm_match.group(1)),
+            "step_total": int(tqdm_match.group(2)),
+        }
+    if _PI05_SAVE_RE.search(line):
+        return {"stage": "checkpoint_saving"}
+    if _PI05_NORM_RE.search(line):
+        return {"stage": "dataset_loading", "step": "compute_norm_stats"}
+    if _PI05_DATASET_RE.search(line):
+        return {"stage": "dataset_loading"}
+    return None
+
+
+def _resolve_openpi_script(rel: str) -> str:
+    """Absolute path to an openpi script under ``$OPENPI_REPO_PATH``.
+
+    Raises a runner-actionable error (not a bare FileNotFoundError) when the
+    checkout is missing, matching the OpenVLA runner's contract.
+    """
+    repo_path = os.getenv("OPENPI_REPO_PATH", _DEFAULT_REPO_PATH)
+    script_path = os.path.join(repo_path, rel)
+    if not os.path.isfile(script_path):
+        raise RuntimeError(
+            f"openpi script not found at {script_path!r}; clone "
+            "https://github.com/Physical-Intelligence/openpi and set "
+            "OPENPI_REPO_PATH (or place it at /srv/openpi)."
+        )
+    return script_path
+
+
+def _tyro_overrides(config: dict[str, Any]) -> list[str]:
+    """Flatten ``config`` into tyro CLI overrides, skipping control keys.
+
+    Nested dicts become dotted flags (``data.repo_id`` → ``--data.repo-id``);
+    booleans become tyro toggle flags (``--overwrite`` / ``--no-overwrite``)
+    rather than ``--flag True`` (which tyro rejects for bool fields).
+    """
+    argv: list[str] = []
+    for key, value in _flatten_config(config):
+        # _flatten_config yields the dotted path; only the LEAF may be a control
+        # key (nested overrides like data.repo_id are always forwarded).
+        if "." not in key and key in _CONTROL_KEYS:
+            continue
+        flag = f"--{key.replace('_', '-')}"
+        if isinstance(value, bool):
+            argv.append(flag if value else f"--no-{key.replace('_', '-')}")
+        else:
+            argv += [flag, str(value)]
+    return argv
+
+
+def build_pi05_train_argv(*, task: TrainingTask, exp_name: str) -> list[str]:
+    """Build the openpi ``scripts/train.py`` argv.
+
+    Shape: ``<config_name> --exp-name <name> [--overwrite|--resume] [overrides…]``.
+    ``config_name`` is REQUIRED — it selects the registered openpi ``TrainConfig``.
+    ``--overwrite`` is emitted by default (re-running a mission clobbers the prior
+    exp dir); set ``config: {overwrite: false}`` to keep it, or ``resume: true`` to
+    continue from the latest checkpoint instead.
+    """
+    config = task.config or {}
+    config_name = config.get("config_name")
+    if not config_name:
+        raise RuntimeError(
+            "π0.5 runner: config['config_name'] is required — it names the "
+            "registered openpi TrainConfig (e.g. 'pi05_libero'). Add a config "
+            "entry to openpi's src/openpi/training/config.py for a custom dataset."
+        )
+
+    argv: list[str] = [str(config_name), "--exp-name", exp_name]
+    if config.get("resume"):
+        argv.append("--resume")
+    elif config.get("overwrite", True):
+        argv.append("--overwrite")
+    argv += _tyro_overrides(config)
+    return argv
+
+
+def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
+    """Build the openpi ``scripts/compute_norm_stats.py`` argv.
+
+    Only the positional ``config_name`` is required; the dataset it reads is fixed
+    by the config's ``data`` factory.
+    """
+    config = task.config or {}
+    config_name = config.get("config_name")
+    if not config_name:
+        raise RuntimeError(
+            "π0.5 runner: config['config_name'] is required for norm-stats."
+        )
+    return [str(config_name)]
+
+
+def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
+    """Env overlay so openpi's LeRobot loader finds a LOCAL dataset.
+
+    openpi resolves ``data.repo_id`` against ``HF_LEROBOT_HOME`` (default
+    ``~/.cache/huggingface/lerobot``). For an absolute local dataset dir we point
+    that at the PARENT so ``repo_id`` == the dataset folder name resolves. HF/hub
+    refs and relative paths are left to the config to interpret.
+    """
+    if task.dataset is None:
+        return {}
+    ref = task.dataset.ref
+    if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
+        parent = os.path.dirname(os.path.normpath(ref))
+        # Set both the current and legacy var names — openpi/lerobot have used
+        # HF_LEROBOT_HOME and LEROBOT_HOME across versions.
+        return {"HF_LEROBOT_HOME": parent, "LEROBOT_HOME": parent}
+    return {}
+
+
+def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
+    """Locate the trained checkpoint under ``<output_dir>/checkpoints``.
+
+    openpi writes ``checkpoints/<config_name>/<exp_name>/<step>/`` (step is an
+    integer dir holding ``params/``). Return the highest-numbered step dir; None
+    if training wrote nothing.
+    """
+    checkpoints_root = output_dir / "checkpoints"
+    if not checkpoints_root.is_dir():
+        return None
+    best: tuple[int, Path] | None = None
+    for entry in checkpoints_root.rglob("*"):
+        if entry.is_dir() and entry.name.isdigit():
+            step = int(entry.name)
+            if best is None or step > best[0]:
+                best = (step, entry)
+    return best[1] if best is not None else None
+
+
+class Pi05Runner(Runner):
+    """Fine-tune a π0.5 model. Subprocess-based — actual training happens in
+    openpi's ``scripts/compute_norm_stats.py`` then ``scripts/train.py``."""
+
+    @property
+    def name(self) -> str:
+        return "pi05"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING}
+
+    @property
+    def supported_types(self) -> set[str]:
+        # Registered behind OpenVLA's wildcard; reached via the task-level
+        # ``config: {runner: pi05}`` override (same pattern as GR00T).
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, TrainingTask):
+            raise TypeError(
+                f"Pi05Runner expects TrainingTask, got {type(spec).__name__}"
+            )
+        if context.agent is None:
+            raise RuntimeError(
+                "Pi05Runner: TaskContext.agent is None — training tasks must be "
+                "invoked through the engine, which resolves the agent from "
+                "spec.robot.agents[task.agent_id]."
+            )
+
+        output_dir = output_path(context)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        config = dict(spec.config)
+        exp_name = str(config.get("exp_name") or spec.name)
+        timeout = getattr(spec, "timeout_seconds", None)
+        child_env = _lerobot_env_for_dataset(spec)
+
+        # Step 1: normalization statistics (openpi requires them before training).
+        if config.get("compute_norm_stats", True):
+            await context.emit_progress(
+                "dataset_loading", step="compute_norm_stats", step_label=exp_name
+            )
+            norm_spec = TrainingProcessSpec(
+                timeout_seconds=timeout,
+                script_path=_resolve_openpi_script(_NORM_STATS_SCRIPT_REL),
+                argv_extra=build_pi05_norm_stats_argv(task=spec),
+                env=child_env,
+                cwd=str(output_dir),
+                line_parser=parse_pi05_train_line,
+            )
+            rc = await run_training_subprocess(context, norm_spec)
+            if context.cancelled():
+                logger.info("π0.5 task %s cancelled during norm-stats", context.task.id)
+                return {"cancelled": True}
+            if rc != 0:
+                raise RuntimeError(
+                    f"openpi compute_norm_stats exited with code {rc}"
+                )
+
+        # Step 2: fine-tune.
+        train_spec = TrainingProcessSpec(
+            timeout_seconds=timeout,
+            script_path=_resolve_openpi_script(_TRAIN_SCRIPT_REL),
+            argv_extra=build_pi05_train_argv(task=spec, exp_name=exp_name),
+            env=child_env,
+            cwd=str(output_dir),
+            line_parser=parse_pi05_train_line,
+        )
+        rc = await run_training_subprocess(context, train_spec)
+        if context.cancelled():
+            logger.info("π0.5 task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"openpi train.py exited with code {rc}")
+
+        checkpoint = _resolve_output_checkpoint(output_dir)
+        if checkpoint is None:
+            raise RuntimeError(
+                f"openpi train.py finished but no checkpoint found under "
+                f"{output_dir / 'checkpoints'!r}"
+            )
+        return {
+            "checkpoint_path": str(checkpoint),
+            "agent_id": context.agent.id,
+            "exp_name": exp_name,
+            "config_name": config.get("config_name"),
+            "training_config": spec.config,
+            "training_type": (
+                spec.training_type.value
+                if isinstance(spec.training_type, TrainingType)
+                else spec.training_type
+            ),
+        }

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -30,7 +30,10 @@ Two subprocesses, in order (openpi requires norm stats before training):
 
   1. ``scripts/compute_norm_stats.py --config-name <config_name>`` — computes
      dataset normalization statistics into ``assets/`` (skippable via
-     ``config: {compute_norm_stats: false}`` when they already exist).
+     ``config: {compute_norm_stats: false}`` when they already exist). Results are
+     cached across runs per ``<config_name>/<repo_id>``; set
+     ``config: {norm_stats_cache: false}`` to force a recompute when a dataset's
+     content changed under an unchanged ``repo_id``.
   2. ``scripts/train.py <config_name> --exp-name <name> [--overwrite] [overrides]``.
 
 Both run with ``cwd = <task output_dir>`` so openpi's cwd-relative ``./assets``
@@ -78,7 +81,15 @@ _NORM_STATS_SCRIPT_REL = "scripts/compute_norm_stats.py"
 
 # Config keys the runner consumes directly — never forwarded as tyro overrides.
 _CONTROL_KEYS = frozenset(
-    {"config_name", "runner", "exp_name", "overwrite", "resume", "compute_norm_stats"}
+    {
+        "config_name",
+        "runner",
+        "exp_name",
+        "overwrite",
+        "resume",
+        "compute_norm_stats",
+        "norm_stats_cache",
+    }
 )
 
 # openpi's train loop logs metrics dicts and a tqdm bar, e.g.:
@@ -248,7 +259,27 @@ def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
     return best[1] if best is not None else None
 
 
-def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | None, bool]:
+def _dataset_repo_id(task: TrainingTask) -> str:
+    """The LeRobot ``repo_id`` openpi keys norm stats by.
+
+    openpi writes ``assets/<config_name>/<repo_id>/norm_stats.json``. ``repo_id``
+    is the mission's ``data.repo_id`` tyro override when present, else the local
+    dataset folder name (same source as ``_lerobot_env_for_dataset``). Empty when
+    neither is set — the registered config's *default* repo_id is then not known
+    to the runner, so the cache cannot be pinned and must recompute.
+    """
+    config = task.config or {}
+    data = config.get("data")
+    if isinstance(data, dict) and data.get("repo_id"):
+        return str(data["repo_id"])
+    if task.dataset is not None and task.dataset.ref:
+        return os.path.basename(os.path.normpath(task.dataset.ref))
+    return ""
+
+
+def _link_norm_stats_cache(
+    output_dir: Path, config_name: str, repo_id: str
+) -> tuple[Path | None, bool]:
     """Point openpi's cwd-relative ``./assets`` at a STABLE per-config cache.
 
     openpi writes norm stats into ``./assets`` relative to cwd (= the per-run
@@ -257,6 +288,15 @@ def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | N
     ``output_dir/assets`` at a stable cache keyed by ``config_name`` so the stats
     persist and are reused across runs; checkpoints still land in the per-run
     ``output_dir/checkpoints`` (only ``./assets`` is redirected).
+
+    The cache-hit test is keyed on the EXACT ``<config_name>/<repo_id>`` path
+    openpi writes, not a recursive glob: one registered config can hold stats for
+    several datasets (iterating datasets against one config is the intended
+    workflow, and what the shipped example does via ``data.repo_id``), so a glob
+    would report a hit for *any* dataset under the config, skip the step, and then
+    ``train.py`` dies looking for the ``repo_id`` it actually needs. An empty
+    ``repo_id`` (config default, unknown here) recomputes rather than risk a wrong
+    hit.
 
     Returns ``(cache_dir, already_has_norm_stats)``; ``(None, False)`` when there
     is no config_name to key the cache on.
@@ -268,7 +308,9 @@ def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | N
     link = output_dir / "assets"
     if not link.is_symlink() and not link.exists():
         link.symlink_to(cache, target_is_directory=True)
-    cached = any(cache.rglob("norm_stats.json"))
+    cached = bool(repo_id) and (
+        cache / config_name / repo_id / "norm_stats.json"
+    ).is_file()
     return cache, cached
 
 
@@ -312,8 +354,24 @@ class Pi05Runner(Runner):
         child_env = _lerobot_env_for_dataset(spec)
 
         # Redirect openpi's ./assets at a stable per-config cache so norm stats are
-        # computed once and reused, not recomputed on every fresh output_dir.
-        assets_cache, norm_cached = _link_norm_stats_cache(output_dir, config_name)
+        # computed once and reused, not recomputed on every fresh output_dir. The
+        # hit is keyed on the exact dataset (config_name + repo_id). Escape hatch:
+        # the cache has no content-fingerprint, so a dataset recaptured under the
+        # SAME repo_id would silently reuse stale stats — set
+        # ``config: {norm_stats_cache: false}`` to force a fresh recompute into the
+        # per-run dir (no shared cache) when the dataset content has changed.
+        if config.get("norm_stats_cache", True):
+            repo_id = _dataset_repo_id(spec)
+            assets_cache, norm_cached = _link_norm_stats_cache(
+                output_dir, config_name, repo_id
+            )
+        else:
+            logger.warning(
+                "π0.5 task %s: norm-stats cache disabled (norm_stats_cache=false)"
+                " — recomputing statistics into the per-run assets dir.",
+                context.task.id,
+            )
+            assets_cache, norm_cached = None, False
 
         # Step 1: normalization statistics (openpi requires them before training).
         # Skip when a prior run already cached them for this config.

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -192,8 +192,10 @@ def build_pi05_train_argv(*, task: TrainingTask, exp_name: str) -> list[str]:
 def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
     """Build the openpi ``scripts/compute_norm_stats.py`` argv.
 
-    Only the positional ``config_name`` is required; the dataset it reads is fixed
-    by the config's ``data`` factory.
+    Unlike ``train.py`` (positional config name via ``overridable_config_cli``),
+    ``compute_norm_stats.py`` is a plain ``tyro.cli(main)`` whose ``config_name``
+    parameter is exposed as a REQUIRED ``--config-name`` flag. The dataset it reads
+    is fixed by the config's ``data`` factory.
     """
     config = task.config or {}
     config_name = config.get("config_name")
@@ -201,7 +203,7 @@ def build_pi05_norm_stats_argv(*, task: TrainingTask) -> list[str]:
         raise RuntimeError(
             "π0.5 runner: config['config_name'] is required for norm-stats."
         )
-    return [str(config_name)]
+    return ["--config-name", str(config_name)]
 
 
 def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -248,6 +248,30 @@ def _resolve_output_checkpoint(output_dir: Path) -> Path | None:
     return best[1] if best is not None else None
 
 
+def _link_norm_stats_cache(output_dir: Path, config_name: str) -> tuple[Path | None, bool]:
+    """Point openpi's cwd-relative ``./assets`` at a STABLE per-config cache.
+
+    openpi writes norm stats into ``./assets`` relative to cwd (= the per-run
+    output_dir), so a fresh output_dir every run recomputes the *deterministic*
+    stats from scratch — a multi-minute full-dataset scan each time. Symlink
+    ``output_dir/assets`` at a stable cache keyed by ``config_name`` so the stats
+    persist and are reused across runs; checkpoints still land in the per-run
+    ``output_dir/checkpoints`` (only ``./assets`` is redirected).
+
+    Returns ``(cache_dir, already_has_norm_stats)``; ``(None, False)`` when there
+    is no config_name to key the cache on.
+    """
+    if not config_name:
+        return None, False
+    cache = Path.home() / ".odyssey" / "pi05_assets" / config_name
+    cache.mkdir(parents=True, exist_ok=True)
+    link = output_dir / "assets"
+    if not link.is_symlink() and not link.exists():
+        link.symlink_to(cache, target_is_directory=True)
+    cached = any(cache.rglob("norm_stats.json"))
+    return cache, cached
+
+
 class Pi05Runner(Runner):
     """Fine-tune a π0.5 model. Subprocess-based — actual training happens in
     openpi's ``scripts/compute_norm_stats.py`` then ``scripts/train.py``."""
@@ -282,12 +306,18 @@ class Pi05Runner(Runner):
         output_dir = output_path(context)
         output_dir.mkdir(parents=True, exist_ok=True)
         config = dict(spec.config)
+        config_name = str(config.get("config_name") or "")
         exp_name = str(config.get("exp_name") or spec.name)
         timeout = getattr(spec, "timeout_seconds", None)
         child_env = _lerobot_env_for_dataset(spec)
 
+        # Redirect openpi's ./assets at a stable per-config cache so norm stats are
+        # computed once and reused, not recomputed on every fresh output_dir.
+        assets_cache, norm_cached = _link_norm_stats_cache(output_dir, config_name)
+
         # Step 1: normalization statistics (openpi requires them before training).
-        if config.get("compute_norm_stats", True):
+        # Skip when a prior run already cached them for this config.
+        if config.get("compute_norm_stats", True) and not norm_cached:
             await context.emit_progress(
                 "dataset_loading", step="compute_norm_stats", step_label=exp_name
             )
@@ -307,6 +337,15 @@ class Pi05Runner(Runner):
                 raise RuntimeError(
                     f"openpi compute_norm_stats exited with code {rc}"
                 )
+        elif norm_cached:
+            logger.info(
+                "π0.5 task %s: reusing cached norm stats at %s",
+                context.task.id,
+                assets_cache,
+            )
+            await context.emit_progress(
+                "dataset_loading", step="norm_stats_cached", step_label=exp_name
+            )
 
         # Step 2: fine-tune.
         train_spec = TrainingProcessSpec(

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -217,9 +217,10 @@ def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
     ref = task.dataset.ref
     if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
         parent = os.path.dirname(os.path.normpath(ref))
-        # Set both the current and legacy var names — openpi/lerobot have used
-        # HF_LEROBOT_HOME and LEROBOT_HOME across versions.
-        return {"HF_LEROBOT_HOME": parent, "LEROBOT_HOME": parent}
+        # Only HF_LEROBOT_HOME — do NOT also set the legacy LEROBOT_HOME. Recent
+        # lerobot HARD-FAILS at import (raises ValueError) if the deprecated
+        # LEROBOT_HOME var is present, which killed compute_norm_stats.
+        return {"HF_LEROBOT_HOME": parent}
     return {}
 
 

--- a/tests/unit/test_custom_eval.py
+++ b/tests/unit/test_custom_eval.py
@@ -1,0 +1,365 @@
+"""Tests for the custom evaluation runner (``evaluation_type: custom``).
+
+No GPU and no real policy here — the runner's testable pieces are the launch
+contract (argv, script/interpreter resolution), the out-json metrics parsing,
+and summary scoring for both the graded (``success_rate``) and metric-only
+paths. One integration-ish test runs a fake eval script (plain python that
+writes an out-json) through the real subprocess machinery end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.engine import TaskStatus
+from odyssey.engine.records import MissionRun
+from odyssey.runners.base import TaskContext
+from odyssey.runners.evals.custom import (
+    CustomEvalRunner,
+    build_custom_argv,
+    read_metrics,
+    resolve_eval_script,
+    resolve_interpreter,
+    summarize,
+)
+from odyssey.spec import (
+    AgentRole,
+    AgentSpec,
+    EvaluationTask,
+    EvaluationType,
+    HFModelRef,
+    Mission,
+    MissionMetadata,
+    RobotSpec,
+    TrainingTask,
+    TrainingType,
+)
+from odyssey.telemetry import EventPublisher
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "eval-custom",
+        "evaluation_type": EvaluationType.CUSTOM,
+        "benchmark_name": "openloop-gt",
+        "num_episodes": 50,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# Launch contract
+# ---------------------------------------------------------------------------
+
+def test_argv_contains_owned_flags(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path / "ckpt", out_json=tmp_path / "m.json", config={}
+    )
+    assert argv[argv.index("--checkpoint") + 1] == str(tmp_path / "ckpt")
+    assert argv[argv.index("--out-json") + 1] == str(tmp_path / "m.json")
+
+
+def test_argv_passthrough_keeps_snake_case(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path,
+        out_json=tmp_path / "m.json",
+        config={"replay_dataset": "/data/ur10e", "max_frames": 200},
+    )
+    assert argv[argv.index("--replay_dataset") + 1] == "/data/ur10e"
+    assert argv[argv.index("--max_frames") + 1] == "200"
+
+
+def test_argv_omits_isaac_specific_flags(tmp_path: Path) -> None:
+    # Custom is decoupled from Isaac Lab: no --task / --headless, and
+    # num_episodes is not auto-forwarded (the script asks for what it needs).
+    argv = build_custom_argv(checkpoint=tmp_path, out_json=tmp_path / "m.json", config={})
+    assert "--task" not in argv
+    assert "--headless" not in argv
+    assert "--num_episodes" not in argv
+
+
+def test_argv_excludes_handled_keys(tmp_path: Path) -> None:
+    argv = build_custom_argv(
+        checkpoint=tmp_path,
+        out_json=tmp_path / "m.json",
+        config={
+            "eval_script": "/x.py",
+            "eval_python": "/venv/bin/python",
+            "runner": "custom",
+            "checkpoint": "/should/not/leak",
+            "out_json": "/nope",
+        },
+    )
+    for handled in ("--eval_script", "--eval_python", "--runner", "--out_json"):
+        assert handled not in argv
+    # checkpoint is resolved by the runner; the config key must not double up
+    # as a passthrough flag pointing at a different path.
+    assert argv.count("--checkpoint") == 1
+    assert "/should/not/leak" not in argv
+
+
+def test_eval_script_from_config() -> None:
+    assert resolve_eval_script({"eval_script": "/opt/eval.py"}) == "/opt/eval.py"
+
+
+def test_eval_script_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ODYSSEY_EVAL_SCRIPT", "/env/eval.py")
+    assert resolve_eval_script({}) == "/env/eval.py"
+
+
+def test_eval_script_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ODYSSEY_EVAL_SCRIPT", raising=False)
+    with pytest.raises(RuntimeError, match="eval script"):
+        resolve_eval_script({})
+
+
+def test_interpreter_defaults_to_sys_executable() -> None:
+    assert resolve_interpreter({}) == [sys.executable]
+
+
+def test_interpreter_from_config() -> None:
+    assert resolve_interpreter({"eval_python": "/venv/bin/python"}) == ["/venv/bin/python"]
+
+
+# ---------------------------------------------------------------------------
+# Metrics parsing
+# ---------------------------------------------------------------------------
+
+def test_read_metrics_loads_object(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text(json.dumps({"success_rate": 0.4, "metrics": {"mae": 0.1}}))
+    assert read_metrics(out) == {"success_rate": 0.4, "metrics": {"mae": 0.1}}
+
+
+def test_read_metrics_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="wrote no metrics file"):
+        read_metrics(tmp_path / "absent.json")
+
+
+def test_read_metrics_invalid_json_raises(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text("{not json")
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        read_metrics(out)
+
+
+def test_read_metrics_non_object_raises(tmp_path: Path) -> None:
+    out = tmp_path / "m.json"
+    out.write_text("[1, 2, 3]")
+    with pytest.raises(RuntimeError, match="must contain a JSON object"):
+        read_metrics(out)
+
+
+# ---------------------------------------------------------------------------
+# Summary scoring
+# ---------------------------------------------------------------------------
+
+def test_summary_graded_when_success_rate_present(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={
+            "success_rate": 0.9,
+            "performance_score": 0.8,
+            "num_episodes": 20,
+            "metrics": {"lift": 18, "seat": 16},
+        },
+        spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt",
+        eval_script="/opt/eval.py",
+    )
+    assert summary["success_rate"] == 0.9
+    assert summary["performance_score"] == 0.8
+    assert summary["letter_grade"] == "A"
+    assert summary["passed"] is True
+    assert summary["num_episodes"] == 20
+    assert summary["metrics"]["lift"] == 18
+    assert summary["metrics"]["eval_script"] == "/opt/eval.py"
+
+
+def test_summary_performance_defaults_to_success_rate(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={"success_rate": 0.5},
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert summary["performance_score"] == 0.5
+
+
+def test_summary_metric_only_has_no_pass_fail(tmp_path: Path) -> None:
+    # The open-loop GT case: per-joint MAE, no success_rate. The summary must
+    # carry the metrics without fabricating a 0.0 / grade-F pass/fail.
+    summary = summarize(
+        payload={"metrics": {"joint_mae": [0.01, 0.02], "gripper_agreement": 0.97}},
+        spec=_eval_task(),
+        checkpoint=tmp_path / "ckpt",
+        eval_script="/opt/eval_openloop_gt.py",
+    )
+    assert "letter_grade" not in summary
+    assert "passed" not in summary
+    assert "success_rate" not in summary
+    assert summary["metrics"]["gripper_agreement"] == 0.97
+    assert summary["metrics"]["benchmark"] == "openloop-gt"
+    assert summary["num_episodes"] == 50  # falls back to spec.num_episodes
+
+
+def test_summary_folds_unknown_top_level_keys_into_metrics(tmp_path: Path) -> None:
+    summary = summarize(
+        payload={"joint_mae": 0.03, "notes": "replay of 200 frames"},
+        spec=_eval_task(),
+        checkpoint=tmp_path,
+        eval_script="/opt/eval.py",
+    )
+    assert summary["metrics"]["joint_mae"] == 0.03
+    assert summary["metrics"]["notes"] == "replay of 200 frames"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real subprocess machinery
+# ---------------------------------------------------------------------------
+
+class _NullPublisher(EventPublisher):
+    async def publish(self, event_type: str, payload: dict[str, Any]) -> None:
+        pass
+
+
+# A fake eval script: reads --checkpoint / --out-json, writes a metrics object.
+# Mirrors what scripts/eval_openloop_gt.py does, minus the model.
+FAKE_EVAL_SCRIPT = """\
+import argparse, json
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+p.add_argument("--replay_dataset", required=True)
+args = p.parse_args()
+with open(args.out_json, "w") as f:
+    json.dump(
+        {"metrics": {"joint_mae": 0.012, "gripper_agreement": 0.98,
+                     "checkpoint_seen": args.checkpoint,
+                     "replay": args.replay_dataset}},
+        f,
+    )
+"""
+
+FAKE_EVAL_SCRIPT_GRADED = """\
+import argparse, json
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+args = p.parse_args()
+with open(args.out_json, "w") as f:
+    json.dump({"success_rate": 0.75, "num_episodes": 8}, f)
+"""
+
+FAKE_EVAL_SCRIPT_NO_OUTPUT = """\
+import argparse
+p = argparse.ArgumentParser()
+p.add_argument("--checkpoint", required=True)
+p.add_argument("--out-json", required=True)
+p.parse_args()  # exits 0 but writes nothing
+"""
+
+
+def _context_for(spec_task: EvaluationTask, tmp_path: Path) -> TaskContext:
+    mission = Mission(
+        metadata=MissionMetadata(name="msn-custom"),
+        objective="objective",
+        acceptance_criteria="acceptance",
+        robot=RobotSpec(
+            embodiment="ur10e",
+            agents=[
+                AgentSpec(
+                    id="pilot",
+                    role=AgentRole.PILOT,
+                    model=HFModelRef(base="nvidia/GR00T-N1.7-3B"),
+                ),
+            ],
+        ),
+        tasks=[
+            TrainingTask(
+                name="train",
+                training_type=TrainingType.DEMONSTRATION,
+                agent_id="pilot",
+            ),
+            spec_task,
+        ],
+    )
+    run = MissionRun.from_spec(mission)
+    train_run = run.tasks[0]
+    train_run.status = TaskStatus.COMPLETED
+    train_run.result_summary = {"checkpoint_path": str(tmp_path / "ckpt")}
+    eval_run = run.tasks[1]
+    return TaskContext(
+        task=eval_run,
+        mission=run,
+        publisher=_NullPublisher(),
+        output_dir=tmp_path / "out",
+    )
+
+
+def test_runner_end_to_end_metric_only(tmp_path: Path) -> None:
+    script = tmp_path / "fake_eval.py"
+    script.write_text(FAKE_EVAL_SCRIPT)
+    task = _eval_task(
+        config={"eval_script": str(script), "replay_dataset": "/data/ur10e"}
+    )
+    context = _context_for(task, tmp_path)
+
+    summary = asyncio.run(CustomEvalRunner().run(context))
+
+    # Metric-only: metrics captured from the out-json the script wrote, no grade.
+    assert "letter_grade" not in summary
+    assert summary["metrics"]["joint_mae"] == 0.012
+    assert summary["metrics"]["gripper_agreement"] == 0.98
+    assert summary["metrics"]["checkpoint_seen"] == str(tmp_path / "ckpt")
+    assert summary["metrics"]["replay"] == "/data/ur10e"
+
+
+def test_runner_end_to_end_graded(tmp_path: Path) -> None:
+    script = tmp_path / "fake_eval_graded.py"
+    script.write_text(FAKE_EVAL_SCRIPT_GRADED)
+    task = _eval_task(config={"eval_script": str(script)})
+    context = _context_for(task, tmp_path)
+
+    summary = asyncio.run(CustomEvalRunner().run(context))
+
+    assert summary["success_rate"] == 0.75
+    assert summary["num_episodes"] == 8
+    assert summary["letter_grade"] == "C"
+    assert summary["passed"] is True
+
+
+def test_runner_raises_when_script_writes_no_metrics(tmp_path: Path) -> None:
+    script = tmp_path / "silent_eval.py"
+    script.write_text(FAKE_EVAL_SCRIPT_NO_OUTPUT)
+    task = _eval_task(config={"eval_script": str(script)})
+    context = _context_for(task, tmp_path)
+
+    with pytest.raises(RuntimeError, match="wrote no metrics file"):
+        asyncio.run(CustomEvalRunner().run(context))
+
+
+# ---------------------------------------------------------------------------
+# Registry dispatch — the reason this runner exists
+# ---------------------------------------------------------------------------
+
+def test_custom_type_dispatches_to_custom_runner_not_mock() -> None:
+    # Acceptance criterion: `evaluation_type: custom` must resolve to the real
+    # runner, not fall through to the wildcard CPUMockRunner. Registration order
+    # mirrors _build_runners (custom before mock).
+    from odyssey.runners.cpu_mock import CPUMockRunner
+    from odyssey.runners.registry import RunnerRegistry
+
+    registry = RunnerRegistry()
+    registry.register(CustomEvalRunner())
+    registry.register(CPUMockRunner())
+
+    selected = registry.select(_eval_task())
+    assert isinstance(selected, CustomEvalRunner)
+    assert selected.name == "custom"

--- a/tests/unit/test_local_providers.py
+++ b/tests/unit/test_local_providers.py
@@ -41,6 +41,18 @@ async def test_robot_resolves_known_embodiment() -> None:
     assert resolved.name == "franka_panda"
 
 
+async def test_robot_resolves_ur10e_embodiment() -> None:
+    # ur10e is a GR00T NEW_EMBODIMENT arm (finetune target); it must resolve
+    # through the local provider so a `robot.embodiment: ur10e` spec validates.
+    provider = LocalRobotProvider()
+    resolved = await provider.resolve(
+        RobotSpec(embodiment="ur10e", agents=_agents())
+    )
+    assert resolved.provider == "local"
+    assert resolved.embodiment == "ur10e"
+    assert resolved.name == "ur10e"
+
+
 async def test_robot_rejects_unknown_embodiment() -> None:
     provider = LocalRobotProvider()
     # model_construct bypasses spec validation — needed because we're
@@ -73,13 +85,15 @@ async def test_robot_rejects_missing_urdf(tmp_path: Path) -> None:
 
 
 def test_known_embodiments_covers_robosuite_robots() -> None:
-    # The trimmed allowlist is the set of embodiments at least one
-    # shipped runner can drive end-to-end. Robosuite is the eval
-    # runner today, so every name here must also have a translation in
-    # runners.evals.robosuite.ROBOSUITE_ROBOT_NAMES.
+    # The allowlist is the set of embodiments at least one shipped runner can
+    # drive end-to-end. Robosuite is the eval runner for most arms, so every
+    # Robosuite-translatable name must be in the catalog...
     from odyssey.runners.evals.robosuite import ROBOSUITE_ROBOT_NAMES
 
-    assert set(ROBOSUITE_ROBOT_NAMES.keys()) == KNOWN_EMBODIMENTS
+    assert set(ROBOSUITE_ROBOT_NAMES.keys()) <= KNOWN_EMBODIMENTS
+    # ...and the only names beyond Robosuite are GR00T NEW_EMBODIMENT arms
+    # (driven by the `gr00t` runner, never Robosuite) — today just ur10e.
+    assert KNOWN_EMBODIMENTS - set(ROBOSUITE_ROBOT_NAMES.keys()) == {"ur10e"}
     # franka_panda is the alias most OpenVLA / LeRobot specs use.
     assert "franka_panda" in KNOWN_EMBODIMENTS
     # Quadrupeds and mobile bases were intentionally trimmed — no

--- a/tests/unit/test_local_providers.py
+++ b/tests/unit/test_local_providers.py
@@ -53,6 +53,21 @@ async def test_robot_resolves_ur10e_embodiment() -> None:
     assert resolved.name == "ur10e"
 
 
+async def test_ur10e_resolves_then_robosuite_refuses_it() -> None:
+    # Pins the behaviour change this PR introduces: on develop, `ur10e` was
+    # rejected at spec/catalog validation; now it resolves cleanly and only a
+    # Robosuite eval task refuses it — loudly (ValueError), never a silent
+    # default-Panda substitution. ur10e is the first real catalog name that can
+    # reach `_resolve_robosuite_robot`, so no `model_construct` is needed here.
+    from odyssey.runners.evals.robosuite import _resolve_robosuite_robot
+
+    spec = RobotSpec(embodiment="ur10e", agents=_agents())
+    resolved = await LocalRobotProvider().resolve(spec)
+    assert resolved.embodiment == "ur10e"
+    with pytest.raises(ValueError, match="Robosuite has no built-in robot"):
+        _resolve_robosuite_robot(spec)
+
+
 async def test_robot_rejects_unknown_embodiment() -> None:
     provider = LocalRobotProvider()
     # model_construct bypasses spec validation — needed because we're

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -151,7 +151,8 @@ def test_lerobot_env_points_at_parent_for_absolute_local() -> None:
     )
     env = _lerobot_env_for_dataset(task)
     assert env["HF_LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
-    assert env["LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+    # The deprecated LEROBOT_HOME must NOT be set — recent lerobot hard-fails on it.
+    assert "LEROBOT_HOME" not in env
 
 
 def test_lerobot_env_empty_for_hf_dataset() -> None:

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -129,9 +129,11 @@ def test_train_argv_excludes_control_keys() -> None:
 # norm-stats argv builder
 # ---------------------------------------------------------------------------
 
-def test_norm_stats_argv_is_config_name_only() -> None:
+def test_norm_stats_argv_uses_config_name_flag() -> None:
+    # compute_norm_stats.py exposes config_name as a --config-name flag (tyro.cli),
+    # NOT positional like train.py.
     task = _task(config={"config_name": "pi05_libero", "num_train_steps": 10})
-    assert build_pi05_norm_stats_argv(task=task) == ["pi05_libero"]
+    assert build_pi05_norm_stats_argv(task=task) == ["--config-name", "pi05_libero"]
 
 
 def test_norm_stats_argv_requires_config_name() -> None:

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -16,6 +16,7 @@ from typing import Any
 import pytest
 
 from odyssey.runners.models.pi05_train import (
+    _dataset_repo_id,
     _lerobot_env_for_dataset,
     _link_norm_stats_cache,
     _resolve_output_checkpoint,
@@ -190,34 +191,96 @@ def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
 # norm-stats cache
 # ---------------------------------------------------------------------------
 
+_CFG = "pi05_ur10e_drugsort"
+
+
 def test_link_norm_stats_cache_symlinks_and_reuses(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("HOME", str(tmp_path / "home"))
     run1 = tmp_path / "run1"
     run1.mkdir()
-    cache, cached = _link_norm_stats_cache(run1, "pi05_ur10e_drugsort")
+    cache, cached = _link_norm_stats_cache(run1, _CFG, "ur10e")
     assert cache is not None
     # ./assets in the run dir is a symlink to the stable per-config cache.
     assert (run1 / "assets").is_symlink()
     assert (run1 / "assets").resolve() == cache.resolve()
     assert cached is False  # nothing cached yet
 
-    # Simulate openpi writing norm stats into the cache; a fresh run reuses them.
-    (cache / "ur10e").mkdir(parents=True)
-    (cache / "ur10e" / "norm_stats.json").write_text("{}")
+    # Simulate openpi writing stats at assets/<config_name>/<repo_id>/; a fresh run
+    # for the SAME dataset reuses them.
+    (cache / _CFG / "ur10e").mkdir(parents=True)
+    (cache / _CFG / "ur10e" / "norm_stats.json").write_text("{}")
     run2 = tmp_path / "run2"
     run2.mkdir()
-    _, cached2 = _link_norm_stats_cache(run2, "pi05_ur10e_drugsort")
+    _, cached2 = _link_norm_stats_cache(run2, _CFG, "ur10e")
     assert cached2 is True
+
+
+def test_link_norm_stats_cache_hit_is_keyed_by_dataset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A cached dataset must NOT satisfy a run for a *different* dataset under the
+    same config — openpi keys norm stats by repo_id, so a glob would wrongly hit
+    and train.py would then die looking for the repo_id it actually needs."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run1 = tmp_path / "run1"
+    run1.mkdir()
+    cache, _ = _link_norm_stats_cache(run1, _CFG, "dataset_A")
+    assert cache is not None
+    (cache / _CFG / "dataset_A").mkdir(parents=True)
+    (cache / _CFG / "dataset_A" / "norm_stats.json").write_text("{}")
+
+    run2 = tmp_path / "run2"
+    run2.mkdir()
+    _, cached_b = _link_norm_stats_cache(run2, _CFG, "dataset_B")  # different dataset
+    assert cached_b is False
+
+
+def test_link_norm_stats_cache_empty_repo_id_recomputes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unknown repo_id (config default) is never a hit — recompute over a wrong
+    guess. Any stray stats under the config must not count."""
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run = tmp_path / "run"
+    run.mkdir()
+    cache, _ = _link_norm_stats_cache(run, _CFG, "")
+    assert cache is not None
+    (cache / _CFG / "whatever").mkdir(parents=True)
+    (cache / _CFG / "whatever" / "norm_stats.json").write_text("{}")
+    _, cached = _link_norm_stats_cache(run, _CFG, "")
+    assert cached is False
 
 
 def test_link_norm_stats_cache_no_config_name(tmp_path: Path) -> None:
     run = tmp_path / "run"
     run.mkdir()
-    cache, cached = _link_norm_stats_cache(run, "")
+    cache, cached = _link_norm_stats_cache(run, "", "ur10e")
     assert cache is None
     assert cached is False
+
+
+def test_dataset_repo_id_prefers_data_override() -> None:
+    task = _task(
+        config={"config_name": _CFG, "data": {"repo_id": "ur10e_partial_cond_aug"}},
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="/data/some_other_folder"
+        ),
+    )
+    assert _dataset_repo_id(task) == "ur10e_partial_cond_aug"
+
+
+def test_dataset_repo_id_falls_back_to_dataset_folder() -> None:
+    task = _task(
+        config={"config_name": _CFG},
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/ur10e_v0/"),
+    )
+    assert _dataset_repo_id(task) == "ur10e_v0"
+
+
+def test_dataset_repo_id_empty_when_unknown() -> None:
+    assert _dataset_repo_id(_task(config={"config_name": _CFG})) == ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -17,6 +17,7 @@ import pytest
 
 from odyssey.runners.models.pi05_train import (
     _lerobot_env_for_dataset,
+    _link_norm_stats_cache,
     _resolve_output_checkpoint,
     build_pi05_norm_stats_argv,
     build_pi05_train_argv,
@@ -183,6 +184,40 @@ def test_resolve_output_checkpoint_picks_highest_step(tmp_path: Path) -> None:
 
 def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
     assert _resolve_output_checkpoint(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# norm-stats cache
+# ---------------------------------------------------------------------------
+
+def test_link_norm_stats_cache_symlinks_and_reuses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    run1 = tmp_path / "run1"
+    run1.mkdir()
+    cache, cached = _link_norm_stats_cache(run1, "pi05_ur10e_drugsort")
+    assert cache is not None
+    # ./assets in the run dir is a symlink to the stable per-config cache.
+    assert (run1 / "assets").is_symlink()
+    assert (run1 / "assets").resolve() == cache.resolve()
+    assert cached is False  # nothing cached yet
+
+    # Simulate openpi writing norm stats into the cache; a fresh run reuses them.
+    (cache / "ur10e").mkdir(parents=True)
+    (cache / "ur10e" / "norm_stats.json").write_text("{}")
+    run2 = tmp_path / "run2"
+    run2.mkdir()
+    _, cached2 = _link_norm_stats_cache(run2, "pi05_ur10e_drugsort")
+    assert cached2 is True
+
+
+def test_link_norm_stats_cache_no_config_name(tmp_path: Path) -> None:
+    run = tmp_path / "run"
+    run.mkdir()
+    cache, cached = _link_norm_stats_cache(run, "")
+    assert cache is None
+    assert cached is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -1,0 +1,232 @@
+"""Tests for the π0.5 (openpi) training runner's argv builders, env overlay,
+checkpoint resolution and stdout parser.
+
+We don't invoke the real openpi ``scripts/train.py`` — that needs the openpi
+package, JAX/torch with CUDA, a GPU and a registered ``TrainConfig``. The
+testable pieces are the pure functions that shape the two subprocess argvs from
+a ``TrainingTask`` spec, the LeRobot env overlay, the checkpoint locator, and the
+parser that turns openpi stdout into progress events.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.runners.models.pi05_train import (
+    _lerobot_env_for_dataset,
+    _resolve_output_checkpoint,
+    build_pi05_norm_stats_argv,
+    build_pi05_train_argv,
+    parse_pi05_train_line,
+)
+from odyssey.spec import DatasetRef, DatasetSource, TrainingTask, TrainingType
+
+
+def _task(**overrides: Any) -> TrainingTask:
+    fields: dict[str, Any] = {
+        "name": "finetune-pi05",
+        "training_type": TrainingType.DEMONSTRATION,
+        "agent_id": "pilot",
+    }
+    fields.update(overrides)
+    return TrainingTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# train argv builder
+# ---------------------------------------------------------------------------
+
+def test_train_argv_requires_config_name() -> None:
+    with pytest.raises(RuntimeError, match="config_name"):
+        build_pi05_train_argv(task=_task(), exp_name="exp")
+
+
+def test_train_argv_positional_config_name_first() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert argv[0] == "pi05_libero"
+
+
+def test_train_argv_includes_exp_name() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="my-exp")
+    idx = argv.index("--exp-name")
+    assert argv[idx + 1] == "my-exp"
+
+
+def test_train_argv_defaults_to_overwrite() -> None:
+    task = _task(config={"config_name": "pi05_libero"})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--overwrite" in argv
+
+
+def test_train_argv_overwrite_false_omits_flag() -> None:
+    task = _task(config={"config_name": "pi05_libero", "overwrite": False})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--overwrite" not in argv
+
+
+def test_train_argv_resume_replaces_overwrite() -> None:
+    task = _task(config={"config_name": "pi05_libero", "resume": True})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--resume" in argv
+    assert "--overwrite" not in argv
+
+
+def test_train_argv_passthrough_is_kebab_case() -> None:
+    task = _task(config={"config_name": "pi05_libero", "num_train_steps": 30000})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    idx = argv.index("--num-train-steps")
+    assert argv[idx + 1] == "30000"
+
+
+def test_train_argv_nested_config_becomes_dotted_flag() -> None:
+    # tyro overrides address nested dataclass fields via dots; underscores in a
+    # leaf still become dashes (data.repo_id -> --data.repo-id).
+    task = _task(
+        config={"config_name": "pi05_ur10e", "data": {"repo_id": "ur10e_partial_cond_aug"}}
+    )
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    idx = argv.index("--data.repo-id")
+    assert argv[idx + 1] == "ur10e_partial_cond_aug"
+
+
+def test_train_argv_bool_true_is_bare_flag() -> None:
+    task = _task(config={"config_name": "c", "wandb_enabled": True})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--wandb-enabled" in argv
+    # A bare flag carries no value token after it.
+    assert "True" not in argv
+
+
+def test_train_argv_bool_false_is_no_flag() -> None:
+    task = _task(config={"config_name": "c", "wandb_enabled": False})
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--no-wandb-enabled" in argv
+
+
+def test_train_argv_excludes_control_keys() -> None:
+    task = _task(
+        config={
+            "config_name": "c",
+            "runner": "pi05",
+            "exp_name": "ignored",
+            "compute_norm_stats": False,
+        }
+    )
+    argv = build_pi05_train_argv(task=task, exp_name="exp")
+    assert "--runner" not in argv
+    assert "--config-name" not in argv
+    assert "--compute-norm-stats" not in argv
+    # exp_name is supplied via the dedicated flag, not passed through twice.
+    assert argv.count("--exp-name") == 1
+
+
+# ---------------------------------------------------------------------------
+# norm-stats argv builder
+# ---------------------------------------------------------------------------
+
+def test_norm_stats_argv_is_config_name_only() -> None:
+    task = _task(config={"config_name": "pi05_libero", "num_train_steps": 10})
+    assert build_pi05_norm_stats_argv(task=task) == ["pi05_libero"]
+
+
+def test_norm_stats_argv_requires_config_name() -> None:
+    with pytest.raises(RuntimeError, match="config_name"):
+        build_pi05_norm_stats_argv(task=_task())
+
+
+# ---------------------------------------------------------------------------
+# LeRobot env overlay
+# ---------------------------------------------------------------------------
+
+def test_lerobot_env_points_at_parent_for_absolute_local() -> None:
+    task = _task(
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="/data/ur10e_drugsort_v0/ur10e_partial_cond_aug"
+        ),
+    )
+    env = _lerobot_env_for_dataset(task)
+    assert env["HF_LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+    assert env["LEROBOT_HOME"] == "/data/ur10e_drugsort_v0"
+
+
+def test_lerobot_env_empty_for_hf_dataset() -> None:
+    task = _task(
+        dataset=DatasetRef(source=DatasetSource.HUGGINGFACE, ref="org/some-lerobot"),
+    )
+    assert _lerobot_env_for_dataset(task) == {}
+
+
+def test_lerobot_env_empty_when_no_dataset() -> None:
+    assert _lerobot_env_for_dataset(_task()) == {}
+
+
+# ---------------------------------------------------------------------------
+# checkpoint resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_output_checkpoint_picks_highest_step(tmp_path: Path) -> None:
+    root = tmp_path / "checkpoints" / "pi05_ur10e" / "exp"
+    for step in (1000, 5000, 2000):
+        (root / str(step) / "params").mkdir(parents=True)
+    resolved = _resolve_output_checkpoint(tmp_path)
+    assert resolved is not None
+    assert resolved.name == "5000"
+
+
+def test_resolve_output_checkpoint_none_when_empty(tmp_path: Path) -> None:
+    assert _resolve_output_checkpoint(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# stdout parser
+# ---------------------------------------------------------------------------
+
+def test_parse_loss_and_step_line() -> None:
+    event = parse_pi05_train_line("step=1000 loss=0.234 grad_norm=1.2")
+    assert event is not None
+    assert event["stage"] == "executing"
+    assert event["step"] == "training_step"
+    assert event["step_index"] == 1000
+    assert "loss=0.234" in event["step_label"]
+
+
+def test_parse_dict_style_metric_line() -> None:
+    event = parse_pi05_train_line("Step 1000: {'loss': 0.234, 'learning_rate': 1e-05}")
+    assert event is not None
+    assert event["step_index"] == 1000
+    assert "loss=0.234" in event["step_label"]
+
+
+def test_parse_tqdm_progress_line() -> None:
+    event = parse_pi05_train_line(" 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]")
+    assert event is not None
+    assert event["step_index"] == 100
+    assert event["step_total"] == 1000
+
+
+def test_parse_checkpoint_save_line() -> None:
+    event = parse_pi05_train_line("Saving checkpoint to ./checkpoints/pi05_libero/exp/1000")
+    assert event is not None
+    assert event["stage"] == "checkpoint_saving"
+
+
+def test_parse_norm_stats_line() -> None:
+    event = parse_pi05_train_line("Computing normalization statistics for pi05_ur10e")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+    assert event["step"] == "compute_norm_stats"
+
+
+def test_parse_dataset_loading_line() -> None:
+    event = parse_pi05_train_line("Loading LeRobot dataset ur10e_partial_cond_aug")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+
+
+def test_parse_unrelated_line_returns_none() -> None:
+    assert parse_pi05_train_line("nothing interesting here") is None


### PR DESCRIPTION
Promotes `develop` to `main` for the **v0.1.0a5** alpha release.

## What ships (since a4)

| PR | What |
|---|---|
| #86 | ur10e embodiment (GR00T NEW_EMBODIMENT) |
| #88 | `CustomEvalRunner` for `evaluation_type: custom` |
| #90 | π0.5 (openpi) training runner (`Pi05Runner`) + fine-tune example |
| #91 | ignore `node_modules/` |
| #92 | browser closed-loop eval harness + `in_well` placement metric |
| #93 | version bump to 0.1.0a5 |

## Merge mechanics (per the release recipe)

- Version bumped to `0.1.0a5` on **develop first** (#93), so `main` never takes a direct version commit.
- This branch is `main` + `git merge --no-ff -X theirs origin/develop`. **`git diff --stat HEAD origin/develop` is empty** — the tree is byte-identical to develop, the safety proof that `-X theirs` only dropped stale main-only content the release supersedes.
- The merge commit carries both `main` and `develop` as parents → heals ancestry, **no back-merge needed**.

⚠️ **Merge this as "Create a merge commit", NOT squash** — squash is the root cause of the divergence cycle this recipe exists to avoid.

## Verification (release branch, local)

- `git diff --stat HEAD origin/develop` → empty (tree == develop)
- ruff clean · mypy strict clean (80 files) · **552 passed, 5 skipped**

## After merge

- Tag `v0.1.0a5` on the merge commit.
- Backfill the missing `v0.1.0a4` tag on `198fd88` (the a4 release merge was never tagged).