### PR TITLE
Closed-loop VLA recovery: tiered stuck detection + rollback (GR00T/pi05) with VLA-Corrector truncation

### DIFF
--- a/docs/experiment-recovery-design-vla.md
+++ b/docs/experiment-recovery-design-vla.md
@@ -145,7 +145,40 @@ outcome is data; teleport ablation isolates it) · GR00T migration regression
 unverified (guarded degrade) · npz memory (~100 MB/episode pre-compression;
 per-episode save, default-off).
 
-## 5. Roadmap
+## 5. Phase 0 results (H100, 2026-08-11) — the stuck check must be two-frame
+
+Setup: `nvidia/Cosmos3-Nano` served via plain `vllm serve` (vllm-omni:v0.26.0
+image, port 8002, `--gpu-memory-utilization 0.60`, ~140 s to ready, judge
+latency 0.06-0.26 s/call). Probed on the H100's staged rollout MP4s: 2×
+cosmos3-OOD LIBERO FAIL (arm never engages) + 3× UR5e drugsort (1 fail,
+2 success; their pick lands in the first ~15%, then the episode idles at the
+tick cap). Artifacts on the box: `~/phase0_{fail,success}_probe.json`,
+`~/phase0_sweep_{fail,success}.jsonl`, server log `~/reasoner_serve_phase0.log`.
+
+| Question | Result |
+| --- | --- |
+| `retry` (single-frame, open-ended — the shipped `STUCK_PROMPT_TEMPLATE`) | **0.0 YES everywhere**, including FAIL videos — reproduces the 2026-08-10 all-NO finding exactly. Useless as a stuck detector. |
+| `control` canary | 1.0 — the judge sees the scene; this is not the #78 blindness. |
+| Concrete single-frame (`s_drop`, `s_near`) | Real but partial perception (`s_near` varies with actual proximity); not a stuck signal. |
+| **`t_frozen` (TWO frames, ~seconds apart: "is the arm essentially FROZEN in the same pose?")** | **Discriminates: 8/8 NO on active windows (arm moving), 10/10 YES on idle/stuck windows** — across both visual domains. |
+| `t_progress` (two frames, open-ended "made progress on the task?") | NO even during genuinely active successful picks — open-ended judgment biases NO, exactly per the reasoner-probe README's law. |
+
+**Design consequences (follow-up commit before Phase 2):**
+
+1. `SpecialistGate` must submit **two frames** — the previous chunk-boundary
+   frame + the current one (`RecoveryPolicy` already touches both; storing
+   the last boundary frame is one field). `OpenAICompatCompletionJudge`
+   needs a multi-image payload path.
+2. `STUCK_PROMPT_TEMPLATE` becomes the two-frame frozen-compare phrasing;
+   keep concrete single-frame add-ons (`s_drop`) as optional extra verdicts
+   rather than open-ended "failed/stuck" judgments.
+3. Honest caveat: two-frame frozen detection overlaps tier 1's kinematic
+   signal (both measure "no motion"). The VLM's *distinct* value must come
+   from semantic checks (dropped/knocked object) — untestable on the staged
+   videos (no such events); the GR00T pose-cliff FAIL corpus is the right
+   material when we pull it in.
+
+## 6. Roadmap
 
 - **PR 1 (this)**: recovery skeleton + VLA-Corrector truncation + rollout logging.
 - **PR 2**: VLA-Corrector LVM tier — vendor/adapt `siglip_dynamics`, train the

--- a/docs/experiment-recovery-design-vla.md
+++ b/docs/experiment-recovery-design-vla.md
@@ -1,559 +1,150 @@
-# Closed-loop recovery experiment — VLA pilots (GR00T / π0.5) + Reasoner specialist
+# Experiment: closed-loop VLA recovery (GR00T / π0.5) with VLA-Corrector integration
 
-**Branch**: `feat/vla-recovery-closedloop` (off `develop`)
-**Status**: design draft — iteration 1 scoped VLA-first, see §13 (which
-supersedes the RoboLab/WAM framing of §§1–6 for this iteration; that design
-is kept as the iteration-2 target).
+**Branch**: `experiment-vla-recovery-closed-loop` (off `develop`)
+**Status**: design final + implementation plan agreed; implementation not started.
+**Paper being integrated**: [VLA-Corrector — Lightweight Detect-and-Correct Inference
+for Adaptive Action Horizon](https://arxiv.org/abs/2607.01804)
+**Code being integrated**: <https://github.com/ZJU-OmniAI/vla-corrector>
+(Apache-2.0; LeRobot fork whose self-contained `src/siglip_dynamics/` module is the
+vendorable piece)
 
-> History: this doc started as the Cosmos3-WAM × RoboLab design
-> (`docs/cosmos3-recovery-experiment-design.md` on the discarded
-> `feat/cosmos3-recovery-closedloop` branch). §§10–13 record how analysis,
-> prior art, and the code audit re-scoped iteration 1 onto the VLAs we
-> already operate end-to-end. The only cosmos3-branch *code* this experiment
-> needs — the generic `OpenAICompatCompletionJudge`
-> (`runners/agents/openai_judge.py` + its unit test, 19 tests green on this
-> base) — has been ported onto this branch; the specialist model
-> (Cosmos3-Nano Reasoner) is pure served config, not a code dependency.
+> The full design history (RoboLab/WAM arm, prior-art survey, code audits, scoping
+> decisions) lives in this file's git history (commit `49a739a`). This version is the
+> clean statement of the final experiment.
 
 ## 1. The experiment
 
-Can a SPECIALIST agent, watching the sim **while** the PILOT executes action
-chunks, detect that the arm is stuck and trigger a recovery that returns the
-arm to the last *successful* action-chunk boundary — and does that recovery
-improve episode success rate?
+A SPECIALIST agent (a served VLM reasoner) monitors the simulation **while** the PILOT
+executes action chunks. When the arm is stuck or failing, the system **truncates** the
+stale chunk (VLA-Corrector's mechanism) and/or **rolls back** the arm to the last good
+chunk boundary, then re-queries the policy. The question: does
+detection → truncate/rollback → re-query convert failures into successes — and what
+does VLM *semantics* add over progressively cheaper signals?
 
-- **Pilot**: `nvidia/Cosmos3-Nano-Policy-DROID` (chunk-emitting WAM, served by
-  cosmos-framework's `action_policy_server_robolab`, WebSocket).
-- **Specialist**: `nvidia/Cosmos3-Nano` Reasoner (vLLM-Omni, OpenAI-compatible
-  endpoint) — the exact judge `examples/cosmos3-reasoner-probe/` already
-  exercises, including a `RETRY_TEMPLATE` ("is the robot FAILED or STUCK such
-  that it should abort and retry?") that is the seed of the stuck check.
-- **Eval**: RoboLab (NVlabs' Isaac Lab twin of the DROID rig), already a
-  first-class `evaluation_type: robolab` (`runners/evals/robolab.py`).
-- **Coordination style**: delegation — the specialist authors no plan; it is
-  asked perception questions on demand while actions are produced
-  (the PR #68 delegation spirit, moved from post-hoc video probing to
-  real-time in-the-loop).
+- **Pilots**: GR00T-N1.7-LIBERO (primary — in-domain, 10/10 on `libero_object`, and
+  the existing perturbation harness induces failures on demand) and π0.5 (secondary —
+  demonstrates pilot-agnosticism). Both are chunk-emitting and run through the shared
+  `ChunkPilotAdapter`.
+- **Specialist**: any OpenAI-compatible served reasoner via
+  `OpenAICompatCompletionJudge` with a stuck/RETRY prompt. Default model:
+  `nvidia/Cosmos3-Nano` on vLLM (pure config, not a code dependency).
+- **Eval**: LIBERO, through our own recipes (`gr00t_libero_eval.py`,
+  `pi05_libero_eval.py`) — we own the loop; MuJoCo state restore enables the
+  `teleport` ablation.
+- **Experiment arms** (same tasks, same init states):
+  A. baseline (recovery off) · B. shadow (detect + log, never intervene) ·
+  C. kinematic-only recovery · D. full delegation (specialist in the loop).
+- **Metrics**: success rate per arm; detector precision/recall (from shadow verdicts
+  vs post-hoc labels); recoveries per episode; post-recovery success rate; specialist
+  latency distribution; wall-clock overhead.
 
-This is the step from *post-hoc* analysis (reasoner probe on rollout MP4s) to
-*concurrent* analysis (verdicts consumed inside the control loop).
+## 2. What we take from VLA-Corrector, and when
 
-## 2. What exists today (inventory)
+The paper has two halves — a **detector** and a **response**:
 
-| Piece | Where | State |
+| | VLA-Corrector (paper) | This experiment |
 | --- | --- | --- |
-| Cosmos3 pilot factory (HTTP client + chunk adapter) | `runners/models/cosmos3.py` (`make_cosmos3_pilot`, lines 75–138) | done (LIBERO wire) |
-| Chunk buffer/replay + flush-on-instruction-change | `runners/agents/chunk_pilot.py` (`ChunkPilotAdapter`) | done, pilot-agnostic |
-| Chunk-boundary VLM polling (cost model: poll per chunk, not per step) | `runners/agents/completion_gate.py` (`ChunkCompletionGate`) | done, **not wired** into any default flow |
-| OpenAI-compat YES/NO judge (vLLM, `modalities:["text"]` fix, zoom/upscale lesson from issue #78) | `runners/agents/openai_judge.py` + `examples/cosmos3-reasoner-probe/` | done, validated post-hoc |
-| RoboLab runner (subprocess, `episode_results.jsonl` scoring, docker bring-up) | `runners/evals/robolab.py` + `examples/cosmos3-robolab/` | done, H100-smoked |
-| `entry_script` mission knob (select RoboLab policy backend) | `robolab.py` handled config keys; README: "a future backend is a mission edit, not a new runner" | done — **our hook** |
-| Multi-agent runtimes (planner arm) | `runners/agents/{runtime,planner,planned,remote_planner}.py` | done (planning), delegation arm lives on `feat/multiagent-delegation-grounding`, **not merged here** |
-| SPECIALIST role in mission spec | `spec/agents.py` (`AgentRole.SPECIALIST`) | done |
-
-What does **not** exist: any per-step observation access or mid-episode state
-manipulation for RoboLab from Odyssey. `RobolabRunner` launches
-`policies/cosmos3/run.py`, waits, and reads `episode_results.jsonl`. The sim
-loop, the policy WebSocket client, and all robot state live inside the Isaac
-Sim docker process.
-
-## 3. The architectural gap and the placement decision
-
-The closed loop needs three capabilities RoboLab's stock `run.py` doesn't
-expose: (a) frames at chunk boundaries for the specialist, (b) a decision
-point between chunks, (c) a way to move the arm back to a saved configuration.
-
-### Options considered
-
-**A. Policy-proxy shim (interpose on the WebSocket).** Odyssey starts a proxy
-that RoboLab connects to as if it were the policy server; the proxy forwards
-obs → real server, sees every observation and chunk, and can substitute a
-"recovery chunk" (reverse-replay of executed deltas). No RoboLab fork.
-*Rejected as primary*: no access to proprio/joint state (the DROID wire is
-video-conditioned), recovery must be approximated by negating action deltas
-(fragile: controller dynamics, gripper state), and the RoboLab client wire
-protocol has to be reverse-engineered and pinned. Keep in the back pocket.
-
-**B. Custom RoboLab entry script (recommended).** A recovery-aware sibling of
-`policies/cosmos3/run.py`, selected via the existing `config.entry_script`
-mission knob, running **inside** the Isaac process where robot state is
-first-class. It reuses RoboLab's own policy client and env setup and wraps the
-step loop with our recovery logic. The *brains* (stuck gate, chunk ledger,
-recovery trajectory) live in Odyssey as pure numpy/stdlib modules — same
-pattern as `ChunkPilotAdapter`/`ChunkCompletionGate`: unit-testable without
-GPU/Isaac, imported by the entry script via the dual bind-mount +
-`sys.path.insert(repo/src)` trick the example bridges already use.
-
-**C. Do it on LIBERO instead.** In-process env, `set_init_state`, full loop
-control — much easier plumbing. *Rejected as the headline* (the experiment is
-DROID-rig + RoboLab by design) but noted as a de-risking fallback if RoboLab
-iteration cost becomes the bottleneck.
-
-### Decision
-
-**Option B**: Odyssey-owned recovery brain + thin Isaac-side entry script.
-Rationale: real joint access makes "return to last good chunk" a *commanded*
-motion (transferable to a real arm) instead of an action-algebra
-approximation; RoboLab's client code is reused rather than re-implemented; and
-the mission-level surface is just `entry_script:` + config keys — no new
-runner, minor `RobolabRunner` extensions for artifacts.
-
-## 4. Proposed architecture
-
-```
-┌────────────────────────────── Isaac Sim docker ──────────────────────────────┐
-│  recovery_run.py  (entry_script — sibling of policies/cosmos3/run.py)        │
-│                                                                              │
-│   sim step loop ──► chunk boundary ──► ChunkLedger.snapshot(joints, frame)   │
-│        │                   │                                                 │
-│        │                   ├─► StuckMonitor (kinematic, cheap, every step)   │
-│        │                   │                                                 │
-│        │                   └─► SpecialistGate ──(bg thread)──► vLLM Reasoner │
-│        │                              │      verdict mailbox   (Cosmos3-Nano)│
-│        ▼                              ▼                                      │
-│   policy WebSocket client      RecoveryController                            │
-│   (RoboLab's own, unchanged)   (joint-interp back to last-good snapshot,     │
-│        │                        then flush pilot chunk state + re-query)     │
-│        ▼                                                                     │
-│   action_policy_server_robolab (Cosmos3-Nano-Policy-DROID)                   │
-│                                                                              │
-│   emits: episode_results.jsonl (+ per-episode recovery events)               │
-└──────────────────────────────────────────────────────────────────────────────┘
-   Odyssey side: RobolabRunner (unchanged launch) + recovery_events artifact
-                 + recovery metrics folded into result_summary
-```
-
-### 4.1 Components (new code)
-
-1. **`ChunkLedger`** (`src/odyssey/runners/agents/chunk_ledger.py`, pure).
-   At every chunk boundary records: chunk index, joint positions + gripper
-   state, EE pose if available, boundary frame (downscaled), and later the
-   verdicts. Exposes `last_good()` — the most recent boundary whose verdicts
-   were clean. This *defines* "último action chunk exitoso": a chunk after
-   which neither the kinematic monitor nor the specialist flagged trouble.
-
-2. **`StuckMonitor`** (same module or sibling, pure). Cheap kinematic
-   first-tier: commanded motion ≠ 0 but EE/joint displacement < ε over the
-   last K steps ⇒ *stuck candidate*. Runs every step, costs nothing, and
-   gates the expensive VLM call — this is the false-positive/latency
-   flywheel: the specialist is only consulted when physics already looks
-   suspicious (plus a low-rate background poll, `poll_every_chunks`, to catch
-   semantic failure modes the kinematics can't see, e.g. dropped object).
-
-3. **`SpecialistGate`** (evolution of `ChunkCompletionGate`). Wraps the
-   existing `OpenAICompatCompletionJudge` with the `RETRY_TEMPLATE`-style
-   stuck prompt, but **asynchronously**: the judge call (~1–2 s) runs in a
-   background thread; the sim never blocks. Verdicts land in a mailbox and
-   are consumed at the *next* chunk boundary. A chunk of 16 steps at DROID
-   control rate gives comfortable headroom; a verdict arriving one boundary
-   late is acceptable because "stuck" is a persistent state, not an edge.
-   Includes timeout + in-flight-call cancellation on episode end.
-
-4. **`RecoveryController`** (pure numpy). Given current joints and the
-   `last_good()` snapshot, emits a joint-space interpolated trajectory
-   (M steps, capped velocity) driving the arm back, gripper commanded to the
-   snapshot's state. After arrival: flush the pilot's chunk state (the
-   WebSocket client just re-queries — the server is stateless per call) and
-   resume normal control from the restored pose. Budget: `max_recoveries`
-   per episode; exceeding it ends the episode as a scored failure with
-   reason `recovery_budget_exhausted`.
-
-5. **`recovery_run.py`** (`examples/cosmos3-recovery-robolab/`, Isaac-side).
-   Forked from RoboLab's `policies/cosmos3/run.py`; wraps its loop with 1–4.
-   Writes `recovery_events.jsonl` (one line per trigger: step, cause
-   kinematic|specialist, verdict latency, rollback target chunk, outcome)
-   next to `episode_results.jsonl`. Example-bridge conventions: repo-`src`
-   path injection, argparse passthrough, not in strict-mypy scope.
-
-6. **`RobolabRunner` extensions** (small): copy `recovery_events.jsonl` as an
-   artifact when present; fold counts (recoveries triggered / episodes with
-   recovery / post-recovery successes) into `result_summary.metrics`.
-
-7. **Mission surface**: SPECIALIST agent declared in `robot.agents`
-   (`nvidia/Cosmos3-Nano`); eval task keys (all passthrough → argv, no spec
-   change needed):
-
-   ```yaml
-   config:
-     entry_script: examples/cosmos3-recovery-robolab/recovery_run.py  # host path, dual-mounted
-     specialist_base_url: "http://<host>:8002/v1"
-     specialist_model: nvidia/Cosmos3-Nano
-     recovery: true            # false = baseline arm of the experiment
-     shadow_mode: false        # true = detect + log, never intervene (Phase 2)
-     stuck_eps_m: 0.005        # kinematic threshold
-     stuck_window_steps: 12
-     poll_every_chunks: 2
-     max_recoveries: 3
-     recovery_steps: 24
-   ```
-
-### 4.2 Concurrency model (the "fontanería")
-
-Single sim thread, one background judge thread, mailbox in between — no
-asyncio inside Isaac (their loop is synchronous; a thread + `queue.Queue` is
-the entire concurrency story). Ordering guarantees:
-
-- Snapshot happens *before* the chunk that follows it executes, so a rollback
-  target is always a pose the arm actually held at a boundary.
-- At most one specialist call in flight; if a boundary arrives while one is
-  pending, we skip launching another (the pending verdict covers it).
-- A stale verdict (episode ended, or a recovery already ran since the frame
-  was captured) is discarded by tagging calls with (episode, chunk index).
-- Recovery is exclusive: while the `RecoveryController` drives, the policy
-  client is not queried and the monitors are muted until arrival + settle.
-
-### 4.3 Recovery semantics — command-back vs teleport
-
-Two modes, worth having both behind a flag:
-
-- **`command` (default, headline)**: drive the arm back via the controller.
-  Physically honest, transferable to a real robot, but can fail (truly wedged
-  arm may not track the trajectory — that itself is a measurable outcome).
-- **`teleport` (ablation/upper bound)**: write joint state directly into the
-  articulation (Isaac API). Clean geometry, breaks physics realism (held
-  objects, contacts). Useful to separate "detector was right" from "recovery
-  motion failed".
-
-Not proposed: full sim-state restore (objects included). It measures a
-different (purely sim-side) capability and has no real-robot analogue.
-
-## 5. Experiment protocol
-
-**Arms** (same task set, same episode seeds/init states where RoboLab allows):
-
-| Arm | recovery | specialist | purpose |
-| --- | --- | --- | --- |
-| A. baseline | off | off | today's success rate |
-| B. shadow | off | on (log-only) | detector precision/recall + latency, zero intervention |
-| C. kinematic-only | on | off | is the VLM adding anything over physics? |
-| D. full delegation | on | on | the headline |
-
-**Metrics**: episode success rate per arm; detector precision/recall (shadow
-verdicts vs post-hoc labels from rollout videos — the reasoner-probe tooling
-already produces per-frame verdict tables for exactly this kind of labeling);
-recoveries per episode; post-recovery success rate (episodes that succeeded
-after ≥1 recovery — the direct evidence recovery *causes* success); judge
-latency distribution; wall-clock overhead per arm.
-
-**Stuck induction**: start with the natural failure rate (the policy on
-RoboLab is not saturated; failures exist — `episode_results.jsonl` already
-carries failure reasons to mine). If natural stuck events are too rare for
-statistical power, inject perturbations in the entry script (action-offset
-window, transient gripper freeze) — the GR00T×LIBERO perturbation work
-(`docs/gr00t-libero-perturbations-summary.md`) is the precedent. Decide after
-Phase 2 data.
-
-## 6. GPU topology
-
-Three GPU consumers (H100-class box, per the existing bring-up):
-
-1. Policy server (Nano-Policy-DROID, bf16 ≥32 GB) — port 8000.
-2. vLLM Reasoner (Cosmos3-Nano) — port 8002, bounded `--gpu-memory-utilization`.
-3. RoboLab Isaac docker (rendering + PhysX).
-
-Mandatory: `disable_subtask: true` in the mission — RoboLab otherwise
-auto-spawns its *own* ~50 GB vLLM judge (documented VRAM landmine in
-`examples/cosmos3-robolab/README.md`). Our specialist replaces it. If one
-card can't hold all three, split policy server vs (Isaac + reasoner) across
-two — all links are already network-transparent.
-
-## 7. Phasing (de-risk order)
-
-- **Phase 0 — specialist calibration (no new code)**: run the existing
-  reasoner probe against RoboLab rollout videos (from the smoke runs) with
-  the retry/stuck question; verify the judge discriminates stuck vs nominal
-  on *this* visual domain before building anything on it (issue #78 lesson:
-  the judge, not the camera, was the problem last time).
-- **Phase 1 — pure modules + tests (no GPU)**: `ChunkLedger`, `StuckMonitor`,
-  `SpecialistGate` (fake judge), `RecoveryController`; unit tests pin
-  ordering, mailbox staleness, budget, trajectory bounds. Strict-mypy clean.
-- **Phase 2 — shadow mode on hardware**: entry script forked, specialist
-  wired, `recovery: false, shadow_mode: true`. Validates the fontanería
-  (mounts, imports, threading, latency) with zero behavioral risk, and
-  yields the detector-quality data (arm B).
-- **Phase 3 — recovery live**: arms A/C/D, headline comparison.
-
-Phase boundaries are also natural PR boundaries (draft PR → develop, per
-repo flow).
-
-## 8. Risks
-
-| Risk | Mitigation |
-| --- | --- |
-| RoboLab `run.py` internals differ from assumption (loop/client structure) — the fork inherits them | Read + pin the actual `run.py` from the checkout **first task of Phase 2**; keep the fork minimal (wrap, don't rewrite) |
-| Judge quality on RoboLab frames (issue #78 déjà vu: always-NO/always-YES) | Phase 0 gate — no build-out until the probe discriminates; zoom/upscale knobs already exist |
-| Judge latency > chunk duration | Async mailbox tolerates one-boundary lag; `poll_every_chunks` throttle; measure in Phase 2 |
-| Commanded rollback fails when genuinely wedged | That outcome is itself data; `teleport` ablation isolates it; recovery budget bounds the cost |
-| Odyssey code import inside the Isaac container | Already-solved pattern: dual bind-mount + `PYTHONPATH` + example-bridge `src` injection (see robolab README wrapper table) |
-| Natural stuck events too rare | Perturbation injection fallback (§5); decide on Phase 2 data |
-| VRAM contention (3 consumers) | `disable_subtask`, bounded vLLM util, two-card split if needed |
-
-## 9. Open questions (to settle before plan mode)
-
-1. **Recovery semantics v1**: geometric rollback only (return + re-query), or
-   should the specialist also *re-instruct* the pilot on recovery (e.g. "lift
-   the arm and retry") — true delegation? Proposal: v1 geometric (measurable,
-   simple), v2 semantic re-instruction as follow-up.
-2. **`command` vs `teleport`** as default recovery mode (proposal: command
-   default, teleport as ablation flag).
-3. **Task selection**: which RoboLab task(s) and how many episodes per arm
-   for acceptable power? (Depends on natural failure rate from the smoke
-   data.)
-4. **"Last good" definition**: strictly the last boundary with clean verdicts,
-   or last boundary with clean verdicts *and* forward progress (EE
-   displacement toward target)? Proposal: start with clean-verdicts only.
-5. **Where the delegation naming lands**: reuse the `coordination: delegation`
-   key from the unmerged `feat/multiagent-delegation-grounding` arm for
-   consistency, or keep this experiment's keys self-contained under
-   `recovery:`? (The delegated runtime itself is not needed — this loop is
-   its own runtime — but key naming should not collide later.)
-6. **LIBERO as development harness** (§10): build and debug the full recovery
-   loop on LIBERO first (cheap iteration, real state save/restore, in-domain
-   frames for the judge) and port to RoboLab as the final step — or go
-   RoboLab-direct?
-
-## 10. Would the methodology change on LIBERO / robosuite? (backend portability)
-
-Short answer: the **brain doesn't change; the plumbing collapses**. The entire
-Option-A/B/C deliberation in §3 exists only because RoboLab's sim loop lives
-inside an Isaac Sim docker process Odyssey can't reach into. That constraint
-is RoboLab-specific.
-
-### What is backend-agnostic by construction
-
-`ChunkLedger`, `StuckMonitor`, `SpecialistGate`, `RecoveryController`, the
-four experiment arms, the metrics, and the phasing were all deliberately
-designed as pure numpy/stdlib modules with no Isaac or RoboLab imports. They
-port verbatim. This is the same bet `ChunkPilotAdapter` already won across
-GR00T/π0.5/Cosmos3.
-
-### What changes per backend
-
-| | RoboLab | LIBERO | Robosuite |
-| --- | --- | --- | --- |
-| Loop ownership | RoboLab's `run.py` (Isaac docker) — must fork via `entry_script` | **ours**: `cosmos3_libero_eval.py` is Odyssey's own recipe | ours: `RobosuiteRunner` steps in-process |
-| Integration cost | docker mounts, PYTHONPATH, fork of external code | edit our own script — no external code touched | as LIBERO, but **no cosmos3 pilot wiring exists** (OpenVLA only) |
-| Proprio for `StuckMonitor` | joints read Isaac-side | robosuite obs carry joint/EE state natively | same |
-| `teleport` recovery | joint write via Isaac API (arm only) | **real sim-state restore** (`get_sim_state`/`set_init_state`, objects included) | same MuJoCo machinery |
-| `command` recovery | joint-space trajectory | EE-space P-controller emitting the env's native 7-D delta actions toward the saved EE pose | same |
-| Pilot domain fit | **in-domain** (Cosmos3-…-Policy-DROID on the DROID twin) | OOD until a Cosmos3-LIBERO SFT exists (quickstart-cosmos3 is OOD smoke) | no Cosmos3 path at all |
-| Judge visual domain | must calibrate on RoboLab frames (Phase 0) | probe already ran on this class of frames | uncalibrated |
-
-So on LIBERO the methodology *simplifies* rather than changes: no entry-script
-fork, no docker plumbing — the recovery loop wraps the rollout loop of our own
-recipe (`cosmos3_libero_eval.py`, `run_eval`), and mid-episode MuJoCo state
-save/restore makes `teleport` a *true* restore (objects included), which
-RoboLab can't offer. Robosuite is the weakest fit: it would first need the
-cosmos3 pilot wiring that LIBERO already has.
-
-### The trade-off is scientific, not architectural
-
-LIBERO buys iteration speed and determinism but costs validity: the
-cosmos3-droid pilot is OOD there, so failures are dominated by
-"policy doesn't know this domain" rather than the recoverable-stuck events the
-experiment is about, and "return to last good chunk" is less meaningful when
-few chunks are good. RoboLab is the opposite: in-domain pilot, meaningful
-stuck events, expensive plumbing.
-
-**Implication for staging** (open question 6): the strongest sequencing may be
-LIBERO as the *development harness* — Phases 1–2 (and mechanically Phase 3)
-debugged there with real state restore as ground truth — then RoboLab as the
-*headline experiment*, where the only new work left is the thin entry-script
-glue of §4.1(5). That converts RoboLab risk into a port, not a build.
-
-## 11. Prior art (web survey, 2026-08-11)
-
-**Nobody has done closed-loop recovery/intervention on RoboLab publicly.**
-All 16 issues on [NVlabs/RoboLab](https://github.com/NVlabs/RoboLab) (423★,
-last push 2026-08-10) are reproducibility/VRAM/checkpoint-access/success-judge
-questions — zero about intervention hooks, custom recovery backends, or
-mid-episode state control. The niche is open.
-
-The surrounding literature, though, is active and directly validates several
-of our design choices:
-
-| Work | What it does | Relevance to us |
-| --- | --- | --- |
-| [EWAM](https://arxiv.org/abs/2606.12690) (2026) | Closed-loop online adaptation on a **frozen Cosmos3 backbone**: internal anomaly-detection layer monitors predicted-vs-actual state divergence; a routing layer picks direct execution / conservative replanning / **rollback recovery**. Evaluated on **RoboLab and LIBERO** vs Cosmos3/GR2/π0. | The closest work — same backbone, same two benchmarks, includes rollback. Key difference: their detector/recovery is *learned internal layers*; ours is an **explicit multi-agent delegation** (separate Reasoner specialist, interpretable YES/NO verdicts, framework-orchestrated). EWAM is our natural published baseline; evaluating on both RoboLab *and* LIBERO matches their protocol (reinforces open question 6). |
-| [Rewind-IL](https://arxiv.org/html/2604.16683v1) (2026) | Online failure detection via **TIDE** (temporal inter-chunk discrepancy — divergence between the current chunk and the one predicted a step earlier, policy-internal, 0.2 ms) + **state respawning by commanding the robot back** to a checkpointed pose (not sim-state restore). Checkpoints picked semi-semantically (offline VLM labels + online feature similarity). RoboCasa + real bimanual; +13.3 pp success, 76.7% vs 18.3% under disturbance. | Validates the **`command` recovery mode** as the physically-honest default, and validates chunk-boundary checkpointing. Two ideas worth adopting: (a) an inter-chunk-discrepancy tier in `StuckMonitor` — at each boundary compare the tail of the previous chunk with the head of the new one (free at our cadence, no extra server calls); (b) *semantic* checkpoints (e.g. post-grasp boundaries as preferred rollback targets) over "most recent clean boundary". |
-| [FAR](https://arxiv.org/pdf/2607.01111) (2026) | Failure-aware retry for test-time recovery + continual improvement. | Retry-budget framing (our `max_recoveries`). |
-| [VLA-Corrector](https://arxiv.org/pdf/2607.01804) (2026) | Lightweight detect-and-correct on chunked VLAs: monitors latent visual dynamics, **truncates stale chunk actions** when drift persists, biases next inference toward recovery. | Names our exact blind spot — open-loop chunk execution — and supports flush-and-requery as the resume mechanism. |
-| [SV-VLA](https://arxiv.org/pdf/2604.02965) (2026) | Speculative verification: verifier monitors during macro-chunk execution, discards remaining chunk on deviation, replans. | Concurrent-verifier pattern ≈ our background `SpecialistGate`. |
-| [FailSafe](https://arxiv.org/html/2510.01642), [SAFE](https://arxiv.org/abs/2506.09937) (NeurIPS), [AHA](https://arxiv.org/abs/2410.00371) (ICLR'25) | VLM-based failure detection/reasoning for manipulation. | Establishes VLM-judge failure detection as a recognized approach; AHA-style failure *reasoning* is a v2 direction for the specialist (explain, not just flag). |
-
-**Positioning**: our contribution is not "recovery exists" (EWAM/Rewind-IL
-cover that) but (a) recovery as **explicit agent delegation** — a served
-Reasoner specialist with interpretable verdicts, composed by an orchestration
-framework, swappable per mission YAML — vs learned internal machinery; and
-(b) doing it on RoboLab's in-domain DROID policy, where no public work has
-put a specialist in the loop.
-
-**Design updates adopted from the survey**: add the inter-chunk-discrepancy
-signal as a third `StuckMonitor` tier (cheap, policy-internal, complements
-kinematics + VLM); keep `command` as default recovery (Rewind-IL evidence);
-consider semantic rollback targets (post-grasp) as a Phase 3 option; report
-EWAM as baseline context in the write-up.
-
-## 12. Code-level compatibility: VLA-Corrector and SV-VLA (repo audit, 2026-08-11)
-
-Both papers released code. Audited for direct integration into Odyssey's
-served-pilot architecture (the pilot is an HTTP/WebSocket server: frames in,
-action chunks out — **no policy latents, no gradients on the wire**).
-
-### [VLA-Corrector](https://github.com/ZJU-OmniAI/vla-corrector) — Apache-2.0, 66★, active (2026-07)
-
-**What the repo is**: a LeRobot fork plus a self-contained
-`src/siglip_dynamics/` module — the ~40M-param latent dynamics corrector
-(MLP/DiT variants), latent-cache extraction (`extract.py`), training
-(`train.py`), and an inference surface with promisingly clean names
-(`inference/circuit_breaker.py`, `safety_module.py`, `guidance_injector.py`).
-Evaluated on π0.5/SmolVLA/X-VLA over MetaWorld + **LIBERO** + real AgileX.
-
-**Mechanism → portability, piece by piece**:
-
-| Piece | What it needs | Fits served pilot? |
-| --- | --- | --- |
-| Event-triggered **truncation** (discard stale queued actions on drift) | a flush hook on the action queue | **Yes, trivially** — maps 1:1 onto a new `ChunkPilotAdapter.flush()` (we already flush on instruction change; this adds flush-on-trigger). Their ablation: truncation *alone* gives +11.65 of the +15.65 pp on MetaWorld — **most of the win is the black-box-compatible part**. |
-| **LVM** (latent-space vision monitor): learned dynamics model predicting visual-feature evolution from features + executed actions; drift = predicted vs observed mismatch | a visual encoder + executed actions + trained ~40M corrector | **Adaptable**: they read the frozen VLA's own SigLIP features, which our wire doesn't expose — but client-side we *do* have every frame and every executed action, so an **independent SigLIP encoder** feeding the same corrector architecture is a faithful variant. Requires training the corrector on our rollout videos (capture already exists). The `siglip_dynamics` module is importable/vendorable (Apache-2.0). |
-| **OGG** (online gradient guidance for the recovery replan) | gradients through the policy | **No** — impossible through a server. Skip, citing their own truncation-only ablation as the justification. |
-
-### [SV-VLA](https://github.com/edsad122/SV-VLA) — MIT, 10★, OpenVLA fork
-
-**What the repo is**: a prismatic/OpenVLA fork. The "lightweight verifier" is
-a **temporal-fusion head grafted onto the same OpenVLA backbone** (extra tiny
-ViT via timm, `vla_scripts/temporal_fusion_utils.py` loads
-`OpenVLAForActionPrediction` with fusion modules), trained on RLDS tfrecords
-(`train_from_pruning_tfrecord.py`). Replan triggers when the deviation between
-the executing macro-chunk (64) and the verifier's high-frequency reference
-actions (chunk 8) exceeds `controller_deviation_threshold`.
-
-**Portability verdict**: **no direct code reuse.** The verifier is not
-observation-only — it shares the OpenVLA backbone in-process and needs
-training on that backbone; none of that transfers to a served Cosmos3 WAM.
-The *pattern* (cheap high-frequency reference vs executing chunk, deviation
-threshold) is already covered training-free by the Rewind-IL-style
-inter-chunk-discrepancy tier adopted in §11. SV-VLA's headline is efficiency
-(2.17× speed-up), which is orthogonal to our recovery goal. Cite as related
-work only.
-
-### Resulting detector ensemble (supersedes the two-tier sketch in §4.1)
-
-`StuckMonitor` becomes a tiered, ablatable ensemble — each tier is a config
-flag, giving the experiment its ablation arms for free:
-
-1. **Kinematic** (free, every step): commanded motion vs actual displacement.
-2. **Inter-chunk discrepancy** (free, per boundary): previous chunk tail vs
-   new chunk head (Rewind-IL TIDE-style, training-free).
-3. **Latent-dynamics drift** (optional, trained): VLA-Corrector-style LVM on
-   an independent SigLIP encoder — *stretch goal / Phase 3+*, needs a
-   corrector training run on our rollouts.
-4. **VLM specialist retry trigger** (per boundary, async): Cosmos3-Nano
-   Reasoner — the delegation headline, and the only tier that understands
-   *semantics* (dropped object, wrong object, unreachable target).
-
-Trigger action for tiers 1–3 = truncate + re-query (VLA-Corrector semantics,
-via `ChunkPilotAdapter.flush()`); tier 4 additionally decides **rollback** to
-the ledger's last-good snapshot. Licenses (Apache-2.0, MIT) are both
-compatible with vendoring if we lift the corrector architecture later.
-
-## 13. Iteration scoping decision (2026-08-11): VLA-first
-
-**Decision**: iteration 1 runs the recovery mental model on the VLAs we
-already operate end-to-end — **GR00T (primary) and π0.5 (secondary) on
-LIBERO** — and defers the WAM/RoboLab arm (which requires the entry-script
-fork of §3) to iteration 2 as a port. This resolves open questions 3 and 6.
-
-### Why this is the better experiment, not just the safer one
-
-Recovery research needs **recoverable failures**: a policy competent enough
-that "return to the last good chunk" lands it back in known-good territory.
-Ranking the substrates:
-
-| Substrate | Pilot domain fit | Failure supply | Plumbing cost |
-| --- | --- | --- | --- |
-| GR00T × LIBERO | **in-domain** (10/10 on `libero_object` t0; t1 5/5) | **controlled** — the existing GR00T×LIBERO perturbation harness induces failures on demand (`docs/gr00t-libero-perturbations-summary.md`) | lowest: our own recipes, in-process auto-serve, known-good VMs |
-| π0.5 × LIBERO | in-domain (fine-tune path exists, PR #90) | natural + perturbable | low: openpi server pre-started, recipe is ours |
-| Cosmos3-droid × RoboLab | in-domain | natural only, uncontrolled | highest: RoboLab fork + Isaac docker |
-| Cosmos3-droid × LIBERO | **OOD** (no LIBERO SFT) | failures are domain mismatch, few good chunks exist — wrong failure *type* | low |
-
-In-domain policy + controlled perturbation = the cleanest causal read on
-whether detection→rollback→re-query converts failures into successes. Even
-the RoboLab fork wouldn't buy that control.
-
-### What changes and what doesn't
-
-**Unchanged**: the four pure modules (§4.1), the detector ensemble (§12), the
-four arms + metrics (§5), the phasing (§7), and — importantly — the
-**specialist**: Cosmos3-Nano Reasoner via vLLM stays the delegation headline
-(it is pilot-independent; the reasoner-probe Phase 0 calibration applies
-as-is, and the cosmos3 branch work on `openai_judge` / probe stays
-load-bearing).
-
-**Changed**:
-
-- Pilots: `pilot: gr00t` (primary; in-domain + perturbation harness) and
-  `pilot: pi05` (secondary; demonstrates pilot-agnosticism across an
-  auto-served and a pre-started-server pilot).
-- Harness: LIBERO recipes we own — no external code forked. `teleport`
-  recovery = real MuJoCo state restore (§10), `command` = EE-delta
-  P-controller.
-- Stuck induction: the perturbation harness is now a *first-class* part of
-  the protocol (perturb-at-step-k, measure recovery), not a fallback.
-- **Migration note**: `gr00t_libero_eval.py` still inlines its own chunk loop
-  and does not use `ChunkPilotAdapter`; moving it onto the adapter is a
-  prerequisite (and a wanted consolidation anyway) so `flush()`/ledger hooks
-  are shared across all pilots.
-
-**Deferred to iteration 2+**: RoboLab entry-script fork + Cosmos3 WAM pilot
-(the §3–§4 design stands, becomes a port per §10); LVM trained tier (§12
-tier 3); semantic re-instruction on recovery (open question 1, v2);
-FlowDAgger-style *steering* recovery (GR00T-only: instead of rolling back,
-steer the frozen flow policy's noise — a third recovery mode candidate,
-connects to the drugsort L1 work).
-
-### The LVM tier across GR00T and π0.5 — pilot-agnostic by construction
-
-Decision (2026-08-11): the VLA-Corrector-style tier targets **both pilots
-with one design**, which is only possible because §12 already replaced the
-paper's faithful variant (reading the VLA's own SigLIP features) with an
-**independent client-side SigLIP encoder**. The faithful variant cannot be
-pilot-agnostic here: π0.5 sits behind openpi's WebsocketPolicyServer (no
-internals on the wire) and GR00T auto-serves in-process (internals reachable
-but pilot-coupled). The external variant needs only what both pilots already
-expose identically in our eval loops: the frames and the decoded 7-D env
-actions passed to `env.step()`.
-
-Consequences:
-
-- **One corrector can serve both pilots**: it models *environment* dynamics
-  conditioned on env-level actions — nothing about the policy enters the
-  model. Same env, same action space ⇒ shareable weights; only the trigger
-  thresholds are calibrated per pilot (chunk sizes differ), conformal-style
-  on successful-rollout discrepancy distributions (the Rewind-IL recipe:
-  ~99.9th percentile).
-- **Finetuned checkpoints are an asset, not a problem**: the corrector never
-  touches policy weights, so base-vs-finetuned is irrelevant to
-  compatibility — and finetuned checkpoints are exactly what makes training
-  data cheap. GR00T-LIBERO at 10/10 with ~30 s episodes can mass-produce
-  successful rollouts today. π0.5's corrector quality is gated on its
-  finetune (PR #90) producing enough successful rollouts — GPU smoke still
-  pending there.
-- **New instrumentation requirement**: current capture saves MP4s but *not
-  actions*. The recipes must log per-step (frame, action) pairs (e.g. an
-  `.npz` next to each rollout video) — this is the corrector's training
-  corpus, and it costs nothing to start collecting from the first Phase 2
-  runs even though the LVM tier itself is Phase 3+.
-- OGG stays excluded for both pilots (gradients through a server — see §12).
-
-### Branch note
-
-Iteration 1 lives on **`feat/vla-recovery-closedloop`, cut from `develop`**
-(the cosmos3-integration base was dropped once the WAM/RoboLab arm moved to
-iteration 2 — nothing cosmos3-specific remains in scope). Two pieces were
-ported over from `cosmos3-integration` because they had not reached develop
-yet: `src/odyssey/runners/agents/openai_judge.py` and
-`tests/unit/test_openai_judge.py` (self-contained; suite green on this base).
-Still on the cosmos3 branch, to port when Phase 0 starts: the reasoner-probe
-example (`examples/cosmos3-reasoner-probe/`) — it is pilot-agnostic (probes
-rollout MP4s through the judge) and would be renamed to a neutral
-`examples/reasoner-probe/` here.
+| Detection | trained LVM (~40M params) over latent visual dynamics | tier 1 kinematic + tier 2 inter-chunk (training-free) + tier 4 specialist VLM (semantic) — **+ the LVM as tier 3 in PR 2** |
+| Response | truncate stale chunk + re-query (+ OGG gradient guidance) | truncate (same mechanism) **+ rollback** to the last-good snapshot (not in the paper) |
+
+**Adopted now (PR 1)**: event-triggered **truncation** → a new
+`ChunkPilotAdapter.flush()`. The paper's own ablation shows truncation alone carries
+most of the gain (MetaWorld 48.70 → 60.35 of the full 64.35). Plus per-step
+**(frame, action) logging** — this is exactly the training corpus the LVM needs.
+
+**Adopted next (PR 2)**: the **LVM detector**, as the *independent-encoder variant*:
+our pilots are served over HTTP/WebSocket, so the paper's faithful read of the VLA's
+internal SigLIP features is unavailable — instead a client-side SigLIP encoder feeds
+the same corrector architecture (vendorable from `src/siglip_dynamics/`,
+Apache-2.0), trained on the rollouts PR 1 logs, plugged in as one more detector tier
+behind the same trigger interface. The ordering is a hard data dependency: the LVM
+cannot be trained before rollouts are logged.
+
+**Never**: **OGG** (online gradient guidance) — needs gradients through the policy,
+impossible with served pilots.
+
+**Finetuned checkpoints are fully compatible**: the paper keeps the VLA frozen (it
+evaluates finetuned π0.5 on LIBERO: 94.0 → 97.8) and our external variant never
+touches policy weights. Finetuned GR00T/π0.5 checkpoints are in fact what makes
+corpus generation cheap. GR00T is not evaluated in the paper (its backbone is not
+SigLIP-based) — another reason the independent-encoder variant is the right fit.
+
+Related work informing the design (details in git history): EWAM
+(<https://arxiv.org/abs/2606.12690>, rollback on a Cosmos3 backbone — our published
+baseline), Rewind-IL (<https://arxiv.org/abs/2604.16683>, command-back respawn +
+inter-chunk TIDE signal), SV-VLA (<https://arxiv.org/abs/2604.02965>, concurrent
+verifier pattern; no code reuse — OpenVLA-fork entangled).
+
+## 3. Architecture
+
+New strict-mypy modules in `src/odyssey/runners/agents/`:
+
+- **`recovery.py`** (stdlib-only math): `BoundarySnapshot` + `ChunkLedger`
+  (boundary snapshots: EE pos/quat, gripper, optional sim state, per-tier verdicts;
+  `last_good()` defines "last successful chunk"), `StuckMonitor` (tier 1: commanded
+  motion vs EE displacement over a window; tier 2: new-chunk head vs previous-chunk
+  tail continuity), `RecoveryController` (EE-space P-controller emitting 7-D OSC
+  delta actions back to a snapshot; outcomes idle/driving/arrived/exhausted),
+  `RecoveryPolicy` (orchestrator: tiers 1–2 → **flush**, specialist verdict →
+  **rollback**; `shadow_mode`; `max_recoveries` budget; staleness rules; jsonl
+  events + metrics), `RolloutLog` (npz per episode: `frames uint8[T,H,W,3]`,
+  `actions float32[T,7]`).
+- **`specialist_gate.py`**: `STUCK_PROMPT_TEMPLATE` (ported RETRY wording from the
+  reasoner probe) + `SpecialistGate` — background single-worker thread + mailbox,
+  at-most-one call in flight, skip-never-queue (judge slower than a chunk degrades
+  to skipped polls), (episode, chunk) staleness tags, injectable executor for
+  deterministic tests. `specialist_max_tokens` defaults 256 (reasoner CoT truncates
+  at the judge's default 8) + `extra_body={"modalities": ["text"]}`.
+
+Changes to existing code:
+
+- `ChunkPilotAdapter.flush()` — drop the buffered chunk so the next `act()`
+  re-queries (`steps_remaining == 0` already flags boundaries incl. post-flush).
+- **GR00T recipe migrated onto `ChunkPilotAdapter`** (it still inlines its chunk
+  loop today); equivalence pinned by test (identical actions + query cadence vs the
+  old loop). π0.5 already uses the adapter.
+- Recovery wiring in both recipes behind default-off flags (`recovery`,
+  `shadow_mode`, `recovery_mode command|teleport`, stuck thresholds,
+  `poll_every_chunks`, `specialist_base_url/model`, `log_actions`, …) — flags off ⇒
+  byte-identical behavior to today. `teleport` hasattr-guards `get_sim_state` and
+  degrades to `command`.
+- `LiberoRunner`: runner-resolved `--recovery_dir` (the `--video_dir` pattern);
+  recovery counts flow through `ODYSSEY_RESULT` metrics into `result_summary`
+  verbatim; `recovery_events.jsonl` + npz attached as artifacts.
+- Examples: `examples/reasoner-probe/` (ported pilot-neutral from
+  `cosmos3-integration~1`) and `examples/recovery-gr00t-libero/` (PILOT GR00T +
+  SPECIALIST Cosmos3-Nano mission, arms A–D documented).
+
+## 4. Implementation plan (PR 1 — draft PR → develop, 9 commits, each green)
+
+1. `feat(agents): ChunkPilotAdapter.flush()` + tests
+2. `feat(recovery): pure recovery core — ledger, tiered monitor, EE controller, policy` + tests
+3. `feat(recovery): async specialist stuck-gate over the OpenAI-compat judge` + tests
+4. `refactor(gr00t-libero): migrate inline chunk loop onto ChunkPilotAdapter` + equivalence tests
+5. `feat(recovery): wire recovery/specialist/rollout-logging into both LIBERO recipes` + tests
+6. `feat(libero): recovery_dir plumbing + recovery artifacts in LiberoRunner` + tests
+7. `feat(examples): port reasoner-probe (pilot-neutral)`
+8. `feat(examples): recovery-gr00t-libero mission`
+9. `docs(recovery): implementation status`
+
+Detailed file-by-file plan (APIs, flags, test list):
+`~/.claude/plans/clever-giggling-harbor.md`.
+
+**Top risks**: command-mode controller vs OSC gains/frames (shadow first; exhausted
+outcome is data; teleport ablation isolates it) · GR00T migration regression
+(equivalence test; per-episode `pilot.reset()`) · gate thread lifecycle/staleness
+(at-most-one in flight, judge-side timeout, injectable executor) · `get_sim_state`
+unverified (guarded degrade) · npz memory (~100 MB/episode pre-compression;
+per-episode save, default-off).
+
+## 5. Roadmap
+
+- **PR 1 (this)**: recovery skeleton + VLA-Corrector truncation + rollout logging.
+- **PR 2**: VLA-Corrector LVM tier — vendor/adapt `siglip_dynamics`, train the
+  corrector on the logged corpus, calibrate thresholds conformal-style, plug in as
+  tier 3.
+- **GPU phases (after PR 1 merges)**: 0) specialist calibration with
+  `examples/reasoner-probe/` on our rollout videos · 2) shadow runs (arm B data) ·
+  3) live arms A/C/D.
+- **Iteration 2**: port to Cosmos3-WAM × RoboLab (entry-script design preserved in
+  this file's git history).

--- a/docs/experiment-recovery-design-vla.md
+++ b/docs/experiment-recovery-design-vla.md
@@ -1,0 +1,559 @@
+# Closed-loop recovery experiment — VLA pilots (GR00T / π0.5) + Reasoner specialist
+
+**Branch**: `feat/vla-recovery-closedloop` (off `develop`)
+**Status**: design draft — iteration 1 scoped VLA-first, see §13 (which
+supersedes the RoboLab/WAM framing of §§1–6 for this iteration; that design
+is kept as the iteration-2 target).
+
+> History: this doc started as the Cosmos3-WAM × RoboLab design
+> (`docs/cosmos3-recovery-experiment-design.md` on the discarded
+> `feat/cosmos3-recovery-closedloop` branch). §§10–13 record how analysis,
+> prior art, and the code audit re-scoped iteration 1 onto the VLAs we
+> already operate end-to-end. The only cosmos3-branch *code* this experiment
+> needs — the generic `OpenAICompatCompletionJudge`
+> (`runners/agents/openai_judge.py` + its unit test, 19 tests green on this
+> base) — has been ported onto this branch; the specialist model
+> (Cosmos3-Nano Reasoner) is pure served config, not a code dependency.
+
+## 1. The experiment
+
+Can a SPECIALIST agent, watching the sim **while** the PILOT executes action
+chunks, detect that the arm is stuck and trigger a recovery that returns the
+arm to the last *successful* action-chunk boundary — and does that recovery
+improve episode success rate?
+
+- **Pilot**: `nvidia/Cosmos3-Nano-Policy-DROID` (chunk-emitting WAM, served by
+  cosmos-framework's `action_policy_server_robolab`, WebSocket).
+- **Specialist**: `nvidia/Cosmos3-Nano` Reasoner (vLLM-Omni, OpenAI-compatible
+  endpoint) — the exact judge `examples/cosmos3-reasoner-probe/` already
+  exercises, including a `RETRY_TEMPLATE` ("is the robot FAILED or STUCK such
+  that it should abort and retry?") that is the seed of the stuck check.
+- **Eval**: RoboLab (NVlabs' Isaac Lab twin of the DROID rig), already a
+  first-class `evaluation_type: robolab` (`runners/evals/robolab.py`).
+- **Coordination style**: delegation — the specialist authors no plan; it is
+  asked perception questions on demand while actions are produced
+  (the PR #68 delegation spirit, moved from post-hoc video probing to
+  real-time in-the-loop).
+
+This is the step from *post-hoc* analysis (reasoner probe on rollout MP4s) to
+*concurrent* analysis (verdicts consumed inside the control loop).
+
+## 2. What exists today (inventory)
+
+| Piece | Where | State |
+| --- | --- | --- |
+| Cosmos3 pilot factory (HTTP client + chunk adapter) | `runners/models/cosmos3.py` (`make_cosmos3_pilot`, lines 75–138) | done (LIBERO wire) |
+| Chunk buffer/replay + flush-on-instruction-change | `runners/agents/chunk_pilot.py` (`ChunkPilotAdapter`) | done, pilot-agnostic |
+| Chunk-boundary VLM polling (cost model: poll per chunk, not per step) | `runners/agents/completion_gate.py` (`ChunkCompletionGate`) | done, **not wired** into any default flow |
+| OpenAI-compat YES/NO judge (vLLM, `modalities:["text"]` fix, zoom/upscale lesson from issue #78) | `runners/agents/openai_judge.py` + `examples/cosmos3-reasoner-probe/` | done, validated post-hoc |
+| RoboLab runner (subprocess, `episode_results.jsonl` scoring, docker bring-up) | `runners/evals/robolab.py` + `examples/cosmos3-robolab/` | done, H100-smoked |
+| `entry_script` mission knob (select RoboLab policy backend) | `robolab.py` handled config keys; README: "a future backend is a mission edit, not a new runner" | done — **our hook** |
+| Multi-agent runtimes (planner arm) | `runners/agents/{runtime,planner,planned,remote_planner}.py` | done (planning), delegation arm lives on `feat/multiagent-delegation-grounding`, **not merged here** |
+| SPECIALIST role in mission spec | `spec/agents.py` (`AgentRole.SPECIALIST`) | done |
+
+What does **not** exist: any per-step observation access or mid-episode state
+manipulation for RoboLab from Odyssey. `RobolabRunner` launches
+`policies/cosmos3/run.py`, waits, and reads `episode_results.jsonl`. The sim
+loop, the policy WebSocket client, and all robot state live inside the Isaac
+Sim docker process.
+
+## 3. The architectural gap and the placement decision
+
+The closed loop needs three capabilities RoboLab's stock `run.py` doesn't
+expose: (a) frames at chunk boundaries for the specialist, (b) a decision
+point between chunks, (c) a way to move the arm back to a saved configuration.
+
+### Options considered
+
+**A. Policy-proxy shim (interpose on the WebSocket).** Odyssey starts a proxy
+that RoboLab connects to as if it were the policy server; the proxy forwards
+obs → real server, sees every observation and chunk, and can substitute a
+"recovery chunk" (reverse-replay of executed deltas). No RoboLab fork.
+*Rejected as primary*: no access to proprio/joint state (the DROID wire is
+video-conditioned), recovery must be approximated by negating action deltas
+(fragile: controller dynamics, gripper state), and the RoboLab client wire
+protocol has to be reverse-engineered and pinned. Keep in the back pocket.
+
+**B. Custom RoboLab entry script (recommended).** A recovery-aware sibling of
+`policies/cosmos3/run.py`, selected via the existing `config.entry_script`
+mission knob, running **inside** the Isaac process where robot state is
+first-class. It reuses RoboLab's own policy client and env setup and wraps the
+step loop with our recovery logic. The *brains* (stuck gate, chunk ledger,
+recovery trajectory) live in Odyssey as pure numpy/stdlib modules — same
+pattern as `ChunkPilotAdapter`/`ChunkCompletionGate`: unit-testable without
+GPU/Isaac, imported by the entry script via the dual bind-mount +
+`sys.path.insert(repo/src)` trick the example bridges already use.
+
+**C. Do it on LIBERO instead.** In-process env, `set_init_state`, full loop
+control — much easier plumbing. *Rejected as the headline* (the experiment is
+DROID-rig + RoboLab by design) but noted as a de-risking fallback if RoboLab
+iteration cost becomes the bottleneck.
+
+### Decision
+
+**Option B**: Odyssey-owned recovery brain + thin Isaac-side entry script.
+Rationale: real joint access makes "return to last good chunk" a *commanded*
+motion (transferable to a real arm) instead of an action-algebra
+approximation; RoboLab's client code is reused rather than re-implemented; and
+the mission-level surface is just `entry_script:` + config keys — no new
+runner, minor `RobolabRunner` extensions for artifacts.
+
+## 4. Proposed architecture
+
+```
+┌────────────────────────────── Isaac Sim docker ──────────────────────────────┐
+│  recovery_run.py  (entry_script — sibling of policies/cosmos3/run.py)        │
+│                                                                              │
+│   sim step loop ──► chunk boundary ──► ChunkLedger.snapshot(joints, frame)   │
+│        │                   │                                                 │
+│        │                   ├─► StuckMonitor (kinematic, cheap, every step)   │
+│        │                   │                                                 │
+│        │                   └─► SpecialistGate ──(bg thread)──► vLLM Reasoner │
+│        │                              │      verdict mailbox   (Cosmos3-Nano)│
+│        ▼                              ▼                                      │
+│   policy WebSocket client      RecoveryController                            │
+│   (RoboLab's own, unchanged)   (joint-interp back to last-good snapshot,     │
+│        │                        then flush pilot chunk state + re-query)     │
+│        ▼                                                                     │
+│   action_policy_server_robolab (Cosmos3-Nano-Policy-DROID)                   │
+│                                                                              │
+│   emits: episode_results.jsonl (+ per-episode recovery events)               │
+└──────────────────────────────────────────────────────────────────────────────┘
+   Odyssey side: RobolabRunner (unchanged launch) + recovery_events artifact
+                 + recovery metrics folded into result_summary
+```
+
+### 4.1 Components (new code)
+
+1. **`ChunkLedger`** (`src/odyssey/runners/agents/chunk_ledger.py`, pure).
+   At every chunk boundary records: chunk index, joint positions + gripper
+   state, EE pose if available, boundary frame (downscaled), and later the
+   verdicts. Exposes `last_good()` — the most recent boundary whose verdicts
+   were clean. This *defines* "último action chunk exitoso": a chunk after
+   which neither the kinematic monitor nor the specialist flagged trouble.
+
+2. **`StuckMonitor`** (same module or sibling, pure). Cheap kinematic
+   first-tier: commanded motion ≠ 0 but EE/joint displacement < ε over the
+   last K steps ⇒ *stuck candidate*. Runs every step, costs nothing, and
+   gates the expensive VLM call — this is the false-positive/latency
+   flywheel: the specialist is only consulted when physics already looks
+   suspicious (plus a low-rate background poll, `poll_every_chunks`, to catch
+   semantic failure modes the kinematics can't see, e.g. dropped object).
+
+3. **`SpecialistGate`** (evolution of `ChunkCompletionGate`). Wraps the
+   existing `OpenAICompatCompletionJudge` with the `RETRY_TEMPLATE`-style
+   stuck prompt, but **asynchronously**: the judge call (~1–2 s) runs in a
+   background thread; the sim never blocks. Verdicts land in a mailbox and
+   are consumed at the *next* chunk boundary. A chunk of 16 steps at DROID
+   control rate gives comfortable headroom; a verdict arriving one boundary
+   late is acceptable because "stuck" is a persistent state, not an edge.
+   Includes timeout + in-flight-call cancellation on episode end.
+
+4. **`RecoveryController`** (pure numpy). Given current joints and the
+   `last_good()` snapshot, emits a joint-space interpolated trajectory
+   (M steps, capped velocity) driving the arm back, gripper commanded to the
+   snapshot's state. After arrival: flush the pilot's chunk state (the
+   WebSocket client just re-queries — the server is stateless per call) and
+   resume normal control from the restored pose. Budget: `max_recoveries`
+   per episode; exceeding it ends the episode as a scored failure with
+   reason `recovery_budget_exhausted`.
+
+5. **`recovery_run.py`** (`examples/cosmos3-recovery-robolab/`, Isaac-side).
+   Forked from RoboLab's `policies/cosmos3/run.py`; wraps its loop with 1–4.
+   Writes `recovery_events.jsonl` (one line per trigger: step, cause
+   kinematic|specialist, verdict latency, rollback target chunk, outcome)
+   next to `episode_results.jsonl`. Example-bridge conventions: repo-`src`
+   path injection, argparse passthrough, not in strict-mypy scope.
+
+6. **`RobolabRunner` extensions** (small): copy `recovery_events.jsonl` as an
+   artifact when present; fold counts (recoveries triggered / episodes with
+   recovery / post-recovery successes) into `result_summary.metrics`.
+
+7. **Mission surface**: SPECIALIST agent declared in `robot.agents`
+   (`nvidia/Cosmos3-Nano`); eval task keys (all passthrough → argv, no spec
+   change needed):
+
+   ```yaml
+   config:
+     entry_script: examples/cosmos3-recovery-robolab/recovery_run.py  # host path, dual-mounted
+     specialist_base_url: "http://<host>:8002/v1"
+     specialist_model: nvidia/Cosmos3-Nano
+     recovery: true            # false = baseline arm of the experiment
+     shadow_mode: false        # true = detect + log, never intervene (Phase 2)
+     stuck_eps_m: 0.005        # kinematic threshold
+     stuck_window_steps: 12
+     poll_every_chunks: 2
+     max_recoveries: 3
+     recovery_steps: 24
+   ```
+
+### 4.2 Concurrency model (the "fontanería")
+
+Single sim thread, one background judge thread, mailbox in between — no
+asyncio inside Isaac (their loop is synchronous; a thread + `queue.Queue` is
+the entire concurrency story). Ordering guarantees:
+
+- Snapshot happens *before* the chunk that follows it executes, so a rollback
+  target is always a pose the arm actually held at a boundary.
+- At most one specialist call in flight; if a boundary arrives while one is
+  pending, we skip launching another (the pending verdict covers it).
+- A stale verdict (episode ended, or a recovery already ran since the frame
+  was captured) is discarded by tagging calls with (episode, chunk index).
+- Recovery is exclusive: while the `RecoveryController` drives, the policy
+  client is not queried and the monitors are muted until arrival + settle.
+
+### 4.3 Recovery semantics — command-back vs teleport
+
+Two modes, worth having both behind a flag:
+
+- **`command` (default, headline)**: drive the arm back via the controller.
+  Physically honest, transferable to a real robot, but can fail (truly wedged
+  arm may not track the trajectory — that itself is a measurable outcome).
+- **`teleport` (ablation/upper bound)**: write joint state directly into the
+  articulation (Isaac API). Clean geometry, breaks physics realism (held
+  objects, contacts). Useful to separate "detector was right" from "recovery
+  motion failed".
+
+Not proposed: full sim-state restore (objects included). It measures a
+different (purely sim-side) capability and has no real-robot analogue.
+
+## 5. Experiment protocol
+
+**Arms** (same task set, same episode seeds/init states where RoboLab allows):
+
+| Arm | recovery | specialist | purpose |
+| --- | --- | --- | --- |
+| A. baseline | off | off | today's success rate |
+| B. shadow | off | on (log-only) | detector precision/recall + latency, zero intervention |
+| C. kinematic-only | on | off | is the VLM adding anything over physics? |
+| D. full delegation | on | on | the headline |
+
+**Metrics**: episode success rate per arm; detector precision/recall (shadow
+verdicts vs post-hoc labels from rollout videos — the reasoner-probe tooling
+already produces per-frame verdict tables for exactly this kind of labeling);
+recoveries per episode; post-recovery success rate (episodes that succeeded
+after ≥1 recovery — the direct evidence recovery *causes* success); judge
+latency distribution; wall-clock overhead per arm.
+
+**Stuck induction**: start with the natural failure rate (the policy on
+RoboLab is not saturated; failures exist — `episode_results.jsonl` already
+carries failure reasons to mine). If natural stuck events are too rare for
+statistical power, inject perturbations in the entry script (action-offset
+window, transient gripper freeze) — the GR00T×LIBERO perturbation work
+(`docs/gr00t-libero-perturbations-summary.md`) is the precedent. Decide after
+Phase 2 data.
+
+## 6. GPU topology
+
+Three GPU consumers (H100-class box, per the existing bring-up):
+
+1. Policy server (Nano-Policy-DROID, bf16 ≥32 GB) — port 8000.
+2. vLLM Reasoner (Cosmos3-Nano) — port 8002, bounded `--gpu-memory-utilization`.
+3. RoboLab Isaac docker (rendering + PhysX).
+
+Mandatory: `disable_subtask: true` in the mission — RoboLab otherwise
+auto-spawns its *own* ~50 GB vLLM judge (documented VRAM landmine in
+`examples/cosmos3-robolab/README.md`). Our specialist replaces it. If one
+card can't hold all three, split policy server vs (Isaac + reasoner) across
+two — all links are already network-transparent.
+
+## 7. Phasing (de-risk order)
+
+- **Phase 0 — specialist calibration (no new code)**: run the existing
+  reasoner probe against RoboLab rollout videos (from the smoke runs) with
+  the retry/stuck question; verify the judge discriminates stuck vs nominal
+  on *this* visual domain before building anything on it (issue #78 lesson:
+  the judge, not the camera, was the problem last time).
+- **Phase 1 — pure modules + tests (no GPU)**: `ChunkLedger`, `StuckMonitor`,
+  `SpecialistGate` (fake judge), `RecoveryController`; unit tests pin
+  ordering, mailbox staleness, budget, trajectory bounds. Strict-mypy clean.
+- **Phase 2 — shadow mode on hardware**: entry script forked, specialist
+  wired, `recovery: false, shadow_mode: true`. Validates the fontanería
+  (mounts, imports, threading, latency) with zero behavioral risk, and
+  yields the detector-quality data (arm B).
+- **Phase 3 — recovery live**: arms A/C/D, headline comparison.
+
+Phase boundaries are also natural PR boundaries (draft PR → develop, per
+repo flow).
+
+## 8. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| RoboLab `run.py` internals differ from assumption (loop/client structure) — the fork inherits them | Read + pin the actual `run.py` from the checkout **first task of Phase 2**; keep the fork minimal (wrap, don't rewrite) |
+| Judge quality on RoboLab frames (issue #78 déjà vu: always-NO/always-YES) | Phase 0 gate — no build-out until the probe discriminates; zoom/upscale knobs already exist |
+| Judge latency > chunk duration | Async mailbox tolerates one-boundary lag; `poll_every_chunks` throttle; measure in Phase 2 |
+| Commanded rollback fails when genuinely wedged | That outcome is itself data; `teleport` ablation isolates it; recovery budget bounds the cost |
+| Odyssey code import inside the Isaac container | Already-solved pattern: dual bind-mount + `PYTHONPATH` + example-bridge `src` injection (see robolab README wrapper table) |
+| Natural stuck events too rare | Perturbation injection fallback (§5); decide on Phase 2 data |
+| VRAM contention (3 consumers) | `disable_subtask`, bounded vLLM util, two-card split if needed |
+
+## 9. Open questions (to settle before plan mode)
+
+1. **Recovery semantics v1**: geometric rollback only (return + re-query), or
+   should the specialist also *re-instruct* the pilot on recovery (e.g. "lift
+   the arm and retry") — true delegation? Proposal: v1 geometric (measurable,
+   simple), v2 semantic re-instruction as follow-up.
+2. **`command` vs `teleport`** as default recovery mode (proposal: command
+   default, teleport as ablation flag).
+3. **Task selection**: which RoboLab task(s) and how many episodes per arm
+   for acceptable power? (Depends on natural failure rate from the smoke
+   data.)
+4. **"Last good" definition**: strictly the last boundary with clean verdicts,
+   or last boundary with clean verdicts *and* forward progress (EE
+   displacement toward target)? Proposal: start with clean-verdicts only.
+5. **Where the delegation naming lands**: reuse the `coordination: delegation`
+   key from the unmerged `feat/multiagent-delegation-grounding` arm for
+   consistency, or keep this experiment's keys self-contained under
+   `recovery:`? (The delegated runtime itself is not needed — this loop is
+   its own runtime — but key naming should not collide later.)
+6. **LIBERO as development harness** (§10): build and debug the full recovery
+   loop on LIBERO first (cheap iteration, real state save/restore, in-domain
+   frames for the judge) and port to RoboLab as the final step — or go
+   RoboLab-direct?
+
+## 10. Would the methodology change on LIBERO / robosuite? (backend portability)
+
+Short answer: the **brain doesn't change; the plumbing collapses**. The entire
+Option-A/B/C deliberation in §3 exists only because RoboLab's sim loop lives
+inside an Isaac Sim docker process Odyssey can't reach into. That constraint
+is RoboLab-specific.
+
+### What is backend-agnostic by construction
+
+`ChunkLedger`, `StuckMonitor`, `SpecialistGate`, `RecoveryController`, the
+four experiment arms, the metrics, and the phasing were all deliberately
+designed as pure numpy/stdlib modules with no Isaac or RoboLab imports. They
+port verbatim. This is the same bet `ChunkPilotAdapter` already won across
+GR00T/π0.5/Cosmos3.
+
+### What changes per backend
+
+| | RoboLab | LIBERO | Robosuite |
+| --- | --- | --- | --- |
+| Loop ownership | RoboLab's `run.py` (Isaac docker) — must fork via `entry_script` | **ours**: `cosmos3_libero_eval.py` is Odyssey's own recipe | ours: `RobosuiteRunner` steps in-process |
+| Integration cost | docker mounts, PYTHONPATH, fork of external code | edit our own script — no external code touched | as LIBERO, but **no cosmos3 pilot wiring exists** (OpenVLA only) |
+| Proprio for `StuckMonitor` | joints read Isaac-side | robosuite obs carry joint/EE state natively | same |
+| `teleport` recovery | joint write via Isaac API (arm only) | **real sim-state restore** (`get_sim_state`/`set_init_state`, objects included) | same MuJoCo machinery |
+| `command` recovery | joint-space trajectory | EE-space P-controller emitting the env's native 7-D delta actions toward the saved EE pose | same |
+| Pilot domain fit | **in-domain** (Cosmos3-…-Policy-DROID on the DROID twin) | OOD until a Cosmos3-LIBERO SFT exists (quickstart-cosmos3 is OOD smoke) | no Cosmos3 path at all |
+| Judge visual domain | must calibrate on RoboLab frames (Phase 0) | probe already ran on this class of frames | uncalibrated |
+
+So on LIBERO the methodology *simplifies* rather than changes: no entry-script
+fork, no docker plumbing — the recovery loop wraps the rollout loop of our own
+recipe (`cosmos3_libero_eval.py`, `run_eval`), and mid-episode MuJoCo state
+save/restore makes `teleport` a *true* restore (objects included), which
+RoboLab can't offer. Robosuite is the weakest fit: it would first need the
+cosmos3 pilot wiring that LIBERO already has.
+
+### The trade-off is scientific, not architectural
+
+LIBERO buys iteration speed and determinism but costs validity: the
+cosmos3-droid pilot is OOD there, so failures are dominated by
+"policy doesn't know this domain" rather than the recoverable-stuck events the
+experiment is about, and "return to last good chunk" is less meaningful when
+few chunks are good. RoboLab is the opposite: in-domain pilot, meaningful
+stuck events, expensive plumbing.
+
+**Implication for staging** (open question 6): the strongest sequencing may be
+LIBERO as the *development harness* — Phases 1–2 (and mechanically Phase 3)
+debugged there with real state restore as ground truth — then RoboLab as the
+*headline experiment*, where the only new work left is the thin entry-script
+glue of §4.1(5). That converts RoboLab risk into a port, not a build.
+
+## 11. Prior art (web survey, 2026-08-11)
+
+**Nobody has done closed-loop recovery/intervention on RoboLab publicly.**
+All 16 issues on [NVlabs/RoboLab](https://github.com/NVlabs/RoboLab) (423★,
+last push 2026-08-10) are reproducibility/VRAM/checkpoint-access/success-judge
+questions — zero about intervention hooks, custom recovery backends, or
+mid-episode state control. The niche is open.
+
+The surrounding literature, though, is active and directly validates several
+of our design choices:
+
+| Work | What it does | Relevance to us |
+| --- | --- | --- |
+| [EWAM](https://arxiv.org/abs/2606.12690) (2026) | Closed-loop online adaptation on a **frozen Cosmos3 backbone**: internal anomaly-detection layer monitors predicted-vs-actual state divergence; a routing layer picks direct execution / conservative replanning / **rollback recovery**. Evaluated on **RoboLab and LIBERO** vs Cosmos3/GR2/π0. | The closest work — same backbone, same two benchmarks, includes rollback. Key difference: their detector/recovery is *learned internal layers*; ours is an **explicit multi-agent delegation** (separate Reasoner specialist, interpretable YES/NO verdicts, framework-orchestrated). EWAM is our natural published baseline; evaluating on both RoboLab *and* LIBERO matches their protocol (reinforces open question 6). |
+| [Rewind-IL](https://arxiv.org/html/2604.16683v1) (2026) | Online failure detection via **TIDE** (temporal inter-chunk discrepancy — divergence between the current chunk and the one predicted a step earlier, policy-internal, 0.2 ms) + **state respawning by commanding the robot back** to a checkpointed pose (not sim-state restore). Checkpoints picked semi-semantically (offline VLM labels + online feature similarity). RoboCasa + real bimanual; +13.3 pp success, 76.7% vs 18.3% under disturbance. | Validates the **`command` recovery mode** as the physically-honest default, and validates chunk-boundary checkpointing. Two ideas worth adopting: (a) an inter-chunk-discrepancy tier in `StuckMonitor` — at each boundary compare the tail of the previous chunk with the head of the new one (free at our cadence, no extra server calls); (b) *semantic* checkpoints (e.g. post-grasp boundaries as preferred rollback targets) over "most recent clean boundary". |
+| [FAR](https://arxiv.org/pdf/2607.01111) (2026) | Failure-aware retry for test-time recovery + continual improvement. | Retry-budget framing (our `max_recoveries`). |
+| [VLA-Corrector](https://arxiv.org/pdf/2607.01804) (2026) | Lightweight detect-and-correct on chunked VLAs: monitors latent visual dynamics, **truncates stale chunk actions** when drift persists, biases next inference toward recovery. | Names our exact blind spot — open-loop chunk execution — and supports flush-and-requery as the resume mechanism. |
+| [SV-VLA](https://arxiv.org/pdf/2604.02965) (2026) | Speculative verification: verifier monitors during macro-chunk execution, discards remaining chunk on deviation, replans. | Concurrent-verifier pattern ≈ our background `SpecialistGate`. |
+| [FailSafe](https://arxiv.org/html/2510.01642), [SAFE](https://arxiv.org/abs/2506.09937) (NeurIPS), [AHA](https://arxiv.org/abs/2410.00371) (ICLR'25) | VLM-based failure detection/reasoning for manipulation. | Establishes VLM-judge failure detection as a recognized approach; AHA-style failure *reasoning* is a v2 direction for the specialist (explain, not just flag). |
+
+**Positioning**: our contribution is not "recovery exists" (EWAM/Rewind-IL
+cover that) but (a) recovery as **explicit agent delegation** — a served
+Reasoner specialist with interpretable verdicts, composed by an orchestration
+framework, swappable per mission YAML — vs learned internal machinery; and
+(b) doing it on RoboLab's in-domain DROID policy, where no public work has
+put a specialist in the loop.
+
+**Design updates adopted from the survey**: add the inter-chunk-discrepancy
+signal as a third `StuckMonitor` tier (cheap, policy-internal, complements
+kinematics + VLM); keep `command` as default recovery (Rewind-IL evidence);
+consider semantic rollback targets (post-grasp) as a Phase 3 option; report
+EWAM as baseline context in the write-up.
+
+## 12. Code-level compatibility: VLA-Corrector and SV-VLA (repo audit, 2026-08-11)
+
+Both papers released code. Audited for direct integration into Odyssey's
+served-pilot architecture (the pilot is an HTTP/WebSocket server: frames in,
+action chunks out — **no policy latents, no gradients on the wire**).
+
+### [VLA-Corrector](https://github.com/ZJU-OmniAI/vla-corrector) — Apache-2.0, 66★, active (2026-07)
+
+**What the repo is**: a LeRobot fork plus a self-contained
+`src/siglip_dynamics/` module — the ~40M-param latent dynamics corrector
+(MLP/DiT variants), latent-cache extraction (`extract.py`), training
+(`train.py`), and an inference surface with promisingly clean names
+(`inference/circuit_breaker.py`, `safety_module.py`, `guidance_injector.py`).
+Evaluated on π0.5/SmolVLA/X-VLA over MetaWorld + **LIBERO** + real AgileX.
+
+**Mechanism → portability, piece by piece**:
+
+| Piece | What it needs | Fits served pilot? |
+| --- | --- | --- |
+| Event-triggered **truncation** (discard stale queued actions on drift) | a flush hook on the action queue | **Yes, trivially** — maps 1:1 onto a new `ChunkPilotAdapter.flush()` (we already flush on instruction change; this adds flush-on-trigger). Their ablation: truncation *alone* gives +11.65 of the +15.65 pp on MetaWorld — **most of the win is the black-box-compatible part**. |
+| **LVM** (latent-space vision monitor): learned dynamics model predicting visual-feature evolution from features + executed actions; drift = predicted vs observed mismatch | a visual encoder + executed actions + trained ~40M corrector | **Adaptable**: they read the frozen VLA's own SigLIP features, which our wire doesn't expose — but client-side we *do* have every frame and every executed action, so an **independent SigLIP encoder** feeding the same corrector architecture is a faithful variant. Requires training the corrector on our rollout videos (capture already exists). The `siglip_dynamics` module is importable/vendorable (Apache-2.0). |
+| **OGG** (online gradient guidance for the recovery replan) | gradients through the policy | **No** — impossible through a server. Skip, citing their own truncation-only ablation as the justification. |
+
+### [SV-VLA](https://github.com/edsad122/SV-VLA) — MIT, 10★, OpenVLA fork
+
+**What the repo is**: a prismatic/OpenVLA fork. The "lightweight verifier" is
+a **temporal-fusion head grafted onto the same OpenVLA backbone** (extra tiny
+ViT via timm, `vla_scripts/temporal_fusion_utils.py` loads
+`OpenVLAForActionPrediction` with fusion modules), trained on RLDS tfrecords
+(`train_from_pruning_tfrecord.py`). Replan triggers when the deviation between
+the executing macro-chunk (64) and the verifier's high-frequency reference
+actions (chunk 8) exceeds `controller_deviation_threshold`.
+
+**Portability verdict**: **no direct code reuse.** The verifier is not
+observation-only — it shares the OpenVLA backbone in-process and needs
+training on that backbone; none of that transfers to a served Cosmos3 WAM.
+The *pattern* (cheap high-frequency reference vs executing chunk, deviation
+threshold) is already covered training-free by the Rewind-IL-style
+inter-chunk-discrepancy tier adopted in §11. SV-VLA's headline is efficiency
+(2.17× speed-up), which is orthogonal to our recovery goal. Cite as related
+work only.
+
+### Resulting detector ensemble (supersedes the two-tier sketch in §4.1)
+
+`StuckMonitor` becomes a tiered, ablatable ensemble — each tier is a config
+flag, giving the experiment its ablation arms for free:
+
+1. **Kinematic** (free, every step): commanded motion vs actual displacement.
+2. **Inter-chunk discrepancy** (free, per boundary): previous chunk tail vs
+   new chunk head (Rewind-IL TIDE-style, training-free).
+3. **Latent-dynamics drift** (optional, trained): VLA-Corrector-style LVM on
+   an independent SigLIP encoder — *stretch goal / Phase 3+*, needs a
+   corrector training run on our rollouts.
+4. **VLM specialist retry trigger** (per boundary, async): Cosmos3-Nano
+   Reasoner — the delegation headline, and the only tier that understands
+   *semantics* (dropped object, wrong object, unreachable target).
+
+Trigger action for tiers 1–3 = truncate + re-query (VLA-Corrector semantics,
+via `ChunkPilotAdapter.flush()`); tier 4 additionally decides **rollback** to
+the ledger's last-good snapshot. Licenses (Apache-2.0, MIT) are both
+compatible with vendoring if we lift the corrector architecture later.
+
+## 13. Iteration scoping decision (2026-08-11): VLA-first
+
+**Decision**: iteration 1 runs the recovery mental model on the VLAs we
+already operate end-to-end — **GR00T (primary) and π0.5 (secondary) on
+LIBERO** — and defers the WAM/RoboLab arm (which requires the entry-script
+fork of §3) to iteration 2 as a port. This resolves open questions 3 and 6.
+
+### Why this is the better experiment, not just the safer one
+
+Recovery research needs **recoverable failures**: a policy competent enough
+that "return to the last good chunk" lands it back in known-good territory.
+Ranking the substrates:
+
+| Substrate | Pilot domain fit | Failure supply | Plumbing cost |
+| --- | --- | --- | --- |
+| GR00T × LIBERO | **in-domain** (10/10 on `libero_object` t0; t1 5/5) | **controlled** — the existing GR00T×LIBERO perturbation harness induces failures on demand (`docs/gr00t-libero-perturbations-summary.md`) | lowest: our own recipes, in-process auto-serve, known-good VMs |
+| π0.5 × LIBERO | in-domain (fine-tune path exists, PR #90) | natural + perturbable | low: openpi server pre-started, recipe is ours |
+| Cosmos3-droid × RoboLab | in-domain | natural only, uncontrolled | highest: RoboLab fork + Isaac docker |
+| Cosmos3-droid × LIBERO | **OOD** (no LIBERO SFT) | failures are domain mismatch, few good chunks exist — wrong failure *type* | low |
+
+In-domain policy + controlled perturbation = the cleanest causal read on
+whether detection→rollback→re-query converts failures into successes. Even
+the RoboLab fork wouldn't buy that control.
+
+### What changes and what doesn't
+
+**Unchanged**: the four pure modules (§4.1), the detector ensemble (§12), the
+four arms + metrics (§5), the phasing (§7), and — importantly — the
+**specialist**: Cosmos3-Nano Reasoner via vLLM stays the delegation headline
+(it is pilot-independent; the reasoner-probe Phase 0 calibration applies
+as-is, and the cosmos3 branch work on `openai_judge` / probe stays
+load-bearing).
+
+**Changed**:
+
+- Pilots: `pilot: gr00t` (primary; in-domain + perturbation harness) and
+  `pilot: pi05` (secondary; demonstrates pilot-agnosticism across an
+  auto-served and a pre-started-server pilot).
+- Harness: LIBERO recipes we own — no external code forked. `teleport`
+  recovery = real MuJoCo state restore (§10), `command` = EE-delta
+  P-controller.
+- Stuck induction: the perturbation harness is now a *first-class* part of
+  the protocol (perturb-at-step-k, measure recovery), not a fallback.
+- **Migration note**: `gr00t_libero_eval.py` still inlines its own chunk loop
+  and does not use `ChunkPilotAdapter`; moving it onto the adapter is a
+  prerequisite (and a wanted consolidation anyway) so `flush()`/ledger hooks
+  are shared across all pilots.
+
+**Deferred to iteration 2+**: RoboLab entry-script fork + Cosmos3 WAM pilot
+(the §3–§4 design stands, becomes a port per §10); LVM trained tier (§12
+tier 3); semantic re-instruction on recovery (open question 1, v2);
+FlowDAgger-style *steering* recovery (GR00T-only: instead of rolling back,
+steer the frozen flow policy's noise — a third recovery mode candidate,
+connects to the drugsort L1 work).
+
+### The LVM tier across GR00T and π0.5 — pilot-agnostic by construction
+
+Decision (2026-08-11): the VLA-Corrector-style tier targets **both pilots
+with one design**, which is only possible because §12 already replaced the
+paper's faithful variant (reading the VLA's own SigLIP features) with an
+**independent client-side SigLIP encoder**. The faithful variant cannot be
+pilot-agnostic here: π0.5 sits behind openpi's WebsocketPolicyServer (no
+internals on the wire) and GR00T auto-serves in-process (internals reachable
+but pilot-coupled). The external variant needs only what both pilots already
+expose identically in our eval loops: the frames and the decoded 7-D env
+actions passed to `env.step()`.
+
+Consequences:
+
+- **One corrector can serve both pilots**: it models *environment* dynamics
+  conditioned on env-level actions — nothing about the policy enters the
+  model. Same env, same action space ⇒ shareable weights; only the trigger
+  thresholds are calibrated per pilot (chunk sizes differ), conformal-style
+  on successful-rollout discrepancy distributions (the Rewind-IL recipe:
+  ~99.9th percentile).
+- **Finetuned checkpoints are an asset, not a problem**: the corrector never
+  touches policy weights, so base-vs-finetuned is irrelevant to
+  compatibility — and finetuned checkpoints are exactly what makes training
+  data cheap. GR00T-LIBERO at 10/10 with ~30 s episodes can mass-produce
+  successful rollouts today. π0.5's corrector quality is gated on its
+  finetune (PR #90) producing enough successful rollouts — GPU smoke still
+  pending there.
+- **New instrumentation requirement**: current capture saves MP4s but *not
+  actions*. The recipes must log per-step (frame, action) pairs (e.g. an
+  `.npz` next to each rollout video) — this is the corrector's training
+  corpus, and it costs nothing to start collecting from the first Phase 2
+  runs even though the LVM tier itself is Phase 3+.
+- OGG stays excluded for both pilots (gradients through a server — see §12).
+
+### Branch note
+
+Iteration 1 lives on **`feat/vla-recovery-closedloop`, cut from `develop`**
+(the cosmos3-integration base was dropped once the WAM/RoboLab arm moved to
+iteration 2 — nothing cosmos3-specific remains in scope). Two pieces were
+ported over from `cosmos3-integration` because they had not reached develop
+yet: `src/odyssey/runners/agents/openai_judge.py` and
+`tests/unit/test_openai_judge.py` (self-contained; suite green on this base).
+Still on the cosmos3 branch, to port when Phase 0 starts: the reasoner-probe
+example (`examples/cosmos3-reasoner-probe/`) — it is pilot-agnostic (probes
+rollout MP4s through the judge) and would be renamed to a neutral
+`examples/reasoner-probe/` here.

--- a/docs/experiment-recovery-design-vla.md
+++ b/docs/experiment-recovery-design-vla.md
@@ -1,7 +1,15 @@
 # Experiment: closed-loop VLA recovery (GR00T / π0.5) with VLA-Corrector integration
 
 **Branch**: `experiment-vla-recovery-closed-loop` (off `develop`)
-**Status**: design final + implementation plan agreed; implementation not started.
+**Status**: PR 1 **implemented** (2026-08-11) — all nine commits of §4 landed:
+`ChunkPilotAdapter.flush()`, `runners/agents/recovery.py` (ledger / tiered
+monitor / EE controller / policy / npz corpus), `runners/agents/specialist_gate.py`,
+the GR00T recipe migrated onto the adapter (equivalence-tested), recovery wired
+into both recipes via `evals/recovery_wiring.py` (default-off inert),
+`LiberoRunner` recovery_dir + artifacts, `examples/reasoner-probe/` (Phase 0)
+and `examples/recovery-gr00t-libero/` (arms A–D). ~90 new unit tests; suite
+green; strict mypy clean. **Next**: GPU phases 0/2/3 on the VM, then PR 2 (LVM
+tier).
 **Paper being integrated**: [VLA-Corrector — Lightweight Detect-and-Correct Inference
 for Adaptive Action Horizon](https://arxiv.org/abs/2607.01804)
 **Code being integrated**: <https://github.com/ZJU-OmniAI/vla-corrector>

--- a/examples/reasoner-probe/README.md
+++ b/examples/reasoner-probe/README.md
@@ -1,0 +1,92 @@
+# Reasoner SPECIALIST probe — grasp / stuck verification
+
+Eval-only mission that answers, **before any closed-loop wiring**: can a served
+VLM reasoner — **any OpenAI-compatible endpoint**; the shipped default is
+`nvidia/Cosmos3-Nano` (the Reasoner surface of the Cosmos 3 family, *not* the
+`-Policy-DROID` action model) — work as a perception SPECIALIST? This is
+**Phase 0 of the recovery experiment**
+(`docs/experiment-recovery-design-vla.md`): the `retry` question below is
+exactly the stuck check the recovery loop's `SpecialistGate` runs
+(`STUCK_PROMPT_TEMPLATE`), so calibrate the judge on your rollout videos here
+before trusting it in the loop.
+
+It follows the *delegation* posture of the planner-vs-delegation experiment
+(PR #68, closed unmerged): the SPECIALIST authors no plan; it answers on-demand
+perception questions. The probe drives `OpenAICompatCompletionJudge` (the
+`CompletionDetector` the multi-agent runtimes gate on — issue #78's "stronger
+judge" direction) over frames sampled at 0% / 50% / 75% / 100% of rollout MP4s,
+asking four YES/NO questions per frame:
+
+| question   | failed rollout             | successful rollout                  |
+|------------|----------------------------|-------------------------------------|
+| control    | YES everywhere (arm visible) | YES everywhere                    |
+| grasp      | NO everywhere              | **YES while the object is held**    |
+| completion | NO everywhere              | YES at the end                      |
+| retry      | YES late in the episode    | NO everywhere                       |
+
+`control` detects the Gemma-judge degenerate mode (always NO). The grasp
+column is the discrimination a delegation SPECIALIST needs. Metric-only: no
+success_rate is fabricated.
+
+## 1. Serve the Reasoner (GPU box; the AR surface loads ≈ 40 GB)
+
+```bash
+sudo docker run --rm --gpus all --network host \
+    -v ~/.cache/huggingface:/root/.cache/huggingface \
+    vllm/vllm-omni:v0.26.0 \
+    vllm serve nvidia/Cosmos3-Nano --host 0.0.0.0 --port 8002 \
+        --gpu-memory-utilization 0.60 --max-model-len 32768
+```
+
+**Plain `vllm serve`, NOT `--omni`** (validated on H100, 2026-08-10):
+`Cosmos3ForConditionalGeneration` is registered in plain vLLM and that is the
+reasoning path — image+text in, text out, sub-second replies. Under `--omni`
+the identical chat request routes to the *diffusion* pipeline: 50 denoise
+steps and an image reply, so no YES/NO text ever comes back and every verdict
+parses as the conservative NO (and in the `:cosmos3` image tag the half-built
+text path 500s / can OOM the diffusion worker). `--omni --no-guardrails`
+remains the recipe for *generation* serving only (the gated
+`nvidia/Cosmos-1.0-Guardrail` would otherwise 401 at startup). Trim
+`--gpu-memory-utilization` to co-exist with other jobs on the GPU.
+
+## 2. Stage probe frames
+
+Two directories of rollout MP4s, one per polarity:
+
+- `videos_dir` of task 1 → **failed** rollouts, e.g. the `videos/` dir of a
+  `quickstart-cosmos3` OOD smoke under `~/.odyssey/runs/<mission>/<task>/videos/`.
+- `videos_dir` of task 2 → **successful** rollouts (e.g. FlowDAgger UR5e
+  drug-sort evals). Set each task's `config.instruction` to what its rollouts
+  attempted.
+
+## 3. Run
+
+```bash
+odyssey run examples/reasoner-probe/mission.yaml
+```
+
+The eval env needs `imageio` + `pillow` (the `env_pilot_cosmos3` from
+`../quickstart-cosmos3/setup.sh` has both — name it via `config.eval_python`).
+
+## Reading the result
+
+`metrics.verdicts` carries one row per (question, frame) with the answer,
+latency and a reply excerpt. Interpretation:
+
+- `control_yes_rate` < 1.0 → the judge can't even confirm the scene; distrust
+  the rest (this is what #78's Gemma judge failed).
+- `grasp` YES concentrated on held-object frames of successful rollouts, NO on
+  failed rollouts → a real grasp-verification SPECIALIST candidate.
+- `latency_s_mean` bounds how often you could afford to gate (the multi-agent
+  runtimes judge at chunk boundaries, ~every 16 env steps).
+- An all-NO grasp column is **not automatically the #78 degenerate mode**:
+  check where the grasp window actually falls. In the UR5e FlowDAgger evals
+  the pick lands in the first ~15% of the episode and the episode idles at
+  the tick cap after early success, so p50/p75/p100 samples are honestly NO.
+  Disambiguate with a dense paired-question sweep (holding? vs empty? on
+  `view: wrist` crops): H100 findings (2026-08-10) — Cosmos3-Nano answers the
+  pair consistently and flags holding=YES inside the true grasp window, so it
+  works as a *gripper-state oracle on wrist crops*; open-ended "is the task
+  done" phrasings still bias NO even post-success, and fine object-location
+  questions are unreliable at 256px. Prefer concrete perception questions
+  over task-completion phrasings when wiring it as a SPECIALIST.

--- a/examples/reasoner-probe/mission-success.yaml
+++ b/examples/reasoner-probe/mission-success.yaml
@@ -1,0 +1,105 @@
+# Cosmos 3 Reasoner SPECIALIST probe — grasp verification (eval-only, custom
+# runner, no simulator).
+#
+# NAMING: `nvidia/Cosmos3-Nano` (the base omnimodal model — the REASONER
+# surface, 16B) is NOT `nvidia/Cosmos3-Nano-Policy-DROID` (the action policy).
+# This mission probes the former as a SPECIALIST candidate in the DELEGATION
+# spirit of the planner-vs-delegation experiment (PR #68, closed unmerged): the
+# SPECIALIST authors no plan — it answers on-demand perception questions, the
+# headline one being GRASP VERIFICATION ("is the object secured in the
+# gripper?"), plus the stock completion check and a retry check. This is the
+# "stronger judge" direction of issue #78 (the co-resident Gemma int4
+# check_done answered NO essentially always — the control question here
+# detects exactly that degenerate mode).
+#
+# It exercises `OpenAICompatCompletionJudge` — the CompletionDetector surface a
+# multi-agent mission would drop this model into — over frames sampled at
+# several positions of existing rollout MP4s. Two tasks give both polarities:
+# failed rollouts (grasp/completion should stay NO) and successful rollouts
+# (grasp should flip YES mid-episode, completion at the end). Metric-only: no
+# fabricated success_rate.
+#
+# EXTERNALLY-SERVED (same posture as the WAM policy evals) — start vLLM-Omni
+# first on a GPU box (Nano 16B bf16 ≈ 32 GB; release-tested container):
+#
+#     sudo docker run --rm --gpus all --network host \
+#         -v ~/.cache/huggingface:/root/.cache/huggingface \
+#         vllm/vllm-omni:cosmos3 \
+#         vllm serve nvidia/Cosmos3-Nano --omni --port 8002 \
+#             --init-timeout 1800 --gpu-memory-utilization 0.55 --no-guardrails
+#
+# `--no-guardrails` skips the GATED nvidia/Cosmos-1.0-Guardrail download (same
+# rationale as the cosmos-framework policy-server workaround in
+# ../quickstart-cosmos3/setup.sh: the guardrails moderate GENERATED media, not
+# a YES/NO judgement path). The Reasoner emits chain-of-thought before its
+# verdict — max_tokens must be generous (the judge's 8-token default would
+# truncate before any YES/NO token and every answer would parse as a spurious NO).
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: cosmos3-reasoner-specialist-probe-success
+  description: >-
+    Eval-only probe of the Cosmos 3 Reasoner (Cosmos3-Nano) as a
+    grasp-verification SPECIALIST — control / grasp / completion / retry
+    judgements over failed and successful rollout frames via the
+    OpenAI-compatible judge surface, delegation-style.
+  tags: [cosmos3, reasoner, nvidia, specialist, grasp, delegation, judge, custom, eval-only]
+
+objective: |
+  Verify that a served Cosmos3-Nano Reasoner loads and answers the judge
+  protocol, and measure whether its YES/NO verdicts track grasp state across
+  rollout frames — the grounding a delegation-style SPECIALIST needs before
+  any multi-agent wiring.
+
+acceptance_criteria: |
+  All judge calls succeed against the endpoint; the control question answers
+  YES (no always-NO degenerate mode); grasp verdicts discriminate held-object
+  frames from pre-grasp and post-place frames; per-call latency is workable
+  for chunk-boundary gating.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    # The spec requires a PILOT in the loadout; it is recorded but NOT
+    # exercised — this mission probes the SPECIALIST only.
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: nvidia/Cosmos3-Nano-Policy-DROID
+    - id: specialist
+      role: SPECIALIST
+      model:
+        source: huggingface
+        base: nvidia/Cosmos3-Nano   # the Reasoner surface, served by vLLM-Omni
+
+tasks:
+  # Polarity 2 — SUCCESSFUL rollouts (UR5e drug-sort FlowDAgger evals): grasp
+  # should flip YES while the object is held, completion YES at the end.
+  - name: probe-grasp-success-rollouts
+    kind: evaluation
+    evaluation_type: custom
+    description: >-
+      Judge frames of successful UR5e drug-sort rollouts through the same
+      endpoint — the YES polarity of grasp verification.
+    benchmark_name: reasoner_grasp_probe
+    num_episodes: 12
+    config:
+      eval_script: examples/reasoner-probe/reasoner_probe.py
+      checkpoint: nvidia/Cosmos3-Nano
+      base_url: http://127.0.0.1:8002/v1
+      model: nvidia/Cosmos3-Nano
+      videos_dir: ~/cosmos3_probe_videos_success
+      instruction: pick up the red capsule and place it in the blue tray
+      max_videos: 3
+      max_tokens: 1024
+      timeout_seconds: 180
+      # Issue #78 zoom lesson: the UR5e rollouts are 256x512 concat_view —
+      # crop to the wrist half (where the grasp actually is) and upscale.
+      view: wrist
+      upscale: 3
+
+leaderboard:
+  publish: false

--- a/examples/reasoner-probe/mission.yaml
+++ b/examples/reasoner-probe/mission.yaml
@@ -1,0 +1,113 @@
+# Cosmos 3 Reasoner SPECIALIST probe — grasp verification (eval-only, custom
+# runner, no simulator).
+#
+# NAMING: `nvidia/Cosmos3-Nano` (the base omnimodal model — the REASONER
+# surface, 16B) is NOT `nvidia/Cosmos3-Nano-Policy-DROID` (the action policy).
+# This mission probes the former as a SPECIALIST candidate in the DELEGATION
+# spirit of the planner-vs-delegation experiment (PR #68, closed unmerged): the
+# SPECIALIST authors no plan — it answers on-demand perception questions, the
+# headline one being GRASP VERIFICATION ("is the object secured in the
+# gripper?"), plus the stock completion check and a retry check. This is the
+# "stronger judge" direction of issue #78 (the co-resident Gemma int4
+# check_done answered NO essentially always — the control question here
+# detects exactly that degenerate mode).
+#
+# It exercises `OpenAICompatCompletionJudge` — the CompletionDetector surface a
+# multi-agent mission would drop this model into — over frames sampled at
+# several positions of existing rollout MP4s. Two tasks give both polarities:
+# failed rollouts (grasp/completion should stay NO) and successful rollouts
+# (grasp should flip YES mid-episode, completion at the end). Metric-only: no
+# fabricated success_rate.
+#
+# EXTERNALLY-SERVED (same posture as the WAM policy evals) — serve with plain
+# vLLM (NOT `--omni`!) from the vllm-omni v0.26.0 image on a GPU box (the AR
+# reasoning surface loads ≈ 40 GB; H100-class):
+#
+#     sudo docker run --rm --gpus all --network host \
+#         -v ~/.cache/huggingface:/root/.cache/huggingface \
+#         vllm/vllm-omni:v0.26.0 \
+#         vllm serve nvidia/Cosmos3-Nano --host 0.0.0.0 --port 8002 \
+#             --gpu-memory-utilization 0.60 --max-model-len 32768
+#
+# ⚠ MODE MATTERS (validated on H100, 2026-08-10): `Cosmos3ForConditionalGeneration`
+# is registered in plain vLLM — that is the REASONING path (image+text -> text,
+# sub-second replies). Under `--omni` the same chat request routes to the
+# DIFFUSION pipeline instead: 50 denoise steps, an *image* reply (never YES/NO
+# text, so every verdict parses as the conservative NO), and in the `:cosmos3`
+# image the half-built text path 500s / can OOM the diffusion worker. The
+# judge's extra_body `{"modalities": ["text"]}` is kept as belt-and-braces —
+# plain vLLM accepts it and omni-routed endpoints need it. (`--omni` +
+# `--no-guardrails` remains the recipe for *generation* serving, where the
+# gated nvidia/Cosmos-1.0-Guardrail would otherwise 401 at startup.)
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: cosmos3-reasoner-specialist-probe
+  description: >-
+    Eval-only probe of the Cosmos 3 Reasoner (Cosmos3-Nano) as a
+    grasp-verification SPECIALIST — control / grasp / completion / retry
+    judgements over failed and successful rollout frames via the
+    OpenAI-compatible judge surface, delegation-style.
+  tags: [cosmos3, reasoner, nvidia, specialist, grasp, delegation, judge, custom, eval-only]
+
+objective: |
+  Verify that a served Cosmos3-Nano Reasoner loads and answers the judge
+  protocol, and measure whether its YES/NO verdicts track grasp state across
+  rollout frames — the grounding a delegation-style SPECIALIST needs before
+  any multi-agent wiring.
+
+acceptance_criteria: |
+  All judge calls succeed against the endpoint; the control question answers
+  YES (no always-NO degenerate mode); grasp verdicts discriminate held-object
+  frames from pre-grasp and post-place frames; per-call latency is workable
+  for chunk-boundary gating.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    # The spec requires a PILOT in the loadout; it is recorded but NOT
+    # exercised — this mission probes the SPECIALIST only.
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: nvidia/Cosmos3-Nano-Policy-DROID
+    - id: specialist
+      role: SPECIALIST
+      model:
+        source: huggingface
+        base: nvidia/Cosmos3-Nano   # the Reasoner surface, served by vLLM-Omni
+
+tasks:
+  # Polarity 1 — FAILED rollouts (e.g. the quickstart-cosmos3 OOD smoke):
+  # grasp + completion should stay NO everywhere; retry should flip YES late.
+  # (The spec allows exactly one evaluation task per mission — the successful-
+  # rollout polarity lives in mission-success.yaml.)
+  - name: probe-grasp-failed-rollouts
+    kind: evaluation
+    evaluation_type: custom
+    description: >-
+      Judge frames of failed LIBERO rollouts (control / grasp / completion /
+      retry) through the endpoint serving Cosmos3-Nano.
+    benchmark_name: reasoner_grasp_probe
+    num_episodes: 8                  # frames probed (4 positions per video)
+    config:
+      eval_script: examples/reasoner-probe/reasoner_probe.py
+      # eval_python: /path/to/env_pilot_cosmos3/bin/python   # needs imageio+pillow
+      checkpoint: nvidia/Cosmos3-Nano          # recorded in the summary only
+      # --- forwarded verbatim to the script (snake_case -> --flags) ---
+      base_url: http://127.0.0.1:8002/v1       # the vLLM-Omni endpoint
+      model: nvidia/Cosmos3-Nano               # served model id
+      videos_dir: ~/cosmos3_probe_videos       # *_FAIL.mp4 from the OOD smoke
+      instruction: pick up the alphabet soup and place it in the basket
+      max_videos: 2
+      max_tokens: 1024                         # room for the Reasoner's CoT
+      timeout_seconds: 180
+      # Issue #78 zoom lesson: starve the judge of pixels and every verdict
+      # collapses to NO. LIBERO rollouts are single-view 256px -> upscale only.
+      upscale: 3
+
+leaderboard:
+  publish: false

--- a/examples/reasoner-probe/reasoner_probe.py
+++ b/examples/reasoner-probe/reasoner_probe.py
@@ -1,0 +1,251 @@
+"""Probe a served Cosmos 3 Reasoner as a SPECIALIST candidate (grasp verification).
+
+Custom-eval script (``evaluation_type: custom`` contract: ``--checkpoint`` /
+``--out-json`` + passthrough flags). It exercises ``OpenAICompatCompletionJudge``
+— the exact ``CompletionDetector`` surface the multi-agent runtimes gate on —
+against an OpenAI-compatible endpoint serving a Cosmos 3 Reasoner (vLLM-Omni),
+in the DELEGATION spirit of the closed planner-vs-delegation experiment
+(PR #68): the SPECIALIST authors no plan; it is asked perception questions on
+demand. Four YES/NO questions per sampled frame:
+
+* ``control``    — "is a robot arm clearly visible?"  Detects the always-NO
+  degenerate mode issue #78 found in the Gemma int4 ``check_done`` judge.
+* ``grasp``      — **the headline check**: "is the object currently secured in
+  the gripper?"  Expect NO on pre-grasp / post-place frames and YES only while
+  the object is actually held (mid-episode of successful rollouts).
+* ``completion`` — the judge's stock done-check. Expect YES only at the end of
+  successful rollouts.
+* ``retry``      — "is the robot failed/stuck such that it should abort and
+  retry?"  Expect YES only late in failed rollouts.
+
+Frames are sampled at fractional positions through each rollout MP4 so the
+grasp window of successful episodes is covered. Metric-only: rates + latency +
+per-frame verdicts, no fabricated success_rate (position ground truth is
+qualitative).
+
+The Cosmos 3 Reasoner emits chain-of-thought; the judge's 8-token default would
+truncate it before any YES/NO token (parsing as a spurious NO), so ``--max_tokens``
+defaults high here and the raw replies are captured for diagnosis.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Runs under the eval env (env_pilot_cosmos3 etc.) where odyssey may not be
+# installed — resolve the repo's src/ relative to this file, like the other
+# example bridges.
+_REPO_SRC = Path(__file__).resolve().parents[2] / "src"
+if _REPO_SRC.is_dir():
+    sys.path.insert(0, str(_REPO_SRC))
+
+from odyssey.runners.agents.openai_judge import (  # noqa: E402
+    DEFAULT_PROMPT_TEMPLATE,
+    OpenAICompatCompletionJudge,
+)
+
+CONTROL_TEMPLATE = (
+    "You are a strict visual judge for a robot manipulation scene. "
+    "Look at the image and answer whether a robot arm and a tabletop scene "
+    "are clearly visible. Answer with exactly one word: YES or NO."
+    "{instruction:.0s}"  # template must consume the instruction slot
+)
+
+GRASP_TEMPLATE = (
+    "You are a strict visual judge verifying a robot grasp. "
+    "The robot is attempting this instruction: {instruction!r}. "
+    "Look at the image and answer whether the target object is CURRENTLY "
+    "secured in the robot's gripper — held between the gripper fingers, lifted "
+    "off the surface or clearly attached to the end-effector. An object still "
+    "resting on the table, already released at its destination, or a gripper "
+    "merely near the object is NOT a grasp. "
+    "Answer with exactly one word: YES or NO."
+)
+
+RETRY_TEMPLATE = (
+    "You are a strict visual judge monitoring a robot manipulation task. "
+    "The robot is attempting this instruction: {instruction!r}. "
+    "Look at the image and answer whether the robot is in a FAILED or STUCK "
+    "state such that it should abort and RETRY the task from the start "
+    "(e.g. object dropped or knocked over, arm wedged or flailing away from "
+    "the target, target unreachable from the current pose). "
+    "A nominal in-progress attempt is NOT a retry state. "
+    "Answer with exactly one word: YES or NO."
+)
+
+QUESTIONS = (
+    ("control", CONTROL_TEMPLATE),
+    ("grasp", GRASP_TEMPLATE),
+    ("completion", DEFAULT_PROMPT_TEMPLATE),
+    ("retry", RETRY_TEMPLATE),
+)
+
+FRAME_POSITIONS = (0.0, 0.5, 0.75, 1.0)
+
+
+def prepare_frame(frame: Any, view: str, upscale: int) -> Any:
+    """Crop to one half of a concat_view frame and/or upscale.
+
+    The issue #78 lesson (``check_crop``/``check_upscale``): small concat sim
+    frames starve the judge of pixels on the region that matters. ``wrist``
+    keeps the right half and ``side`` the left half of a 2:1-wide concat frame
+    (non-concat frames pass through untouched); ``upscale`` LANCZOS-resizes by
+    an integer factor.
+    """
+    import numpy as np
+    from PIL import Image
+
+    array = np.asarray(frame)
+    height, width = array.shape[:2]
+    if view in ("wrist", "side") and width == 2 * height:
+        array = array[:, width // 2 :] if view == "wrist" else array[:, : width // 2]
+    if upscale > 1:
+        img = Image.fromarray(array)
+        img = img.resize((img.width * upscale, img.height * upscale), Image.LANCZOS)
+        array = np.asarray(img)
+    return array
+
+
+def load_probe_frames(
+    videos_dir: Path, max_videos: int, view: str = "full", upscale: int = 1
+) -> list[dict[str, Any]]:
+    """Frames at ``FRAME_POSITIONS`` of each rollout MP4 (sorted for determinism)."""
+    import imageio.v3 as iio
+
+    videos = sorted(videos_dir.glob("*.mp4"))[:max_videos]
+    if not videos:
+        raise SystemExit(f"no .mp4 rollouts found under {videos_dir}")
+    frames: list[dict[str, Any]] = []
+    for video in videos:
+        stack = iio.imread(video)
+        for fraction in FRAME_POSITIONS:
+            index = min(int(fraction * (len(stack) - 1)), len(stack) - 1)
+            frames.append(
+                {
+                    "video": video.name,
+                    "position": f"p{int(fraction * 100)}",
+                    "image": prepare_frame(stack[index], view, upscale),
+                }
+            )
+    return frames
+
+
+def make_judge(args: argparse.Namespace, template: str) -> OpenAICompatCompletionJudge:
+    return OpenAICompatCompletionJudge(
+        base_url=args.base_url,
+        model=args.model,
+        prompt_template=template,
+        max_tokens=args.max_tokens,
+        timeout_seconds=args.timeout_seconds,
+        # vLLM-Omni routes image+text chat to IMAGE GENERATION (50 diffusion
+        # steps, image reply, no YES/NO text) unless the request selects the
+        # text output modality explicitly.
+        extra_body={"modalities": ["text"]},
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", required=True, help="recorded in the summary only")
+    parser.add_argument("--out-json", required=True)
+    parser.add_argument("--base_url", default="http://127.0.0.1:8002/v1")
+    parser.add_argument("--model", default="nvidia/Cosmos3-Nano")
+    parser.add_argument("--videos_dir", required=True, help="dir of rollout MP4s to probe")
+    parser.add_argument("--instruction", required=True, help="the task the rollouts attempted")
+    parser.add_argument("--max_videos", type=int, default=4)
+    parser.add_argument("--max_tokens", type=int, default=1024)
+    parser.add_argument("--timeout_seconds", type=float, default=180.0)
+    parser.add_argument(
+        "--view",
+        choices=["full", "wrist", "side"],
+        default="full",
+        help="crop half of a 2:1 concat_view frame (issue #78 zoom lesson)",
+    )
+    parser.add_argument("--upscale", type=int, default=1, help="integer LANCZOS upscale factor")
+    args = parser.parse_args()
+
+    frames = load_probe_frames(
+        Path(args.videos_dir).expanduser(), args.max_videos, args.view, args.upscale
+    )
+
+    verdicts: list[dict[str, Any]] = []
+    latencies: list[float] = []
+    raw_replies: list[str | None] = []
+
+    for name, template in QUESTIONS:
+        judge = make_judge(args, template)
+        original_post = judge._post
+
+        def capturing_post(
+            payload: dict[str, Any], _post: Any = original_post
+        ) -> dict[str, Any]:
+            response = _post(payload)
+            try:
+                raw_replies.append(str(response["choices"][0]["message"]["content"]))
+            except Exception:
+                raw_replies.append(None)
+            return response
+
+        judge._post = capturing_post  # type: ignore[method-assign]
+
+        for frame in frames:
+            raw_before = len(raw_replies)
+            start = time.monotonic()
+            answer = judge.is_complete(frame["image"], args.instruction)
+            elapsed = time.monotonic() - start
+            latencies.append(elapsed)
+            reply = raw_replies[raw_before] if len(raw_replies) > raw_before else None
+            verdicts.append(
+                {
+                    "question": name,
+                    "video": frame["video"],
+                    "position": frame["position"],
+                    "answer": "YES" if answer else "NO",
+                    "latency_s": round(elapsed, 2),
+                    "reply_excerpt": (reply or "")[-200:] or None,
+                    "call_failed": reply is None,
+                }
+            )
+            print(
+                f"[{name:>10}] {frame['video']} ({frame['position']}): "
+                f"{'YES' if answer else 'NO'} ({elapsed:.1f}s)",
+                flush=True,
+            )
+
+    def yes_rate(question: str) -> float | None:
+        rows = [v for v in verdicts if v["question"] == question]
+        return round(sum(v["answer"] == "YES" for v in rows) / len(rows), 3) if rows else None
+
+    calls_ok = sum(not v["call_failed"] for v in verdicts)
+    payload = {
+        "num_episodes": len(frames),
+        "metrics": {
+            "endpoint": args.base_url,
+            "model": args.model,
+            "frames_probed": len(frames),
+            "view": args.view,
+            "upscale": args.upscale,
+            "judge_calls": len(verdicts),
+            "call_success_rate": round(calls_ok / len(verdicts), 3),
+            "latency_s_mean": round(sum(latencies) / len(latencies), 2),
+            "latency_s_max": round(max(latencies), 2),
+            # Aggregate YES rates per question; the discriminative signal lives
+            # in the per-frame verdicts below (which video x position said YES).
+            "control_yes_rate": yes_rate("control"),
+            "grasp_yes_rate": yes_rate("grasp"),
+            "completion_yes_rate": yes_rate("completion"),
+            "retry_yes_rate": yes_rate("retry"),
+            "verdicts": verdicts,
+        },
+    }
+    Path(args.out_json).write_text(json.dumps(payload, indent=2))
+    print(f"wrote metrics -> {args.out_json}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/recovery-gr00t-libero/README.md
+++ b/examples/recovery-gr00t-libero/README.md
@@ -1,0 +1,82 @@
+# Closed-loop recovery — GR00T pilot + Reasoner SPECIALIST on LIBERO
+
+The recovery experiment's LIBERO harness
+(`docs/experiment-recovery-design-vla.md`): a tiered stuck detector runs
+inside the eval loop of a chunk-emitting pilot; on trigger it truncates the
+stale chunk ([VLA-Corrector](https://arxiv.org/abs/2607.01804)'s
+event-triggered truncation via `ChunkPilotAdapter.flush()`) and — on a
+SPECIALIST verdict — rolls the arm back to the last chunk boundary whose
+verdicts were clean. The SPECIALIST is polled **asynchronously** at chunk
+boundaries (`SpecialistGate`): the sim never blocks on the VLM.
+
+The shipped `mission.yaml` is **arm B (shadow)**: detect + log everything,
+intervene never. Run it first — it is behavior-identical to the plain GR00T
+eval and yields the detector-quality data the live arms depend on.
+
+## Experiment arms
+
+| Arm | config | measures |
+| --- | --- | --- |
+| A. baseline | drop every recovery/shadow/specialist key | today's success rate |
+| B. shadow (shipped) | `shadow_mode: true` | detector precision/recall, zero risk |
+| C. kinematic-only | `recovery: true`, no `specialist_base_url` | do physics tiers alone help? |
+| D. full delegation | `recovery: true` + `specialist_base_url` | the headline |
+
+Run the same `task_id` + `num_episodes` across arms; success rates and the
+`recovery` block inside `result_summary.metrics` are directly comparable.
+
+## Prerequisites
+
+1. **GR00T server deps** — same as `examples/franka-libero/mission-gr00t.yaml`
+   (auto-serve; `server_python` if gr00t lives in another venv).
+2. **Specialist endpoint** (arms B/D; drop `specialist_base_url` otherwise) —
+   any OpenAI-compatible server. The default judge is `nvidia/Cosmos3-Nano`
+   via vLLM-Omni:
+
+   ```bash
+   vllm serve nvidia/Cosmos3-Nano --host 0.0.0.0 --port 8002 --max-model-len 8192
+   ```
+
+   Calibrate it FIRST on your rollout videos with `examples/reasoner-probe/`
+   (its `retry` question is exactly the loop's stuck prompt). The issue #78
+   lesson applies: a judge that always answers NO silently degrades arm D
+   into arm C — the probe catches that before you burn GPU-days.
+
+## Outputs (under the task's output dir)
+
+- `recovery/recovery_events.jsonl` — one line per trigger/outcome: step,
+  cause (`kinematic`/`continuity`/`specialist`), kind (`flush`/`rollback`),
+  `applied` (always `false` in shadow), rollback target, controller outcome.
+- `recovery/rollouts/episode_NN_{PASS,FAIL}.npz` — per-step
+  `frames uint8[T,H,W,3]` + `actions float32[T,7]` (`log_actions: true`).
+  This is the training corpus for the VLA-Corrector LVM tier (PR 2).
+  Footprint: a 520-step episode at 256×256 is ~100 MB in RAM before
+  compression — budget disk accordingly or lower `camera_height/width`.
+- `result_summary.metrics.recovery` — counters (shadow_triggers, flushes,
+  recoveries_triggered, post_recovery_successes, specialist_polls, …).
+
+## Flag reference (all optional, all default-off)
+
+`recovery` · `shadow_mode` · `recovery_mode: command|teleport` ·
+`max_recoveries` · `recovery_steps` · `recovery_settle_steps` ·
+`stuck_window_steps` · `stuck_eps_m` · `stuck_min_commanded` ·
+`continuity_eps` (0 = tier 2 off) · `poll_every_chunks` ·
+`specialist_base_url` · `specialist_model` · `specialist_max_tokens` ·
+`specialist_timeout_s` · `specialist_text_modality` ·
+`specialist_api_key_env` · `log_actions` · `recovery_dir`
+(runner-resolved to `<output_dir>/recovery` when any recovery flag is set).
+
+`teleport` mode restores MuJoCo sim state via `env.set_init_state` when the
+env exposes a state getter; otherwise the rollback degrades to a logged
+`teleport_unavailable` event (command mode is unaffected).
+
+## Notes
+
+- The SPECIALIST entry under `robot.agents` documents the loadout; the wiring
+  is `config.specialist_base_url` (the `_has_specialist` multi-agent path
+  only affects the in-process OpenVLA pilot, which `pilot: gr00t` bypasses).
+- π0.5 runs the identical recovery surface: swap to
+  `pilot: pi05` + the openpi server keys (`examples/franka-libero`'s π0.5
+  mission) — the flags are shared verbatim (`evals/recovery_wiring.py`).
+- With every recovery key removed this mission is byte-identical to the plain
+  GR00T eval — the flags are inert by construction.

--- a/examples/recovery-gr00t-libero/mission.yaml
+++ b/examples/recovery-gr00t-libero/mission.yaml
@@ -1,0 +1,90 @@
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: recovery-gr00t-libero
+  description: >-
+    Closed-loop recovery experiment (shadow arm) — GR00T-N1.7 pilot on the LIBERO
+    object suite with a tiered stuck detector running in the loop and a served
+    Cosmos3-Nano Reasoner SPECIALIST polled asynchronously at chunk boundaries.
+    Shadow mode: every would-be intervention is detected and logged
+    (recovery_events.jsonl) but never applied — the zero-risk arm that measures
+    detector precision/recall before recovery goes live.
+  tags: [recovery, gr00t, libero, specialist, multi-agent, vla-corrector]
+
+objective: |
+  Measure the stuck-detector tiers (kinematic + specialist VLM) against real
+  GR00T rollouts on LIBERO, and collect the per-step (frame, action) corpus the
+  trained LVM tier will need — without changing pilot behavior (shadow mode).
+
+acceptance_criteria: |
+  The run completes with today's baseline success rate (shadow mode must not
+  change behavior), recovery_events.jsonl records the shadow triggers, and one
+  npz rollout log per episode lands under the task's recovery/rollouts dir.
+
+robot:
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        base: nvidia/GR00T-N1.7-LIBERO
+
+    # Declarative: records the experiment loadout. The recipe wires the judge
+    # through config.specialist_base_url below (the multi-agent _has_specialist
+    # path only applies to the in-process OpenVLA pilot, not pilot: gr00t).
+    - id: stuck-judge
+      role: SPECIALIST
+      model:
+        source: huggingface
+        base: nvidia/Cosmos3-Nano
+        modality: multimodal
+
+tasks:
+  - name: eval-libero-object-gr00t-recovery-shadow
+    kind: evaluation
+    evaluation_type: libero
+    description: >-
+      GR00T on LIBERO object task_id=0 with the recovery stack in SHADOW mode:
+      detect + log, never intervene (experiment arm B).
+    benchmark_name: libero_object
+    num_episodes: 10
+    config:
+      pilot: gr00t
+      checkpoint: nvidia/GR00T-N1.7-LIBERO
+      task_id: 0
+
+      # --- GR00T policy server (closed-loop auto-serve; see franka-libero) ---
+      serve_checkpoint: true
+      embodiment_tag: LIBERO_PANDA
+      sim_policy_wrapper: true
+      port: 5555
+      n_action_steps: 16
+      capture_video: true
+
+      # --- recovery: experiment arm B (shadow) ------------------------------
+      # Arms (see README):
+      #   A baseline    -> drop every recovery/shadow/specialist key
+      #   B shadow      -> this file as shipped
+      #   C kinematic   -> recovery: true, shadow_mode: false, NO specialist_base_url
+      #   D delegation  -> recovery: true, shadow_mode: false, specialist_base_url set
+      shadow_mode: true
+      # recovery: true
+      # recovery_mode: command        # or: teleport (sim-state restore ablation)
+      # max_recoveries: 3
+      # recovery_steps: 24
+
+      # Tier 1 — kinematic (commanded motion vs EE displacement):
+      stuck_window_steps: 12
+      stuck_eps_m: 0.005
+      # Tier 2 — inter-chunk continuity (0 disables; enable after calibration):
+      # continuity_eps: 0.75
+
+      # Tier 4 — specialist VLM (serve Cosmos3-Nano first; see README):
+      specialist_base_url: "http://127.0.0.1:8002/v1"
+      specialist_model: nvidia/Cosmos3-Nano
+      poll_every_chunks: 2
+
+      # LVM corpus (PR 2): one npz of (frames, actions) per episode.
+      log_actions: true

--- a/src/odyssey/runners/agents/chunk_pilot.py
+++ b/src/odyssey/runners/agents/chunk_pilot.py
@@ -92,6 +92,18 @@ class ChunkPilotAdapter:
         self._cursor = 0
         self._instruction = None
 
+    def flush(self) -> None:
+        """Truncate the buffered chunk so the next ``act`` re-queries.
+
+        The trigger-side counterpart of flush-on-instruction-change: a recovery
+        or drift monitor calls this to discard the remaining open-loop actions
+        of a stale chunk (VLA-Corrector's event-triggered truncation) without
+        touching the instruction. ``steps_remaining`` reads 0 afterwards, so
+        chunk-boundary bookkeeping fires naturally on the next step.
+        """
+        self._chunk = None
+        self._cursor = 0
+
     # -- PilotRuntime surface --------------------------------------------------
 
     def _needs_requery(self, instruction: str) -> bool:

--- a/src/odyssey/runners/agents/openai_judge.py
+++ b/src/odyssey/runners/agents/openai_judge.py
@@ -1,0 +1,187 @@
+"""OpenAI-compatible VLM completion judge — a ``CompletionDetector`` over HTTP.
+
+Issue #78's finding: the co-resident Gemma int4 ``check_done`` judge answers NO
+essentially always — even after the zoom fix made the gripper clearly visible —
+so multi-agent phases advance by step-cap instead of by completion. The fix
+direction is a **stronger judge**, and the serving landscape makes one judge
+surface cover them all: Cosmos 3's Reasoner (Edge 4B / Nano 16B / Super 64B),
+vLLM- or NIM-served VLMs, and hosted endpoints all speak the OpenAI
+``/chat/completions`` protocol with image content parts.
+
+``OpenAICompatCompletionJudge`` satisfies the ``CompletionDetector`` protocol
+(``runners/agents/runtime.py``) structurally, so it drops into the
+``ChunkCompletionGate`` wherever the Gemma judge does today — the gate neither
+knows nor cares that the judge moved out-of-process. Family-/vendor-wide by
+construction: ``base_url`` + ``model`` are the only required knobs.
+
+The judge frames the question as a strict YES/NO visual check and parses the
+first YES/NO token of the reply; an unparseable reply counts as NO (not done) —
+the conservative direction, since a spurious YES would skip a phase mid-task.
+
+stdlib-only transport (``urllib``) with an injectable ``transport`` callable, so
+unit tests stub the endpoint without a server and this module stays
+strict-mypy-clean (contrast the exempted SDK-mirror glue in ``models/``).
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+import os
+import re
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PROMPT_TEMPLATE = (
+    "You are a strict visual judge for a robot manipulation task. "
+    "Look at the image and answer whether the robot has ALREADY fully "
+    "completed this sub-instruction: {instruction!r}. "
+    "Answer with exactly one word: YES or NO."
+)
+
+_YES_NO_RE = re.compile(r"\b(yes|no)\b", re.IGNORECASE)
+
+
+def _encode_data_uri(observation: Any) -> str:
+    """Encode an observation image (HWC uint8 ndarray or PIL Image) as a data URI."""
+    from PIL import Image  # lazy: pillow is a dev/eval dep, not a core one
+
+    if not isinstance(observation, Image.Image):
+        import numpy as np
+
+        observation = Image.fromarray(
+            np.ascontiguousarray(np.asarray(observation, dtype=np.uint8))
+        )
+    buf = io.BytesIO()
+    observation.save(buf, format="PNG")
+    b64 = base64.b64encode(buf.getvalue()).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def parse_yes_no(text: str) -> bool:
+    """``True`` iff the reply's first YES/NO token is YES; unparseable -> ``False``.
+
+    Conservative by design: a judge that rambles without committing keeps the
+    phase running (the step cap still bounds it), whereas a false YES would
+    skip a phase mid-task.
+    """
+    match = _YES_NO_RE.search(text or "")
+    if match is None:
+        logger.warning("completion judge reply had no YES/NO token: %r", text)
+        return False
+    return match.group(1).lower() == "yes"
+
+
+class OpenAICompatCompletionJudge:
+    """Judge sub-instruction completion via an OpenAI-compatible chat endpoint.
+
+    Parameters
+    ----------
+    base_url:
+        Endpoint base, e.g. ``http://127.0.0.1:8001/v1`` (vLLM/NIM serving a
+        Cosmos 3 Reasoner) or a hosted provider. ``/chat/completions`` is
+        appended.
+    model:
+        The served model id, e.g. ``nvidia/Cosmos3-Edge``.
+    api_key / api_key_env:
+        Bearer token, given directly or named via an env var (never hardcode
+        secrets in missions; ``api_key_env`` is the YAML-friendly form).
+    prompt_template:
+        ``str.format``-style template receiving ``instruction``.
+    extra_body:
+        Extra top-level keys merged into every request payload, for
+        server-specific routing knobs. Motivating case: vLLM-Omni serving a
+        Cosmos 3 Reasoner routes image+text chat requests to *image
+        generation* unless the request carries ``{"modalities": ["text"]}``.
+    transport:
+        Injectable ``payload -> response-dict`` callable (tests / custom HTTP
+        stacks). Defaults to a stdlib ``urllib`` POST.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        model: str,
+        api_key: str | None = None,
+        api_key_env: str | None = None,
+        prompt_template: str = DEFAULT_PROMPT_TEMPLATE,
+        max_tokens: int = 8,
+        temperature: float = 0.0,
+        timeout_seconds: float = 60.0,
+        extra_body: dict[str, Any] | None = None,
+        transport: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    ) -> None:
+        self._url = base_url.rstrip("/") + "/chat/completions"
+        self._model = model
+        self._template = prompt_template
+        self._max_tokens = int(max_tokens)
+        self._temperature = float(temperature)
+        self._timeout = float(timeout_seconds)
+        self._extra_body = dict(extra_body) if extra_body else {}
+        self._transport = transport
+        key = api_key or (os.getenv(api_key_env) if api_key_env else None)
+        self._headers = {"Content-Type": "application/json"}
+        if key:
+            self._headers["Authorization"] = f"Bearer {key}"
+
+    def _post(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self._transport is not None:
+            return self._transport(payload)
+        req = urllib.request.Request(
+            self._url,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=self._headers,
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+            return dict(json.loads(resp.read().decode("utf-8")))
+
+    def build_payload(self, observation: Any, instruction: str) -> dict[str, Any]:
+        """The chat-completions request for one judgement (exposed for tests)."""
+        return {
+            **self._extra_body,
+            "model": self._model,
+            "max_tokens": self._max_tokens,
+            "temperature": self._temperature,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": _encode_data_uri(observation)},
+                        },
+                        {
+                            "type": "text",
+                            "text": self._template.format(instruction=instruction),
+                        },
+                    ],
+                }
+            ],
+        }
+
+    # -- CompletionDetector surface -------------------------------------------
+
+    def is_complete(self, observation: Any, instruction: str) -> bool:
+        """``True`` when the VLM judges ``instruction`` complete in ``observation``.
+
+        Endpoint/parse failures are logged and reported as NO (not done) rather
+        than raised — a flaky judge must not abort the episode; the phase's step
+        cap remains the fallback, exactly as with the in-process judge.
+        """
+        try:
+            response = self._post(self.build_payload(observation, instruction))
+            content = response["choices"][0]["message"]["content"]
+        except Exception:
+            logger.warning(
+                "completion judge call failed (%s); judging NOT complete", self._url,
+                exc_info=True,
+            )
+            return False
+        return parse_yes_no(str(content))

--- a/src/odyssey/runners/agents/recovery.py
+++ b/src/odyssey/runners/agents/recovery.py
@@ -1,0 +1,715 @@
+"""Closed-loop recovery core — ledger, tiered stuck detection, rollback control.
+
+The recovery experiment (``docs/experiment-recovery-design-vla.md``) runs a
+tiered stuck detector inside the LIBERO eval loop of a chunk-emitting pilot
+and, on trigger, either logs the event (shadow mode) or intervenes:
+
+* tiers 1-2 (kinematic / inter-chunk continuity, both training-free) trigger a
+  **flush** — the recipe calls ``ChunkPilotAdapter.flush()`` so the stale chunk
+  is truncated and the policy re-queried from the current state (VLA-Corrector's
+  event-triggered truncation);
+* tier 4 (a SPECIALIST VLM verdict, delivered asynchronously by
+  ``specialist_gate.SpecialistGate``) triggers a **rollback** — return the arm
+  to the last chunk boundary whose verdicts were clean, then flush + re-query.
+
+Everything here is pure Python over sequences of floats (math/dataclasses
+only — numpy appears lazily inside ``RolloutLog.save_episode`` alone), so the
+module is strict-mypy clean, imports under bare stdlib, and is unit-testable
+with plain fakes — the same bet as ``chunk_pilot.py``. The mypy-exempt eval
+recipes convert ndarrays to lists at the call sites.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from collections import deque
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+_TIERS = ("kinematic", "continuity", "specialist")
+
+
+# ---------------------------------------------------------------------------
+# Quaternion helpers (xyzw order, matching robosuite's ``robot0_eef_quat``).
+# ---------------------------------------------------------------------------
+
+
+def _quat_conj(q: Sequence[float]) -> tuple[float, float, float, float]:
+    return (-q[0], -q[1], -q[2], q[3])
+
+
+def _quat_mul(
+    a: Sequence[float], b: Sequence[float]
+) -> tuple[float, float, float, float]:
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return (
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz,
+    )
+
+
+def _quat_error_axis_angle(
+    target_xyzw: Sequence[float], current_xyzw: Sequence[float]
+) -> tuple[float, float, float]:
+    """Axis-angle rotation carrying ``current`` onto ``target`` (shortest path)."""
+    err = _quat_mul(target_xyzw, _quat_conj(current_xyzw))
+    x, y, z, w = err
+    norm = math.sqrt(x * x + y * y + z * z + w * w)
+    if norm < 1e-12:
+        return (0.0, 0.0, 0.0)
+    x, y, z, w = x / norm, y / norm, z / norm, w / norm
+    if w < 0.0:  # shortest path
+        x, y, z, w = -x, -y, -z, -w
+    vec_norm = math.sqrt(x * x + y * y + z * z)
+    if vec_norm < 1e-9:
+        return (0.0, 0.0, 0.0)
+    angle = 2.0 * math.atan2(vec_norm, w)
+    scale = angle / vec_norm
+    return (x * scale, y * scale, z * scale)
+
+
+def _l2(a: Sequence[float], b: Sequence[float]) -> float:
+    return math.sqrt(sum((float(x) - float(y)) ** 2 for x, y in zip(a, b, strict=False)))
+
+
+def _clip(value: float, limit: float) -> float:
+    return max(-limit, min(limit, value))
+
+
+# ---------------------------------------------------------------------------
+# Ledger — chunk-boundary snapshots; ``last_good()`` defines "last successful
+# action chunk".
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class BoundarySnapshot:
+    """State the arm actually held at a chunk boundary (recorded before act)."""
+
+    step: int
+    chunk_index: int
+    eef_pos: tuple[float, float, float]
+    eef_quat_xyzw: tuple[float, float, float, float]
+    gripper_qpos: tuple[float, float]
+    sim_state: Any | None = None  # opaque; only teleport mode touches it
+    kinematic_ok: bool = True
+    continuity_ok: bool = True
+    specialist_ok: bool | None = None  # None = no verdict yet (counts as clean)
+
+    @property
+    def good(self) -> bool:
+        return self.kinematic_ok and self.continuity_ok and self.specialist_ok is not False
+
+
+class ChunkLedger:
+    """Ring of boundary snapshots + per-tier verdicts landing after the fact."""
+
+    def __init__(self, *, capacity: int = 64) -> None:
+        if capacity < 1:
+            raise ValueError(f"capacity must be >= 1, got {capacity}")
+        self._snapshots: deque[BoundarySnapshot] = deque(maxlen=capacity)
+
+    def record(self, snapshot: BoundarySnapshot) -> None:
+        self._snapshots.append(snapshot)
+
+    def mark(self, chunk_index: int, *, tier: str, ok: bool) -> None:
+        """Apply a (possibly late) verdict to the snapshot for ``chunk_index``."""
+        if tier not in _TIERS:
+            raise ValueError(f"unknown tier {tier!r}; expected one of {_TIERS}")
+        for snapshot in self._snapshots:
+            if snapshot.chunk_index == chunk_index:
+                if tier == "kinematic":
+                    snapshot.kinematic_ok = ok
+                elif tier == "continuity":
+                    snapshot.continuity_ok = ok
+                else:
+                    snapshot.specialist_ok = ok
+                return
+
+    def mark_from(self, chunk_index: int, *, tier: str, ok: bool) -> None:
+        """Apply a verdict to every snapshot at or after ``chunk_index``.
+
+        A stuck state persists: a specialist verdict about chunk *k* taints all
+        boundaries recorded since — the rollback target must predate it.
+        """
+        for snapshot in list(self._snapshots):
+            if snapshot.chunk_index >= chunk_index:
+                self.mark(snapshot.chunk_index, tier=tier, ok=ok)
+
+    def last_good(self) -> BoundarySnapshot | None:
+        for snapshot in reversed(self._snapshots):
+            if snapshot.good:
+                return snapshot
+        return None
+
+    def latest(self) -> BoundarySnapshot | None:
+        return self._snapshots[-1] if self._snapshots else None
+
+    def reset(self) -> None:
+        self._snapshots.clear()
+
+
+# ---------------------------------------------------------------------------
+# Tiered stuck detection (tiers 1-2; the specialist is tier 4, delivered via
+# the gate; the trained LVM tier 3 arrives in a later PR).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StuckSignal:
+    kinematic: bool = False
+    continuity: bool = False
+
+    @property
+    def triggered(self) -> bool:
+        return self.kinematic or self.continuity
+
+    @property
+    def cause(self) -> str:
+        if self.kinematic:
+            return "kinematic"
+        if self.continuity:
+            return "continuity"
+        return ""
+
+
+class StuckMonitor:
+    """Training-free stuck detection over the (action, EE-pos) stream.
+
+    Tier 1 (kinematic, every step): over the last ``window_steps`` steps the
+    commanded translation summed to >= ``min_commanded`` while the EE moved
+    less than ``eps_m`` — the arm is pushing but not going anywhere.
+
+    Tier 2 (continuity, chunk starts only): the new chunk's first action
+    diverges from the mean of the previous chunk's last ``continuity_tail``
+    actions by more than ``continuity_eps`` over the 6 pose dims — the policy
+    changed its mind sharply between chunks (Rewind-IL's TIDE signal at our
+    query cadence). ``continuity_eps=0`` disables the tier.
+    """
+
+    def __init__(
+        self,
+        *,
+        window_steps: int = 12,
+        eps_m: float = 0.005,
+        min_commanded: float = 0.05,
+        continuity_eps: float = 0.0,
+        continuity_tail: int = 3,
+    ) -> None:
+        if window_steps < 2:
+            raise ValueError(f"window_steps must be >= 2, got {window_steps}")
+        self._window = int(window_steps)
+        self._eps_m = float(eps_m)
+        self._min_commanded = float(min_commanded)
+        self._continuity_eps = float(continuity_eps)
+        self._continuity_tail = max(1, int(continuity_tail))
+        self._positions: deque[tuple[float, ...]] = deque(maxlen=self._window)
+        self._commanded: deque[float] = deque(maxlen=self._window)
+        self._recent_actions: deque[tuple[float, ...]] = deque(maxlen=self._continuity_tail)
+
+    def update(
+        self,
+        *,
+        action: Sequence[float],
+        eef_pos: Sequence[float],
+        chunk_start: bool,
+    ) -> StuckSignal:
+        signal = StuckSignal()
+
+        if (
+            chunk_start
+            and self._continuity_eps > 0.0
+            and len(self._recent_actions) == self._continuity_tail
+        ):
+            tail = [
+                sum(a[i] for a in self._recent_actions) / len(self._recent_actions)
+                for i in range(6)
+            ]
+            head = [float(action[i]) for i in range(6)]
+            if _l2(head, tail) > self._continuity_eps:
+                signal.continuity = True
+
+        self._positions.append(tuple(float(v) for v in eef_pos[:3]))
+        commanded = math.sqrt(sum(float(action[i]) ** 2 for i in range(3)))
+        self._commanded.append(commanded)
+        self._recent_actions.append(tuple(float(v) for v in action[:6]))
+
+        if len(self._positions) == self._window:
+            displacement = _l2(self._positions[-1], self._positions[0])
+            if sum(self._commanded) >= self._min_commanded and displacement < self._eps_m:
+                signal.kinematic = True
+
+        return signal
+
+    def reset(self) -> None:
+        self._positions.clear()
+        self._commanded.clear()
+        self._recent_actions.clear()
+
+
+# ---------------------------------------------------------------------------
+# Command-back recovery controller — EE-space P-control emitting the env's
+# native 7-D OSC delta actions toward a boundary snapshot.
+# ---------------------------------------------------------------------------
+
+
+class RecoveryController:
+    """Drive the arm back to a snapshot with clipped EE-delta actions."""
+
+    def __init__(
+        self,
+        *,
+        kp_pos: float = 8.0,
+        kp_rot: float = 2.0,
+        max_steps: int = 24,
+        pos_tol_m: float = 0.01,
+        rot_tol_rad: float = 0.15,
+        max_action: float = 1.0,
+        gripper_closed_below: float = 0.03,
+    ) -> None:
+        self._kp_pos = float(kp_pos)
+        self._kp_rot = float(kp_rot)
+        self._max_steps = int(max_steps)
+        self._pos_tol = float(pos_tol_m)
+        self._rot_tol = float(rot_tol_rad)
+        self._max_action = float(max_action)
+        self._gripper_closed_below = float(gripper_closed_below)
+        self._target: BoundarySnapshot | None = None
+        self._steps = 0
+        self._outcome = "idle"
+
+    @property
+    def active(self) -> bool:
+        return self._target is not None
+
+    @property
+    def outcome(self) -> str:
+        return self._outcome
+
+    @property
+    def steps_used(self) -> int:
+        return self._steps
+
+    def start(self, target: BoundarySnapshot) -> None:
+        self._target = target
+        self._steps = 0
+        self._outcome = "driving"
+
+    def action(
+        self, *, eef_pos: Sequence[float], eef_quat_xyzw: Sequence[float]
+    ) -> list[float] | None:
+        """One 7-D OSC delta toward the target; None = arrived/exhausted/idle."""
+        target = self._target
+        if target is None:
+            return None
+
+        pos_err = [target.eef_pos[i] - float(eef_pos[i]) for i in range(3)]
+        rot_err = _quat_error_axis_angle(target.eef_quat_xyzw, eef_quat_xyzw)
+        pos_dist = math.sqrt(sum(e * e for e in pos_err))
+        rot_dist = math.sqrt(sum(e * e for e in rot_err))
+
+        if pos_dist < self._pos_tol and rot_dist < self._rot_tol:
+            self._target = None
+            self._outcome = "arrived"
+            return None
+        if self._steps >= self._max_steps:
+            self._target = None
+            self._outcome = "exhausted"
+            return None
+
+        self._steps += 1
+        gripper_width = abs(target.gripper_qpos[0]) + abs(target.gripper_qpos[1])
+        # LIBERO gripper action: -1.0 opens, +1.0 closes (warmup no-op uses -1).
+        gripper_cmd = 1.0 if gripper_width < self._gripper_closed_below else -1.0
+        return [
+            *(_clip(self._kp_pos * e, self._max_action) for e in pos_err),
+            *(_clip(self._kp_rot * e, self._max_action) for e in rot_err),
+            gripper_cmd,
+        ]
+
+    def reset(self) -> None:
+        self._target = None
+        self._steps = 0
+        self._outcome = "idle"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator — glues ledger + monitor + controller + specialist gate; owns
+# shadow mode, the recovery budget, staleness rules, events and metrics.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SpecialistGateLike(Protocol):
+    """Structural surface of ``specialist_gate.SpecialistGate`` (or a fake)."""
+
+    def begin_episode(self, episode: int) -> None: ...
+
+    def submit(self, *, chunk_index: int, frame: Any, instruction: str) -> bool: ...
+
+    def poll(self) -> Any | None: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass
+class RecoveryDecision:
+    kind: str = "none"  # "none" | "flush" | "rollback"
+    snapshot: BoundarySnapshot | None = None
+    cause: str = ""  # "kinematic" | "continuity" | "specialist"
+
+
+@dataclass
+class _EpisodeState:
+    number: int = 0
+    chunk_index: int = -1
+    interventions: int = 0
+    settle_remaining: int = 0
+    pending_specialist: Any | None = None
+    stale_horizon: int = -1  # verdicts about chunks <= this predate a rollback
+    had_intervention: bool = False
+
+
+class RecoveryPolicy:
+    """Per-episode recovery orchestration for one eval rollout loop.
+
+    Call order per step (see the recipes): ``on_chunk_boundary`` before the
+    boundary ``act`` (records the held pose, drains + re-arms the specialist),
+    then ``after_step`` after ``env.step`` (feeds the monitor, returns the
+    decision). While ``recovering`` the recipe pulls ``recovery_action``
+    instead of ``pilot.act`` and the monitors stay muted (plus
+    ``settle_steps`` afterwards).
+    """
+
+    def __init__(
+        self,
+        *,
+        ledger: ChunkLedger,
+        monitor: StuckMonitor,
+        controller: RecoveryController,
+        specialist: SpecialistGateLike | None = None,
+        mode: str = "command",
+        shadow: bool = False,
+        max_recoveries: int = 3,
+        settle_steps: int = 5,
+    ) -> None:
+        if mode not in ("command", "teleport"):
+            raise ValueError(f"mode must be 'command' or 'teleport', got {mode!r}")
+        self._ledger = ledger
+        self._monitor = monitor
+        self._controller = controller
+        self._specialist = specialist
+        self._mode = mode
+        self._shadow = bool(shadow)
+        self._max_recoveries = int(max_recoveries)
+        self._settle_steps = int(settle_steps)
+        self._ep = _EpisodeState()
+        self._events: list[dict[str, Any]] = []
+        self._metrics = {
+            "recoveries_triggered": 0,
+            "flushes": 0,
+            "shadow_triggers": 0,
+            "specialist_polls": 0,
+            "stale_verdicts": 0,
+            "episodes_with_recovery": 0,
+            "post_recovery_successes": 0,
+            "budget_exhausted_episodes": 0,
+        }
+
+    # -- episode lifecycle --------------------------------------------------
+
+    def begin_episode(self, episode: int) -> None:
+        self._ep = _EpisodeState(number=episode)
+        self._ledger.reset()
+        self._monitor.reset()
+        self._controller.reset()
+        if self._specialist is not None:
+            self._specialist.begin_episode(episode)
+
+    def end_episode(self, *, success: bool) -> None:
+        if self._ep.had_intervention:
+            self._metrics["episodes_with_recovery"] += 1
+            if success:
+                self._metrics["post_recovery_successes"] += 1
+        if self._ep.interventions >= self._max_recoveries and self._ep.had_intervention:
+            self._metrics["budget_exhausted_episodes"] += 1
+
+    # -- chunk boundaries ---------------------------------------------------
+
+    def on_chunk_boundary(
+        self,
+        *,
+        step: int,
+        frame: Any,
+        instruction: str,
+        eef_pos: Sequence[float],
+        eef_quat_xyzw: Sequence[float],
+        gripper_qpos: Sequence[float],
+        sim_state: Any | None = None,
+    ) -> None:
+        self._ep.chunk_index += 1
+        self._ledger.record(
+            BoundarySnapshot(
+                step=step,
+                chunk_index=self._ep.chunk_index,
+                eef_pos=(float(eef_pos[0]), float(eef_pos[1]), float(eef_pos[2])),
+                eef_quat_xyzw=(
+                    float(eef_quat_xyzw[0]),
+                    float(eef_quat_xyzw[1]),
+                    float(eef_quat_xyzw[2]),
+                    float(eef_quat_xyzw[3]),
+                ),
+                gripper_qpos=(float(gripper_qpos[0]), float(gripper_qpos[1])),
+                sim_state=sim_state,
+            )
+        )
+        if self._specialist is None:
+            return
+        verdict = self._specialist.poll()
+        if verdict is not None:
+            self._consume_verdict(verdict)
+        if self._specialist.submit(
+            chunk_index=self._ep.chunk_index, frame=frame, instruction=instruction
+        ):
+            self._metrics["specialist_polls"] += 1
+
+    def _consume_verdict(self, verdict: Any) -> None:
+        episode = int(getattr(verdict, "episode", -1))
+        chunk_index = int(getattr(verdict, "chunk_index", -1))
+        stuck = bool(getattr(verdict, "stuck", False))
+        if episode != self._ep.number or chunk_index <= self._ep.stale_horizon:
+            self._metrics["stale_verdicts"] += 1
+            self._events.append(
+                {
+                    "kind": "stale_verdict",
+                    "episode": self._ep.number,
+                    "verdict_episode": episode,
+                    "verdict_chunk": chunk_index,
+                }
+            )
+            return
+        if stuck:
+            # A stuck state persists: taint every boundary since the frame.
+            self._ledger.mark_from(chunk_index, tier="specialist", ok=False)
+            self._ep.pending_specialist = verdict
+        else:
+            # A clean verdict vouches only for the chunk it actually saw.
+            self._ledger.mark(chunk_index, tier="specialist", ok=True)
+
+    # -- per-step decision --------------------------------------------------
+
+    def after_step(
+        self,
+        *,
+        step: int,
+        action: Sequence[float],
+        eef_pos: Sequence[float],
+        chunk_start: bool,
+    ) -> RecoveryDecision:
+        if self._controller.active:
+            return RecoveryDecision()
+        if self._ep.settle_remaining > 0:
+            self._ep.settle_remaining -= 1
+            return RecoveryDecision()
+
+        signal = self._monitor.update(
+            action=action, eef_pos=eef_pos, chunk_start=chunk_start
+        )
+
+        if self._ep.pending_specialist is not None:
+            self._ep.pending_specialist = None
+            target = self._ledger.last_good()
+            return self._decide(
+                step=step, cause="specialist", kind="rollback", snapshot=target
+            )
+
+        if signal.triggered:
+            self._ledger.mark(self._ep.chunk_index, tier=signal.cause, ok=False)
+            return self._decide(step=step, cause=signal.cause, kind="flush", snapshot=None)
+
+        return RecoveryDecision()
+
+    def _decide(
+        self,
+        *,
+        step: int,
+        cause: str,
+        kind: str,
+        snapshot: BoundarySnapshot | None,
+    ) -> RecoveryDecision:
+        event: dict[str, Any] = {
+            "kind": kind,
+            "cause": cause,
+            "episode": self._ep.number,
+            "step": step,
+            "chunk_index": self._ep.chunk_index,
+            "mode": self._mode,
+            "shadow": self._shadow,
+        }
+        if snapshot is not None:
+            event["target_chunk"] = snapshot.chunk_index
+            event["target_step"] = snapshot.step
+
+        if self._shadow:
+            event["applied"] = False
+            self._metrics["shadow_triggers"] += 1
+            self._events.append(event)
+            self._reset_after_trigger()
+            return RecoveryDecision()
+
+        if self._ep.interventions >= self._max_recoveries:
+            event["applied"] = False
+            event["reason"] = "recovery_budget_exhausted"
+            self._events.append(event)
+            self._reset_after_trigger()
+            return RecoveryDecision()
+
+        if kind == "rollback" and snapshot is None:
+            # Nothing clean to return to: degrade to a flush.
+            kind = "flush"
+            event["kind"] = "flush"
+            event["reason"] = "no_good_snapshot"
+
+        event["applied"] = True
+        self._events.append(event)
+        self._ep.interventions += 1
+        self._ep.had_intervention = True
+        self._reset_after_trigger()
+
+        if kind == "flush":
+            self._metrics["flushes"] += 1
+            return RecoveryDecision(kind="flush", cause=cause)
+
+        assert snapshot is not None
+        self._metrics["recoveries_triggered"] += 1
+        # Any in-flight verdict was captured at or before the current chunk —
+        # it describes the pre-rollback world and must not re-trigger.
+        self._ep.stale_horizon = self._ep.chunk_index
+        if self._mode == "command":
+            self._controller.start(snapshot)
+        return RecoveryDecision(kind="rollback", snapshot=snapshot, cause=cause)
+
+    def _reset_after_trigger(self) -> None:
+        self._monitor.reset()
+        self._ep.settle_remaining = self._settle_steps
+
+    # -- recovery drive (command mode) --------------------------------------
+
+    @property
+    def recovering(self) -> bool:
+        return self._controller.active
+
+    def recovery_action(
+        self, *, eef_pos: Sequence[float], eef_quat_xyzw: Sequence[float]
+    ) -> list[float] | None:
+        action = self._controller.action(eef_pos=eef_pos, eef_quat_xyzw=eef_quat_xyzw)
+        if action is None and self._controller.outcome in ("arrived", "exhausted"):
+            self._events.append(
+                {
+                    "kind": "recovery_outcome",
+                    "episode": self._ep.number,
+                    "outcome": self._controller.outcome,
+                    "steps_used": self._controller.steps_used,
+                }
+            )
+            self._ep.settle_remaining = self._settle_steps
+        return action
+
+    def note_teleport(self, *, applied: bool) -> None:
+        """Record the recipe-side teleport outcome (state restore or degrade)."""
+        self._events.append(
+            {
+                "kind": "recovery_outcome",
+                "episode": self._ep.number,
+                "outcome": "teleported" if applied else "teleport_unavailable",
+            }
+        )
+        self._ep.settle_remaining = self._settle_steps
+
+    # -- reporting -----------------------------------------------------------
+
+    @property
+    def events(self) -> list[dict[str, Any]]:
+        return self._events
+
+    def metrics(self) -> dict[str, Any]:
+        return dict(self._metrics)
+
+    def write_events(self, path: str | Path) -> Path | None:
+        """Append events as JSON lines; best-effort like video encoding."""
+        try:
+            target = Path(path)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("a", encoding="utf-8") as fh:
+                for event in self._events:
+                    fh.write(json.dumps(event) + "\n")
+            return target
+        except OSError:
+            logger.warning("recovery: failed to write events to %s", path, exc_info=True)
+            return None
+
+    def close(self) -> None:
+        if self._specialist is not None:
+            self._specialist.close()
+
+
+# ---------------------------------------------------------------------------
+# Rollout corpus logging — (frame, action) pairs per step, one npz per
+# episode. This is the LVM tier's future training corpus (PR 2).
+# ---------------------------------------------------------------------------
+
+
+class RolloutLog:
+    """Accumulate per-step (frame, action) pairs; save one npz per episode."""
+
+    def __init__(self, directory: str | Path) -> None:
+        self._dir = Path(directory)
+        self._episode = 0
+        self._frames: list[Any] = []
+        self._actions: list[Sequence[float]] = []
+
+    def begin_episode(self, episode: int) -> None:
+        self._episode = episode
+        self._frames = []
+        self._actions = []
+
+    def add(self, *, frame: Any, action: Sequence[float]) -> None:
+        if frame is not None:
+            self._frames.append(frame)
+            self._actions.append([float(v) for v in action])
+
+    def save_episode(self, *, success: bool) -> Path | None:
+        """Write ``episode_{ep:02d}_{PASS|FAIL}.npz`` (frames + actions); None on error."""
+        if not self._frames:
+            return None
+        try:
+            import numpy as np
+
+            self._dir.mkdir(parents=True, exist_ok=True)
+            tag = "PASS" if success else "FAIL"
+            path = self._dir / f"episode_{self._episode:02d}_{tag}.npz"
+            np.savez_compressed(
+                path,
+                frames=np.asarray(self._frames, dtype=np.uint8),
+                actions=np.asarray(self._actions, dtype=np.float32),
+            )
+            return path
+        except Exception:
+            logger.warning(
+                "recovery: failed to save rollout log for episode %d",
+                self._episode,
+                exc_info=True,
+            )
+            return None
+        finally:
+            self._frames = []
+            self._actions = []

--- a/src/odyssey/runners/agents/specialist_gate.py
+++ b/src/odyssey/runners/agents/specialist_gate.py
@@ -1,0 +1,203 @@
+"""Async SPECIALIST stuck-gate — VLM verdicts without blocking the sim loop.
+
+The recovery loop (``runners/agents/recovery.py``) wants a SPECIALIST VLM's
+"is the robot stuck?" verdict at chunk boundaries, but a served reasoner takes
+~1-2 s per call while a sim step takes milliseconds. This gate runs the judge
+call on a single background worker thread and delivers verdicts through a
+non-blocking mailbox:
+
+  * ``submit`` never blocks and never queues more than one call: while a call
+    is in flight, further boundaries are *skipped* (a judge slower than a
+    chunk degrades to a lower poll rate, never a backlog);
+  * ``poll`` is a non-blocking mailbox read; a verdict is consumed at the
+    *next* boundary after it lands — acceptable one-boundary lag, because
+    stuck is a persistent state, not an edge;
+  * verdicts are tagged ``(episode, chunk_index)``; cross-episode verdicts are
+    dropped here, rollback-horizon staleness is the policy's job.
+
+The detector is injected (same ``DetectorLike`` duck-typing as
+``ChunkCompletionGate``): pass an ``OpenAICompatCompletionJudge`` built with
+:data:`STUCK_PROMPT_TEMPLATE` and a YES reply *is* the stuck verdict. Pass
+``executor=lambda job: job()`` in tests for fully synchronous determinism —
+the thread machinery is then never touched (``remote_planner.py`` precedent:
+daemon worker + queue + ``None`` sentinel + ``atexit`` close).
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import queue
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from odyssey.runners.agents.completion_gate import DetectorLike, _as_callable
+
+logger = logging.getLogger(__name__)
+
+# The reasoner-probe's RETRY question (``examples/reasoner-probe/``), i.e. the
+# calibrated wording for "should the robot abort and retry from here".
+STUCK_PROMPT_TEMPLATE = (
+    "You are a strict visual judge monitoring a robot manipulation task. "
+    "The robot is attempting this instruction: {instruction!r}. "
+    "Look at the image and answer whether the robot is in a FAILED or STUCK "
+    "state such that it should abort and RETRY the task from the start "
+    "(e.g. object dropped or knocked over, arm wedged or flailing away from "
+    "the target, target unreachable from the current pose). "
+    "A nominal in-progress attempt is NOT a retry state. "
+    "Answer with exactly one word: YES or NO."
+)
+
+
+@dataclass
+class SpecialistVerdict:
+    """One judge call's outcome, tagged with when its frame was captured."""
+
+    episode: int
+    chunk_index: int
+    stuck: bool
+    latency_s: float
+    error: str | None = None
+
+
+class SpecialistGate:
+    """Chunk-boundary async wrapper around a stuck detector.
+
+    Parameters
+    ----------
+    detector:
+        A ``(frame, instruction) -> bool`` callable or any object exposing
+        ``is_complete`` (the judge surface). ``True`` means **stuck** when the
+        detector carries :data:`STUCK_PROMPT_TEMPLATE`.
+    poll_every_chunks:
+        Submit only for chunk indices divisible by this (default 1 = every
+        boundary the gate is offered).
+    executor:
+        How a judge job runs. ``None`` (default) = lazy single daemon worker
+        thread + request queue. Tests inject ``lambda job: job()`` (sync) or a
+        deferred list to pin the in-flight semantics.
+    """
+
+    def __init__(
+        self,
+        *,
+        detector: DetectorLike,
+        poll_every_chunks: int = 1,
+        executor: Callable[[Callable[[], None]], None] | None = None,
+    ) -> None:
+        if int(poll_every_chunks) < 1:
+            raise ValueError(f"poll_every_chunks must be >= 1, got {poll_every_chunks}")
+        self._detect = _as_callable(detector)
+        self._poll_every = int(poll_every_chunks)
+        self._executor = executor
+        self._mailbox: queue.Queue[SpecialistVerdict] = queue.Queue()
+        self._requests: queue.Queue[Callable[[], None] | None] = queue.Queue()
+        self._worker: threading.Thread | None = None
+        self._in_flight = False
+        self._episode = 0
+        self._closed = False
+
+    # -- lifecycle -----------------------------------------------------------
+
+    def begin_episode(self, episode: int) -> None:
+        """Tag subsequent calls with ``episode``; drop any buffered verdicts."""
+        self._episode = int(episode)
+        while True:
+            try:
+                self._mailbox.get_nowait()
+            except queue.Empty:
+                break
+
+    def close(self) -> None:
+        """Stop the worker thread. Idempotent; also registered at exit."""
+        if self._closed:
+            return
+        self._closed = True
+        worker = self._worker
+        if worker is not None:
+            self._requests.put(None)
+            worker.join(timeout=5.0)
+            if worker.is_alive():
+                logger.warning("specialist gate worker did not stop within 5s")
+            self._worker = None
+
+    # -- submit / poll --------------------------------------------------------
+
+    @property
+    def in_flight(self) -> bool:
+        return self._in_flight
+
+    def submit(self, *, chunk_index: int, frame: Any, instruction: str) -> bool:
+        """Launch a judge call for this boundary; ``False`` = skipped.
+
+        Skips (never blocks, never queues a backlog) when a call is already in
+        flight, the boundary is throttled out, or the gate is closed.
+        """
+        if self._closed or self._in_flight or chunk_index % self._poll_every != 0:
+            return False
+        episode = self._episode
+        self._in_flight = True
+
+        def job() -> None:
+            start = time.monotonic()
+            stuck = False
+            error: str | None = None
+            try:
+                stuck = bool(self._detect(frame, instruction))
+            except Exception as exc:  # a flaky judge must not kill the episode
+                error = f"{type(exc).__name__}: {exc}"
+                logger.warning("specialist stuck-check failed", exc_info=True)
+            finally:
+                self._mailbox.put(
+                    SpecialistVerdict(
+                        episode=episode,
+                        chunk_index=chunk_index,
+                        stuck=stuck,
+                        latency_s=time.monotonic() - start,
+                        error=error,
+                    )
+                )
+                self._in_flight = False
+
+        if self._executor is not None:
+            self._executor(job)
+        else:
+            self._ensure_worker()
+            self._requests.put(job)
+        return True
+
+    def poll(self) -> SpecialistVerdict | None:
+        """Non-blocking mailbox read; cross-episode verdicts are dropped."""
+        while True:
+            try:
+                verdict = self._mailbox.get_nowait()
+            except queue.Empty:
+                return None
+            if verdict.episode == self._episode:
+                return verdict
+            logger.debug(
+                "specialist gate: dropping verdict from episode %d (now %d)",
+                verdict.episode,
+                self._episode,
+            )
+
+    # -- worker thread ---------------------------------------------------------
+
+    def _ensure_worker(self) -> None:
+        if self._worker is not None:
+            return
+        self._worker = threading.Thread(
+            target=self._drain_requests, name="specialist-gate", daemon=True
+        )
+        self._worker.start()
+        atexit.register(self.close)
+
+    def _drain_requests(self) -> None:
+        while True:
+            job = self._requests.get()
+            if job is None:
+                return
+            job()

--- a/src/odyssey/runners/evals/gr00t_libero_eval.py
+++ b/src/odyssey/runners/evals/gr00t_libero_eval.py
@@ -209,6 +209,34 @@ def _build_obs(obs, instruction, *, image_key, wrist_image_key, flip):
     )
 
 
+def _make_gr00t_pilot(client, args):
+    """Wrap the msgpack policy client in the shared ``ChunkPilotAdapter``.
+
+    This retires the recipe's historical inline ``for k in range(n_action_steps)``
+    replay loop in favour of the pilot-agnostic adapter π0.5 and Cosmos 3 already
+    use — one chunk engine, and the recovery hooks (``flush()``, chunk-boundary
+    bookkeeping) come for free. The adapter re-queries with the observation of
+    the boundary step, exactly when the old loop rebuilt the wire obs; tuple
+    results from ``client.get_action`` are unwrapped adapter-side.
+    """
+    from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
+
+    t = _transforms()
+    return ChunkPilotAdapter(
+        predict_chunk=client.get_action,
+        action_decoder=lambda chunk, k: t.gr00t_action_to_libero(
+            chunk, k, translation_only=args.translation_only,
+        ),
+        n_action_steps=args.n_action_steps,
+        observation_builder=lambda raw_obs, instr: _build_obs(
+            raw_obs, instr,
+            image_key=args.image_key,
+            wrist_image_key=args.wrist_image_key,
+            flip=args.flip_images,
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Run path (heavy imports live here)
 # ---------------------------------------------------------------------------
@@ -220,7 +248,6 @@ def run_eval(args: argparse.Namespace) -> dict:
     )
     from odyssey.runners.video import save_rollout_video, to_uint8_frame
 
-    t = _transforms()
     cfg = {
         "camera_height": args.camera_height,
         "camera_width": args.camera_width,
@@ -239,6 +266,7 @@ def run_eval(args: argparse.Namespace) -> dict:
     client = _server().connect_policy_client(
         host=args.host, port=args.port, timeout_ms=args.timeout_ms
     )
+    pilot = _make_gr00t_pilot(client, args)
 
     successes, returns = 0, []
     video_dir = args.video_dir or None
@@ -252,35 +280,25 @@ def run_eval(args: argparse.Namespace) -> dict:
 
         ep_return, success = 0.0, False
         frames: list = []
+        # Drop any partially-replayed chunk from the previous episode — the old
+        # inline loop did this implicitly by re-querying at the top of the while.
+        pilot.reset()
         step = 0
         try:
             while step < args.max_steps_per_episode and not success:
-                observation = _build_obs(
-                    obs, instruction,
-                    image_key=args.image_key,
-                    wrist_image_key=args.wrist_image_key,
-                    flip=args.flip_images,
-                )
-                result = client.get_action(observation)
-                chunk = result[0] if isinstance(result, tuple) else result
-                for k in range(args.n_action_steps):
-                    if step >= args.max_steps_per_episode:
-                        break
-                    action = t.gr00t_action_to_libero(
-                        chunk, k, translation_only=args.translation_only,
-                    )
-                    obs, reward, done, _info = env.step(action.tolist())
-                    ep_return += float(reward)
-                    if video_dir is not None:
-                        # match the pilot's orientation: LIBERO's agentview is stored
-                        # 180°-rotated, so flip the video frame too (else it's upside down).
-                        frame = to_uint8_frame(_frame(obs, args.image_key, flip=args.flip_images))
-                        if frame is not None:
-                            frames.append(frame)
-                    step += 1
-                    if done:  # LIBERO sets done=True when the task is solved
-                        success = True
-                        break
+                action = pilot.act(obs, instruction)
+                obs, reward, done, _info = env.step(action.tolist())
+                ep_return += float(reward)
+                if video_dir is not None:
+                    # match the pilot's orientation: LIBERO's agentview is stored
+                    # 180°-rotated, so flip the video frame too (else it's upside down).
+                    frame = to_uint8_frame(_frame(obs, args.image_key, flip=args.flip_images))
+                    if frame is not None:
+                        frames.append(frame)
+                step += 1
+                if done:  # LIBERO sets done=True when the task is solved
+                    success = True
+                    break
         except Exception as ep_exc:
             # A flaky get_action()/env.step() must not abort the whole sweep (that
             # would drop the remaining episodes AND the final ODYSSEY_RESULT line).

--- a/src/odyssey/runners/evals/gr00t_libero_eval.py
+++ b/src/odyssey/runners/evals/gr00t_libero_eval.py
@@ -120,6 +120,10 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument("--server_device", default="cuda:0")
     ap.add_argument("--server_ready_timeout", type=int, default=900)
     ap.add_argument("--server_denoising_steps", type=int, default=0)
+    # --- recovery (closed-loop stuck detection + rollback; default off) ---
+    from odyssey.runners.evals.recovery_wiring import add_recovery_args
+
+    add_recovery_args(ap, bool_type=_bool)
     return ap
 
 
@@ -268,6 +272,13 @@ def run_eval(args: argparse.Namespace) -> dict:
     )
     pilot = _make_gr00t_pilot(client, args)
 
+    from odyssey.runners.evals import recovery_wiring as rw
+    recovery = rw.make_recovery(args)
+    rollout_log = rw.make_rollout_log(args)
+    if recovery is not None:
+        log.info("recovery enabled: mode=%s shadow=%s specialist=%s",
+                 args.recovery_mode, args.shadow_mode, bool(args.specialist_base_url))
+
     successes, returns = 0, []
     video_dir = args.video_dir or None
     dummy = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]  # no-op, gripper open (physics settle)
@@ -283,11 +294,42 @@ def run_eval(args: argparse.Namespace) -> dict:
         # Drop any partially-replayed chunk from the previous episode — the old
         # inline loop did this implicitly by re-querying at the top of the while.
         pilot.reset()
+        if recovery is not None:
+            recovery.begin_episode(ep)
+        if rollout_log is not None:
+            rollout_log.begin_episode(ep)
         step = 0
         try:
             while step < args.max_steps_per_episode and not success:
-                action = pilot.act(obs, instruction)
-                obs, reward, done, _info = env.step(action.tolist())
+                chunk_start = False
+                if recovery is not None and recovery.recovering:
+                    # Command-mode rollback: the controller drives; the pilot waits.
+                    eef_pos, eef_quat, _grip = rw.proprio(obs)
+                    maybe = recovery.recovery_action(
+                        eef_pos=eef_pos, eef_quat_xyzw=eef_quat
+                    )
+                    if maybe is None:  # arrived/exhausted: fresh chunk from here
+                        pilot.flush()
+                        continue
+                    action_list = maybe
+                else:
+                    chunk_start = recovery is not None and pilot.steps_remaining == 0
+                    if chunk_start:
+                        # Snapshot the pose the arm actually holds at the boundary
+                        # (before the boundary act) + hand the frame to the specialist.
+                        eef_pos, eef_quat, grip = rw.proprio(obs)
+                        recovery.on_chunk_boundary(
+                            step=step,
+                            frame=_frame(obs, args.image_key, flip=args.flip_images),
+                            instruction=instruction,
+                            eef_pos=eef_pos,
+                            eef_quat_xyzw=eef_quat,
+                            gripper_qpos=grip,
+                            sim_state=(rw.maybe_sim_state(env)
+                                       if args.recovery_mode == "teleport" else None),
+                        )
+                    action_list = pilot.act(obs, instruction).tolist()
+                obs, reward, done, _info = env.step(action_list)
                 ep_return += float(reward)
                 if video_dir is not None:
                     # match the pilot's orientation: LIBERO's agentview is stored
@@ -295,6 +337,36 @@ def run_eval(args: argparse.Namespace) -> dict:
                     frame = to_uint8_frame(_frame(obs, args.image_key, flip=args.flip_images))
                     if frame is not None:
                         frames.append(frame)
+                if rollout_log is not None:
+                    rollout_log.add(
+                        frame=_frame(obs, args.image_key, flip=args.flip_images),
+                        action=action_list,
+                    )
+                if recovery is not None:
+                    eef_pos, _quat, _grip = rw.proprio(obs)
+                    decision = recovery.after_step(
+                        step=step, action=action_list, eef_pos=eef_pos,
+                        chunk_start=chunk_start,
+                    )
+                    if decision.kind == "flush":
+                        pilot.flush()
+                    elif decision.kind == "rollback":
+                        pilot.flush()
+                        if args.recovery_mode == "teleport":
+                            state = (decision.snapshot.sim_state
+                                     if decision.snapshot is not None else None)
+                            applied = False
+                            if state is not None:
+                                try:
+                                    env.set_init_state(state)
+                                    applied = True
+                                except Exception:
+                                    log.warning("teleport restore failed; continuing",
+                                                exc_info=True)
+                            recovery.note_teleport(applied=applied)
+                            if applied:  # let physics settle at the restored state
+                                for _ in range(args.recovery_settle_steps):
+                                    obs, _, _, _ = env.step(dummy)
                 step += 1
                 if done:  # LIBERO sets done=True when the task is solved
                     success = True
@@ -305,6 +377,10 @@ def run_eval(args: argparse.Namespace) -> dict:
             log.warning("episode %d/%d aborted (%s) — recording as fail, continuing.",
                         ep, args.num_episodes, ep_exc, exc_info=True)
 
+        if recovery is not None:
+            recovery.end_episode(success=success)
+        if rollout_log is not None:
+            rollout_log.save_episode(success=success)
         successes += int(success)
         returns.append(ep_return)
         log.info("episode %d/%d: %s (steps=%d, return=%.3f)",
@@ -319,15 +395,20 @@ def run_eval(args: argparse.Namespace) -> dict:
     env.close()
     n = max(args.num_episodes, 1)
     success_rate = successes / n
+    metrics = {
+        "successes": successes,
+        "episode_returns": [round(r, 4) for r in returns],
+        "benchmark": f"{args.task}[task={args.task_id}]",
+        "instruction": instruction,
+    }
+    if recovery is not None:
+        # Recovery counters ride the ODYSSEY_RESULT metrics into result_summary;
+        # finalize also writes recovery_events.jsonl and closes the specialist.
+        metrics["recovery"] = rw.finalize(recovery, args)
     summary = {
         "success_rate": success_rate,
         "performance_score": success_rate,
-        "metrics": {
-            "successes": successes,
-            "episode_returns": [round(r, 4) for r in returns],
-            "benchmark": f"{args.task}[task={args.task_id}]",
-            "instruction": instruction,
-        },
+        "metrics": metrics,
     }
     _emit(result_line(**summary))
     return summary

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -424,6 +424,7 @@ class LiberoRunner(Runner):
         video_dir: Path | None = None
         if bool(cfg.get("capture_video", False)) and context.output_dir is not None:
             video_dir = context.output_dir / "videos"
+        recovery_dir = _resolve_recovery_dir(cfg, context.output_dir)
 
         await context.emit_progress(
             "executing",
@@ -436,7 +437,8 @@ class LiberoRunner(Runner):
             timeout_seconds=getattr(spec, "timeout_seconds", None),
             script_path=script,
             argv_extra=build_gr00t_libero_argv(
-                spec=spec, checkpoint=checkpoint, video_dir=video_dir
+                spec=spec, checkpoint=checkpoint, video_dir=video_dir,
+                recovery_dir=recovery_dir,
             ),
             line_parser=collector.parse,
         )
@@ -448,12 +450,15 @@ class LiberoRunner(Runner):
         if rc != 0:
             raise RuntimeError(f"gr00t_libero_eval exited with code {rc}")
 
-        return summarize(
+        summary = summarize(
             collector=collector,
             spec=spec,
             checkpoint=checkpoint,
             eval_script=script,
         )
+        if recovery_dir is not None:
+            _attach_recovery_artifacts(summary, recovery_dir)
+        return summary
 
     async def _run_pi05_pilot(
         self, context: TaskContext, spec: EvaluationTask
@@ -475,6 +480,7 @@ class LiberoRunner(Runner):
         video_dir: Path | None = None
         if bool(cfg.get("capture_video", False)) and context.output_dir is not None:
             video_dir = context.output_dir / "videos"
+        recovery_dir = _resolve_recovery_dir(cfg, context.output_dir)
 
         await context.emit_progress(
             "executing",
@@ -487,7 +493,8 @@ class LiberoRunner(Runner):
             timeout_seconds=getattr(spec, "timeout_seconds", None),
             script_path=script,
             argv_extra=build_pi05_libero_argv(
-                spec=spec, checkpoint=checkpoint, video_dir=video_dir
+                spec=spec, checkpoint=checkpoint, video_dir=video_dir,
+                recovery_dir=recovery_dir,
             ),
             line_parser=collector.parse,
         )
@@ -499,24 +506,68 @@ class LiberoRunner(Runner):
         if rc != 0:
             raise RuntimeError(f"pi05_libero_eval exited with code {rc}")
 
-        return summarize(
+        summary = summarize(
             collector=collector,
             spec=spec,
             checkpoint=checkpoint,
             eval_script=script,
         )
+        if recovery_dir is not None:
+            _attach_recovery_artifacts(summary, recovery_dir)
+        return summary
 
 
 # Config keys the GR00T-LIBERO runner consumes itself — never forwarded as flags
 # to the eval script (mirrors isaac_lab._HANDLED_CONFIG_KEYS). Video is wired via
-# the resolved --video_dir, not the raw capture_video/*_fps/*_format keys.
+# the resolved --video_dir, not the raw capture_video/*_fps/*_format keys;
+# recovery_dir is likewise runner-resolved (an explicit config value overrides).
 _GR00T_HANDLED_CONFIG_KEYS = {
     "pilot", "checkpoint", "runner", "capture_video", "video_fps", "video_format",
+    "recovery_dir",
 }
 
 
+def _truthy(value: Any) -> bool:
+    """Config values arrive as YAML bools or forwarded strings — accept both."""
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _resolve_recovery_dir(cfg: dict[str, Any], output_dir: Path | None) -> Path | None:
+    """Where the recipe's recovery artifacts land (the ``--video_dir`` pattern).
+
+    An explicit ``config.recovery_dir`` wins; otherwise any recovery-flavoured
+    flag (``recovery``/``shadow_mode``/``log_actions``) resolves the task's
+    ``output_dir/recovery``. ``None`` = the recipe gets no ``--recovery_dir``.
+    """
+    explicit = cfg.get("recovery_dir")
+    if explicit:
+        return Path(str(explicit))
+    wants = any(_truthy(cfg.get(k, False)) for k in ("recovery", "shadow_mode", "log_actions"))
+    if wants and output_dir is not None:
+        return output_dir / "recovery"
+    return None
+
+
+def _attach_recovery_artifacts(summary: dict[str, Any], recovery_dir: Path) -> None:
+    """Register the recipe-written recovery outputs on the result summary.
+
+    Nothing is copied — the subprocess wrote in place (the video precedent);
+    the counters already arrived via the ``ODYSSEY_RESULT`` metrics.
+    """
+    artifacts: dict[str, Any] = {}
+    events = recovery_dir / "recovery_events.jsonl"
+    if events.exists():
+        artifacts["recovery_events"] = str(events)
+    rollouts = sorted((recovery_dir / "rollouts").glob("*.npz"))
+    if rollouts:
+        artifacts["rollout_logs"] = [str(p) for p in rollouts]
+    if artifacts:
+        summary.setdefault("artifacts", {}).update(artifacts)
+
+
 def build_gr00t_libero_argv(
-    *, spec: EvaluationTask, checkpoint: Path, video_dir: Path | None
+    *, spec: EvaluationTask, checkpoint: Path, video_dir: Path | None,
+    recovery_dir: Path | None = None,
 ) -> list[str]:
     """Build ``gr00t_libero_eval.py`` argv: contract flags + config passthrough.
 
@@ -532,6 +583,8 @@ def build_gr00t_libero_argv(
     ]
     if video_dir is not None:
         argv += ["--video_dir", str(video_dir)]
+    if recovery_dir is not None:
+        argv += ["--recovery_dir", str(recovery_dir)]
     for key, value in cfg.items():
         if key in _GR00T_HANDLED_CONFIG_KEYS:
             continue
@@ -545,7 +598,8 @@ _PI05_HANDLED_CONFIG_KEYS = _GR00T_HANDLED_CONFIG_KEYS
 
 
 def build_pi05_libero_argv(
-    *, spec: EvaluationTask, checkpoint: Path, video_dir: Path | None
+    *, spec: EvaluationTask, checkpoint: Path, video_dir: Path | None,
+    recovery_dir: Path | None = None,
 ) -> list[str]:
     """Build ``pi05_libero_eval.py`` argv: contract flags + config passthrough.
 
@@ -563,6 +617,8 @@ def build_pi05_libero_argv(
     ]
     if video_dir is not None:
         argv += ["--video_dir", str(video_dir)]
+    if recovery_dir is not None:
+        argv += ["--recovery_dir", str(recovery_dir)]
     for key, value in cfg.items():
         if key in _PI05_HANDLED_CONFIG_KEYS:
             continue

--- a/src/odyssey/runners/evals/pi05_libero_eval.py
+++ b/src/odyssey/runners/evals/pi05_libero_eval.py
@@ -109,6 +109,10 @@ def build_parser() -> argparse.ArgumentParser:
                          "(match the checkpoint's action_horizon; 10 for pi05_libero).")
     ap.add_argument("--translation_only", type=_bool, default=False,
                     help="de-risk: zero rotation + fixed-open gripper.")
+    # --- recovery (closed-loop stuck detection + rollback; default off) ---
+    from odyssey.runners.evals.recovery_wiring import add_recovery_args
+
+    add_recovery_args(ap, bool_type=_bool)
     return ap
 
 
@@ -204,6 +208,13 @@ def run_eval(args: argparse.Namespace) -> dict:
         translation_only=args.translation_only,
     )
 
+    from odyssey.runners.evals import recovery_wiring as rw
+    recovery = rw.make_recovery(args)
+    rollout_log = rw.make_rollout_log(args)
+    if recovery is not None:
+        log.info("recovery enabled: mode=%s shadow=%s specialist=%s",
+                 args.recovery_mode, args.shadow_mode, bool(args.specialist_base_url))
+
     successes, returns = 0, []
     video_dir = args.video_dir or None
     dummy = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]  # no-op, gripper open (physics settle)
@@ -217,21 +228,52 @@ def run_eval(args: argparse.Namespace) -> dict:
         ep_return, success = 0.0, False
         frames: list = []
         pilot.reset()  # drop the chunk buffer so the first act re-queries this episode
+        if recovery is not None:
+            recovery.begin_episode(ep)
+        if rollout_log is not None:
+            rollout_log.begin_episode(ep)
         step = 0
         try:
             while step < args.max_steps_per_episode and not success:
-                # One act per env step; the ChunkPilotAdapter buffers the chunk and
-                # only re-queries the openpi server when it drains (every n_action_steps).
-                action = pilot.act(
-                    _raw_obs(
-                        obs,
-                        image_key=args.image_key,
-                        wrist_image_key=args.wrist_image_key,
-                        flip=args.flip_images,
-                    ),
-                    instruction,
-                )
-                obs, reward, done, _info = env.step(action.tolist())
+                chunk_start = False
+                if recovery is not None and recovery.recovering:
+                    # Command-mode rollback: the controller drives; the pilot waits.
+                    eef_pos, eef_quat, _grip = rw.proprio(obs)
+                    maybe = recovery.recovery_action(
+                        eef_pos=eef_pos, eef_quat_xyzw=eef_quat
+                    )
+                    if maybe is None:  # arrived/exhausted: fresh chunk from here
+                        pilot.flush()
+                        continue
+                    action_list = maybe
+                else:
+                    chunk_start = recovery is not None and pilot.steps_remaining == 0
+                    if chunk_start:
+                        # Snapshot the pose the arm actually holds at the boundary
+                        # (before the boundary act) + hand the frame to the specialist.
+                        eef_pos, eef_quat, grip = rw.proprio(obs)
+                        recovery.on_chunk_boundary(
+                            step=step,
+                            frame=_frame(obs, args.image_key, flip=args.flip_images),
+                            instruction=instruction,
+                            eef_pos=eef_pos,
+                            eef_quat_xyzw=eef_quat,
+                            gripper_qpos=grip,
+                            sim_state=(rw.maybe_sim_state(env)
+                                       if args.recovery_mode == "teleport" else None),
+                        )
+                    # One act per env step; the ChunkPilotAdapter buffers the chunk and
+                    # only re-queries the openpi server when it drains (every n_action_steps).
+                    action_list = pilot.act(
+                        _raw_obs(
+                            obs,
+                            image_key=args.image_key,
+                            wrist_image_key=args.wrist_image_key,
+                            flip=args.flip_images,
+                        ),
+                        instruction,
+                    ).tolist()
+                obs, reward, done, _info = env.step(action_list)
                 ep_return += float(reward)
                 if video_dir is not None:
                     # match the pilot's orientation: LIBERO's agentview is stored
@@ -239,6 +281,36 @@ def run_eval(args: argparse.Namespace) -> dict:
                     frame = to_uint8_frame(_frame(obs, args.image_key, flip=args.flip_images))
                     if frame is not None:
                         frames.append(frame)
+                if rollout_log is not None:
+                    rollout_log.add(
+                        frame=_frame(obs, args.image_key, flip=args.flip_images),
+                        action=action_list,
+                    )
+                if recovery is not None:
+                    eef_pos, _quat, _grip = rw.proprio(obs)
+                    decision = recovery.after_step(
+                        step=step, action=action_list, eef_pos=eef_pos,
+                        chunk_start=chunk_start,
+                    )
+                    if decision.kind == "flush":
+                        pilot.flush()
+                    elif decision.kind == "rollback":
+                        pilot.flush()
+                        if args.recovery_mode == "teleport":
+                            state = (decision.snapshot.sim_state
+                                     if decision.snapshot is not None else None)
+                            applied = False
+                            if state is not None:
+                                try:
+                                    env.set_init_state(state)
+                                    applied = True
+                                except Exception:
+                                    log.warning("teleport restore failed; continuing",
+                                                exc_info=True)
+                            recovery.note_teleport(applied=applied)
+                            if applied:  # let physics settle at the restored state
+                                for _ in range(args.recovery_settle_steps):
+                                    obs, _, _, _ = env.step(dummy)
                 step += 1
                 if done:  # LIBERO sets done=True when the task is solved
                     success = True
@@ -249,6 +321,10 @@ def run_eval(args: argparse.Namespace) -> dict:
             log.warning("episode %d/%d aborted (%s) — recording as fail, continuing.",
                         ep, args.num_episodes, ep_exc, exc_info=True)
 
+        if recovery is not None:
+            recovery.end_episode(success=success)
+        if rollout_log is not None:
+            rollout_log.save_episode(success=success)
         successes += int(success)
         returns.append(ep_return)
         log.info("episode %d/%d: %s (steps=%d, return=%.3f)",
@@ -263,15 +339,20 @@ def run_eval(args: argparse.Namespace) -> dict:
     env.close()
     n = max(args.num_episodes, 1)
     success_rate = successes / n
+    metrics = {
+        "successes": successes,
+        "episode_returns": [round(r, 4) for r in returns],
+        "benchmark": f"{args.task}[task={args.task_id}]",
+        "instruction": instruction,
+    }
+    if recovery is not None:
+        # Recovery counters ride the ODYSSEY_RESULT metrics into result_summary;
+        # finalize also writes recovery_events.jsonl and closes the specialist.
+        metrics["recovery"] = rw.finalize(recovery, args)
     summary = {
         "success_rate": success_rate,
         "performance_score": success_rate,
-        "metrics": {
-            "successes": successes,
-            "episode_returns": [round(r, 4) for r in returns],
-            "benchmark": f"{args.task}[task={args.task_id}]",
-            "instruction": instruction,
-        },
+        "metrics": metrics,
     }
     _emit(result_line(**summary))
     return summary

--- a/src/odyssey/runners/evals/recovery_wiring.py
+++ b/src/odyssey/runners/evals/recovery_wiring.py
@@ -1,0 +1,201 @@
+"""Shared recovery wiring for the LIBERO eval recipes (GR00T + π0.5).
+
+The two recipes are deliberate siblings; this module keeps their recovery
+surface identical instead of letting two copies drift: one argparse block
+(:func:`add_recovery_args`), one assembly path from parsed args to a
+:class:`~odyssey.runners.agents.recovery.RecoveryPolicy`
+(:func:`make_recovery`), and the small env/obs helpers the loop hooks need.
+
+Everything imports lazily and the module itself is stdlib-only at import time
+(the recipes import it inside ``build_parser``/``run_eval``, preserving their
+bare-stdlib import contract). Strict-mypy clean — the recipes are the exempt
+layer, this glue is not.
+
+Default-off by construction: with none of the flags set,
+:func:`recovery_enabled` is ``False``, :func:`make_recovery` returns ``None``
+and every loop hook is skipped — the recipes behave byte-identically to the
+pre-recovery code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SPECIALIST_MODEL = "nvidia/Cosmos3-Nano"
+_sim_state_warned = False
+
+
+def add_recovery_args(
+    ap: argparse.ArgumentParser, *, bool_type: Callable[[str], bool]
+) -> None:
+    """Add the recovery flag block (shared verbatim by both recipes).
+
+    ``bool_type`` is the recipe's ``--flag <value>``-style boolean parser (the
+    runner forwards config keys as ``--key value``, so ``store_true`` would
+    choke on the trailing value).
+    """
+    g = ap.add_argument_group("recovery", "closed-loop stuck detection + rollback")
+    g.add_argument("--recovery", type=bool_type, default=False,
+                   help="enable interventions (flush / rollback) on stuck triggers.")
+    g.add_argument("--shadow_mode", type=bool_type, default=False,
+                   help="detect + log would-be interventions, never intervene.")
+    g.add_argument("--recovery_mode", choices=["command", "teleport"], default="command",
+                   help="rollback style: drive the arm back (command) or restore "
+                        "sim state (teleport; degrades to an event if unsupported).")
+    g.add_argument("--max_recoveries", type=int, default=3,
+                   help="intervention budget per episode; past it, triggers only log.")
+    g.add_argument("--recovery_steps", type=int, default=24,
+                   help="max command-mode drive steps back to the snapshot.")
+    g.add_argument("--recovery_settle_steps", type=int, default=5,
+                   help="steps the monitors stay muted after an intervention.")
+    g.add_argument("--stuck_eps_m", type=float, default=0.005,
+                   help="tier-1: EE displacement below this over the window = stuck.")
+    g.add_argument("--stuck_window_steps", type=int, default=12,
+                   help="tier-1 kinematic window length in steps.")
+    g.add_argument("--stuck_min_commanded", type=float, default=0.05,
+                   help="tier-1: minimum commanded translation over the window.")
+    g.add_argument("--continuity_eps", type=float, default=0.0,
+                   help="tier-2 inter-chunk discrepancy threshold (0 = disabled).")
+    g.add_argument("--poll_every_chunks", type=int, default=2,
+                   help="specialist poll throttle (every Nth chunk boundary).")
+    g.add_argument("--specialist_base_url", default="",
+                   help="OpenAI-compatible endpoint serving the stuck judge "
+                        "(empty = no specialist tier).")
+    g.add_argument("--specialist_model", default="",
+                   help=f"served judge model id (default {_DEFAULT_SPECIALIST_MODEL}).")
+    g.add_argument("--specialist_max_tokens", type=int, default=256,
+                   help="reasoner CoT needs headroom before its YES/NO token.")
+    g.add_argument("--specialist_timeout_s", type=float, default=30.0)
+    g.add_argument("--specialist_text_modality", type=bool_type, default=True,
+                   help="send {'modalities': ['text']} (vLLM-Omni image-gen footgun).")
+    g.add_argument("--specialist_api_key_env", default="",
+                   help="env var holding the judge endpoint's bearer token, if any.")
+    g.add_argument("--log_actions", type=bool_type, default=False,
+                   help="log per-step (frame, action) npz — the LVM training corpus.")
+    g.add_argument("--recovery_dir", default="",
+                   help="where recovery_events.jsonl + rollout npz land "
+                        "(the runner resolves this like --video_dir).")
+
+
+def recovery_enabled(args: argparse.Namespace) -> bool:
+    return bool(args.recovery or args.shadow_mode)
+
+
+def make_recovery(args: argparse.Namespace) -> Any | None:
+    """Assemble the RecoveryPolicy from parsed args; ``None`` when disabled."""
+    if not recovery_enabled(args):
+        return None
+    from odyssey.runners.agents.recovery import (
+        ChunkLedger,
+        RecoveryController,
+        RecoveryPolicy,
+        StuckMonitor,
+    )
+
+    specialist = None
+    if args.specialist_base_url:
+        from odyssey.runners.agents.openai_judge import OpenAICompatCompletionJudge
+        from odyssey.runners.agents.specialist_gate import (
+            STUCK_PROMPT_TEMPLATE,
+            SpecialistGate,
+        )
+
+        judge = OpenAICompatCompletionJudge(
+            base_url=args.specialist_base_url,
+            model=args.specialist_model or _DEFAULT_SPECIALIST_MODEL,
+            prompt_template=STUCK_PROMPT_TEMPLATE,
+            max_tokens=args.specialist_max_tokens,
+            timeout_seconds=args.specialist_timeout_s,
+            api_key_env=args.specialist_api_key_env or None,
+            extra_body=(
+                {"modalities": ["text"]} if args.specialist_text_modality else None
+            ),
+        )
+        specialist = SpecialistGate(
+            detector=judge, poll_every_chunks=args.poll_every_chunks
+        )
+
+    return RecoveryPolicy(
+        ledger=ChunkLedger(),
+        monitor=StuckMonitor(
+            window_steps=args.stuck_window_steps,
+            eps_m=args.stuck_eps_m,
+            min_commanded=args.stuck_min_commanded,
+            continuity_eps=args.continuity_eps,
+        ),
+        controller=RecoveryController(max_steps=args.recovery_steps),
+        specialist=specialist,
+        mode=args.recovery_mode,
+        shadow=args.shadow_mode,
+        max_recoveries=args.max_recoveries,
+        settle_steps=args.recovery_settle_steps,
+    )
+
+
+def make_rollout_log(args: argparse.Namespace) -> Any | None:
+    """The (frame, action) npz corpus logger; ``None`` unless flagged + dir set."""
+    if not (args.log_actions and args.recovery_dir):
+        if args.log_actions:
+            logger.warning("log_actions set but no recovery_dir; skipping npz corpus")
+        return None
+    from odyssey.runners.agents.recovery import RolloutLog
+
+    return RolloutLog(Path(args.recovery_dir) / "rollouts")
+
+
+def maybe_sim_state(env: Any) -> Any | None:
+    """Best-effort MuJoCo sim-state snapshot for teleport mode.
+
+    ``get_sim_state`` is not pinned across LIBERO versions, hence the hasattr
+    chain with a one-time warning; ``None`` degrades teleport rollbacks to a
+    ``teleport_unavailable`` event (command mode is unaffected).
+    """
+    global _sim_state_warned
+    getter = getattr(env, "get_sim_state", None)
+    if callable(getter):
+        try:
+            return getter()
+        except Exception:
+            logger.debug("get_sim_state() failed", exc_info=True)
+    sim = getattr(env, "sim", None)
+    if sim is not None:
+        try:
+            return sim.get_state().flatten()
+        except Exception:
+            logger.debug("sim.get_state() failed", exc_info=True)
+    if not _sim_state_warned:
+        logger.warning(
+            "teleport recovery: env exposes no sim state; rollbacks will degrade"
+        )
+        _sim_state_warned = True
+    return None
+
+
+def proprio(obs: Any) -> tuple[list[float], list[float], list[float]]:
+    """(eef_pos, eef_quat_xyzw, gripper_qpos) as plain float lists."""
+
+    def _vec(key: str, n: int) -> list[float]:
+        raw = obs[key]
+        flat = raw.reshape(-1) if hasattr(raw, "reshape") else raw
+        return [float(v) for v in list(flat)[:n]]
+
+    return (
+        _vec("robot0_eef_pos", 3),
+        _vec("robot0_eef_quat", 4),
+        _vec("robot0_gripper_qpos", 2),
+    )
+
+
+def finalize(policy: Any, args: argparse.Namespace) -> dict[str, Any]:
+    """Write events (when a dir is set), return the metrics block, close."""
+    metrics: dict[str, Any] = dict(policy.metrics())
+    if args.recovery_dir:
+        policy.write_events(Path(args.recovery_dir) / "recovery_events.jsonl")
+    policy.close()
+    return metrics

--- a/tests/unit/test_chunk_pilot_flush.py
+++ b/tests/unit/test_chunk_pilot_flush.py
@@ -1,0 +1,92 @@
+"""Tests for ``ChunkPilotAdapter.flush()`` — event-triggered chunk truncation.
+
+``flush()`` is the trigger-side counterpart of flush-on-instruction-change:
+a recovery/drift monitor discards the rest of a stale chunk so the next
+``act`` re-queries the policy from the current observation (VLA-Corrector's
+truncation semantics). Exercised with the same dependency-free fakes as the
+adapter's own tests (``test_pi05_pilot.py``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from odyssey.runners.agents.chunk_pilot import ChunkPilotAdapter
+
+
+class _RecordingPolicy:
+    """Fake chunk-emitting policy: records every query, returns a tagged chunk."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def infer(self, wire_obs: Any) -> Any:
+        self.calls.append(wire_obs)
+        return {"query": len(self.calls)}
+
+
+def _index_decoder(chunk: Any, k: int) -> tuple[Any, int]:
+    return (chunk, k)
+
+
+def _make_adapter(policy: _RecordingPolicy, *, n_action_steps: int = 4) -> ChunkPilotAdapter:
+    return ChunkPilotAdapter(
+        predict_chunk=policy.infer,
+        action_decoder=_index_decoder,
+        n_action_steps=n_action_steps,
+    )
+
+
+def test_flush_forces_requery_next_act() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=4)
+
+    adapter.act("obs", "instr")
+    assert len(policy.calls) == 1
+
+    adapter.flush()
+    _chunk, k = adapter.act("obs", "instr")
+
+    assert len(policy.calls) == 2  # flush dropped the buffer -> fresh query
+    assert k == 0  # fresh chunk replays from its first step
+
+
+def test_flush_midchunk_discards_remaining_actions() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=4)
+
+    adapter.act("obs", "instr")  # cursor 0 of chunk 1
+    adapter.act("obs", "instr")  # cursor 1 of chunk 1
+    adapter.flush()  # steps 2..3 of chunk 1 are never decoded
+
+    outs = [adapter.act("obs", "instr") for _ in range(2)]
+
+    assert [k for _c, k in outs] == [0, 1]
+    assert all(chunk == {"query": 2} for chunk, _k in outs)
+
+
+def test_flush_preserves_instruction_and_reads_as_boundary() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=4)
+
+    adapter.act("obs", "same instruction")
+    assert adapter.steps_remaining == 3
+
+    adapter.flush()
+
+    # Boundary predicate: recipes detect chunk starts via steps_remaining == 0.
+    assert adapter.steps_remaining == 0
+    # Same instruction after flush -> exactly one new query, no double flush.
+    adapter.act("obs", "same instruction")
+    assert len(policy.calls) == 2
+
+
+def test_flush_before_first_act_is_noop() -> None:
+    policy = _RecordingPolicy()
+    adapter = _make_adapter(policy, n_action_steps=4)
+
+    adapter.flush()  # nothing buffered yet: must not raise
+    adapter.act("obs", "instr")
+
+    assert len(policy.calls) == 1
+    assert adapter.steps_remaining == 3

--- a/tests/unit/test_gr00t_libero_eval.py
+++ b/tests/unit/test_gr00t_libero_eval.py
@@ -373,3 +373,140 @@ def test_gr00t_pilot_reset_between_episodes_drops_partial_chunk(monkeypatch: Any
     # Episode 2 re-queried instead of replaying episode 1's leftover actions.
     assert len(client.calls) == 2
     assert [obs for _w, obs, _i in client.calls] == [0, 0]  # both queries at reset obs
+
+
+# ---------------------------------------------------------------------------
+# Recovery wiring — flags default off; enabled path runs end-to-end on fakes.
+# ---------------------------------------------------------------------------
+
+
+def _base_argv(*extra: str) -> list[str]:
+    return ["--task", "libero_object", "--checkpoint", "/ckpt", *extra]
+
+
+def test_parser_accepts_recovery_flags_defaulting_off() -> None:
+    args = E.build_parser().parse_args(_base_argv())
+    assert args.recovery is False and args.shadow_mode is False
+    assert args.recovery_mode == "command"
+    assert args.log_actions is False and args.recovery_dir == ""
+
+    on = E.build_parser().parse_args(_base_argv(
+        "--recovery", "true", "--recovery_mode", "teleport",
+        "--specialist_base_url", "http://judge:8002/v1",
+        "--stuck_window_steps", "6", "--log_actions", "true",
+        "--recovery_dir", "/out/recovery",
+    ))
+    assert on.recovery is True and on.recovery_mode == "teleport"
+    assert on.specialist_base_url == "http://judge:8002/v1"
+    assert on.stuck_window_steps == 6 and on.log_actions is True
+
+
+class _StaticLiberoEnv:
+    """LIBERO-shaped env whose arm never moves — a guaranteed kinematic stuck."""
+
+    def __init__(self) -> None:
+        self.steps = 0
+        self.restored: list[Any] = []
+
+    def _obs(self) -> dict[str, Any]:
+        import numpy as np
+        return {
+            "robot0_eef_pos": np.zeros(3),
+            "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+            "robot0_gripper_qpos": np.array([0.04, -0.04]),
+            "agentview_image": np.zeros((4, 4, 3), dtype=np.uint8),
+            "robot0_eye_in_hand_image": np.zeros((4, 4, 3), dtype=np.uint8),
+        }
+
+    def reset(self) -> dict[str, Any]:
+        return self._obs()
+
+    def set_init_state(self, state: Any) -> None:
+        self.restored.append(state)
+
+    def step(self, action: Any):
+        self.steps += 1
+        return self._obs(), 0.0, False, {}
+
+    def close(self) -> None:
+        pass
+
+
+def _run_recovery_eval(monkeypatch: Any, tmp_path: Path, *extra: str) -> tuple[dict, Any]:
+    """Drive run_eval end-to-end on fakes; return (summary, fake client)."""
+    import numpy as np
+
+    from odyssey.runners.evals import libero as runner_mod
+
+    def fake_decode(chunk: Any, k: int, *, translation_only: bool = False) -> Any:
+        return np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0], dtype=np.float32)
+
+    class _T:
+        gr00t_action_to_libero = staticmethod(fake_decode)
+
+    client = _FakeChunkClient()
+
+    class _S:
+        @staticmethod
+        def connect_policy_client(*, host: str, port: int, timeout_ms: int) -> Any:
+            return client
+
+    env = _StaticLiberoEnv()
+    monkeypatch.setattr(E, "_transforms", lambda: _T)
+    monkeypatch.setattr(E, "_server", lambda: _S)
+    monkeypatch.setattr(
+        E, "_build_obs",
+        lambda obs, instr, *, image_key, wrist_image_key, flip: {"wire": instr},
+    )
+    monkeypatch.setattr(
+        runner_mod, "_make_libero_env", lambda *a, **k: (env, object(), [0])
+    )
+    monkeypatch.setattr(runner_mod, "_resolve_libero_instruction", lambda *a, **k: "pick")
+
+    args = E.build_parser().parse_args(_base_argv(
+        "--num_episodes", "1", "--max_steps_per_episode", "30",
+        "--num_warmup_steps", "0", "--n_action_steps", "4", *extra,
+    ))
+    return E.run_eval(args), client
+
+
+def test_run_eval_recovery_off_is_inert(monkeypatch: Any, tmp_path: Path) -> None:
+    summary, client = _run_recovery_eval(monkeypatch, tmp_path)
+    assert "recovery" not in summary["metrics"]
+    assert len(client.calls) == 8  # ceil(30 / 4) chunks, no extra queries
+    assert not list(tmp_path.iterdir())  # nothing written anywhere
+
+
+def test_run_eval_kinematic_stuck_flushes_and_writes_events(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    summary, client = _run_recovery_eval(
+        monkeypatch, tmp_path,
+        "--recovery", "true", "--stuck_window_steps", "6",
+        "--recovery_settle_steps", "0", "--max_recoveries", "2",
+        "--recovery_dir", str(tmp_path),
+    )
+    recovery = summary["metrics"]["recovery"]
+    assert recovery["flushes"] >= 1  # the static arm tripped tier 1
+    assert len(client.calls) > 8  # each flush forces an extra re-query
+
+    events_file = tmp_path / "recovery_events.jsonl"
+    assert events_file.exists()
+    events = [json.loads(line) for line in events_file.read_text().splitlines()]
+    assert any(e["kind"] == "flush" and e["cause"] == "kinematic" for e in events)
+
+
+def test_run_eval_log_actions_writes_npz_corpus(monkeypatch: Any, tmp_path: Path) -> None:
+    import numpy as np
+
+    summary, _client = _run_recovery_eval(
+        monkeypatch, tmp_path,
+        "--shadow_mode", "true", "--log_actions", "true",
+        "--recovery_dir", str(tmp_path),
+    )
+    assert "recovery" in summary["metrics"]
+    npz_files = sorted((tmp_path / "rollouts").glob("*.npz"))
+    assert len(npz_files) == 1 and npz_files[0].name == "episode_01_FAIL.npz"
+    data = np.load(npz_files[0])
+    assert data["frames"].shape == (30, 4, 4, 3)
+    assert data["actions"].shape == (30, 7)

--- a/tests/unit/test_gr00t_libero_eval.py
+++ b/tests/unit/test_gr00t_libero_eval.py
@@ -243,3 +243,133 @@ def test_argv_parses_back_into_the_recipe() -> None:
     assert args.task_id == 2
     assert args.serve_checkpoint is True
     assert args.n_action_steps == 8
+
+
+# ---------------------------------------------------------------------------
+# ChunkPilotAdapter migration — the adapter-driven loop is action-for-action
+# and query-for-query identical to the recipe's historical inline chunk loop.
+# ---------------------------------------------------------------------------
+
+
+class _FakeChunkClient:
+    """msgpack-client stand-in: records wire obs, returns tagged (tuple) chunks."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def get_action(self, observation: Any) -> Any:
+        self.calls.append(observation)
+        return (f"chunk-{len(self.calls)}", {"latency_ms": 1})  # tuple, like the real client
+
+
+class _CountingEnv:
+    """Gym-4-tuple env: obs is a step counter; done fires at ``done_at`` steps."""
+
+    def __init__(self, *, done_at: int | None = None) -> None:
+        self._done_at = done_at
+        self._steps = 0
+
+    def reset(self) -> dict[str, Any]:
+        self._steps = 0
+        return {"tick": 0}
+
+    def step(self, action: Any) -> tuple[dict[str, Any], float, bool, dict[str, Any]]:
+        self._steps += 1
+        done = self._done_at is not None and self._steps >= self._done_at
+        return {"tick": self._steps}, 0.0, done, {}
+
+
+def _fake_decode(chunk: Any, k: int, *, translation_only: bool = False) -> Any:
+    return (chunk, k, translation_only)
+
+
+def _patched_pilot(monkeypatch: Any, client: _FakeChunkClient, *, n: int) -> Any:
+    class _T:
+        gr00t_action_to_libero = staticmethod(_fake_decode)
+
+    monkeypatch.setattr(E, "_transforms", lambda: _T)
+    monkeypatch.setattr(
+        E, "_build_obs",
+        lambda obs, instr, *, image_key, wrist_image_key, flip: ("wire", obs["tick"], instr),
+    )
+    args = E.build_parser().parse_args(
+        ["--task", "libero_object", "--checkpoint", "/ckpt", "--n_action_steps", str(n)]
+    )
+    return E._make_gr00t_pilot(client, args)
+
+
+def _drive_adapter(pilot: Any, env: _CountingEnv, *, max_steps: int) -> list[Any]:
+    """The migrated run_eval loop shape (per-step act, break on done/max)."""
+    actions: list[Any] = []
+    obs = env.reset()
+    pilot.reset()
+    step, success = 0, False
+    while step < max_steps and not success:
+        action = pilot.act(obs, "pick up the milk")
+        actions.append(action)
+        obs, _r, done, _i = env.step(action)
+        step += 1
+        if done:
+            success = True
+    return actions
+
+
+def _drive_inline(client: _FakeChunkClient, env: _CountingEnv, *, n: int,
+                  max_steps: int) -> list[Any]:
+    """The recipe's PRE-migration inline chunk loop, reimplemented verbatim."""
+    actions: list[Any] = []
+    obs = env.reset()
+    step, success = 0, False
+    while step < max_steps and not success:
+        observation = ("wire", obs["tick"], "pick up the milk")
+        result = client.get_action(observation)
+        chunk = result[0] if isinstance(result, tuple) else result
+        for k in range(n):
+            if step >= max_steps:
+                break
+            action = _fake_decode(chunk, k)
+            actions.append(action)
+            obs, _r, done, _i = env.step(action)
+            step += 1
+            if done:
+                success = True
+                break
+    return actions
+
+
+def _assert_equivalent(monkeypatch: Any, *, n: int, max_steps: int,
+                       done_at: int | None) -> None:
+    old_client = _FakeChunkClient()
+    old = _drive_inline(old_client, _CountingEnv(done_at=done_at), n=n, max_steps=max_steps)
+
+    new_client = _FakeChunkClient()
+    pilot = _patched_pilot(monkeypatch, new_client, n=n)
+    new = _drive_adapter(pilot, _CountingEnv(done_at=done_at), max_steps=max_steps)
+
+    assert new == old  # identical action sequence (chunk tag, cursor, flags)
+    assert new_client.calls == old_client.calls  # identical query count AND wire obs
+
+
+def test_gr00t_pilot_adapter_matches_inline_loop_clean_drain(monkeypatch: Any) -> None:
+    _assert_equivalent(monkeypatch, n=4, max_steps=8, done_at=None)
+
+
+def test_gr00t_pilot_adapter_matches_inline_loop_done_midchunk(monkeypatch: Any) -> None:
+    _assert_equivalent(monkeypatch, n=4, max_steps=20, done_at=6)
+
+
+def test_gr00t_pilot_adapter_matches_inline_loop_max_steps_midchunk(monkeypatch: Any) -> None:
+    _assert_equivalent(monkeypatch, n=4, max_steps=6, done_at=None)
+
+
+def test_gr00t_pilot_reset_between_episodes_drops_partial_chunk(monkeypatch: Any) -> None:
+    client = _FakeChunkClient()
+    pilot = _patched_pilot(monkeypatch, client, n=4)
+
+    _drive_adapter(pilot, _CountingEnv(done_at=2), max_steps=10)  # ends mid-chunk
+    assert len(client.calls) == 1
+    _drive_adapter(pilot, _CountingEnv(done_at=2), max_steps=10)  # fresh episode
+
+    # Episode 2 re-queried instead of replaying episode 1's leftover actions.
+    assert len(client.calls) == 2
+    assert [obs for _w, obs, _i in client.calls] == [0, 0]  # both queries at reset obs

--- a/tests/unit/test_libero_recovery_artifacts.py
+++ b/tests/unit/test_libero_recovery_artifacts.py
@@ -1,0 +1,116 @@
+"""Tests for LiberoRunner's recovery plumbing (``evals/libero.py``).
+
+The runner resolves ``--recovery_dir`` exactly like ``--video_dir`` (the
+recipe writes in place, nothing is copied) and registers the written
+artifacts on the result summary after ``summarize``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.evals.libero import (
+    _attach_recovery_artifacts,
+    _resolve_recovery_dir,
+    build_gr00t_libero_argv,
+    build_pi05_libero_argv,
+)
+from odyssey.spec import EvaluationTask, EvaluationType
+
+
+def _eval_task(**overrides: Any) -> EvaluationTask:
+    fields: dict[str, Any] = {
+        "name": "recovery-eval",
+        "evaluation_type": EvaluationType.LIBERO,
+        "benchmark_name": "libero_object",
+        "num_episodes": 2,
+    }
+    fields.update(overrides)
+    return EvaluationTask(**fields)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_recovery_dir — the --video_dir pattern.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_recovery_dir_off_by_default() -> None:
+    assert _resolve_recovery_dir({}, Path("/out")) is None
+    assert _resolve_recovery_dir({"recovery": False}, Path("/out")) is None
+
+
+def test_resolve_recovery_dir_for_each_recovery_flag() -> None:
+    for key in ("recovery", "shadow_mode", "log_actions"):
+        resolved = _resolve_recovery_dir({key: True}, Path("/out"))
+        assert resolved == Path("/out/recovery"), key
+        # Forwarded-string truthiness too (YAML values may arrive as strings).
+        assert _resolve_recovery_dir({key: "true"}, Path("/out")) == Path("/out/recovery")
+
+
+def test_resolve_recovery_dir_requires_output_dir() -> None:
+    assert _resolve_recovery_dir({"recovery": True}, None) is None
+
+
+def test_resolve_recovery_dir_explicit_config_wins() -> None:
+    cfg = {"recovery": True, "recovery_dir": "/elsewhere/rec"}
+    assert _resolve_recovery_dir(cfg, Path("/out")) == Path("/elsewhere/rec")
+    # Explicit dir works even without any recovery flag (standalone corpus runs).
+    assert _resolve_recovery_dir({"recovery_dir": "/e"}, None) == Path("/e")
+
+
+# ---------------------------------------------------------------------------
+# argv builders — --recovery_dir appended, raw recovery_dir key not forwarded.
+# ---------------------------------------------------------------------------
+
+
+def test_builders_append_recovery_dir() -> None:
+    task = _eval_task(config={"pilot": "gr00t", "recovery": True})
+    for build in (build_gr00t_libero_argv, build_pi05_libero_argv):
+        argv = build(
+            spec=task, checkpoint=Path("/ckpt"), video_dir=None,
+            recovery_dir=Path("/out/recovery"),
+        )
+        assert argv[argv.index("--recovery_dir") + 1] == "/out/recovery"
+        assert argv[argv.index("--recovery") + 1] == "True"  # flag still forwarded
+
+
+def test_builders_omit_recovery_dir_when_none() -> None:
+    task = _eval_task(config={"pilot": "pi05"})
+    for build in (build_gr00t_libero_argv, build_pi05_libero_argv):
+        argv = build(spec=task, checkpoint=Path("/ckpt"), video_dir=None)
+        assert "--recovery_dir" not in argv
+
+
+def test_builders_drop_raw_recovery_dir_config_key() -> None:
+    # The runner consumes recovery_dir itself; the resolved value is what the
+    # recipe sees — never the raw config string a second time.
+    task = _eval_task(config={"recovery_dir": "/from/config"})
+    argv = build_gr00t_libero_argv(
+        spec=task, checkpoint=Path("/ckpt"), video_dir=None,
+        recovery_dir=Path("/from/config"),
+    )
+    assert argv.count("--recovery_dir") == 1
+
+
+# ---------------------------------------------------------------------------
+# _attach_recovery_artifacts.
+# ---------------------------------------------------------------------------
+
+
+def test_attach_recovery_artifacts_registers_events_and_rollouts(tmp_path: Path) -> None:
+    (tmp_path / "recovery_events.jsonl").write_text('{"kind": "flush"}\n')
+    (tmp_path / "rollouts").mkdir()
+    (tmp_path / "rollouts" / "episode_01_FAIL.npz").write_bytes(b"npz")
+
+    summary: dict[str, Any] = {"success_rate": 0.0}
+    _attach_recovery_artifacts(summary, tmp_path)
+
+    assert summary["artifacts"]["recovery_events"].endswith("recovery_events.jsonl")
+    assert len(summary["artifacts"]["rollout_logs"]) == 1
+
+
+def test_attach_recovery_artifacts_noops_when_nothing_written(tmp_path: Path) -> None:
+    summary: dict[str, Any] = {"success_rate": 0.0}
+    _attach_recovery_artifacts(summary, tmp_path / "never-created")
+    assert "artifacts" not in summary

--- a/tests/unit/test_openai_judge.py
+++ b/tests/unit/test_openai_judge.py
@@ -1,0 +1,184 @@
+"""Tests for the OpenAI-compatible VLM completion judge (issue #78 direction).
+
+``OpenAICompatCompletionJudge`` is the out-of-process judge surface (a served
+Cosmos 3 Reasoner, any vLLM/NIM VLM, or a hosted endpoint): a
+``CompletionDetector`` over ``/chat/completions``. Everything is exercised with
+an injected ``transport`` stub — no server, no network, no GPU:
+
+  * YES/NO reply parsing (first committed token wins; unparseable -> NO);
+  * the chat payload (model id, base64 PNG data URI, instruction in the text);
+  * failure semantics: endpoint/parse errors judge NOT complete, never raise
+    (a flaky judge must not abort an episode — the step cap is the fallback);
+  * auth header wiring via ``api_key`` / ``api_key_env``;
+  * it satisfies ``CompletionDetector`` structurally and drops into the
+    ``ChunkCompletionGate`` exactly like the in-process Gemma judge.
+
+All tests are named ``test_openai_judge_*`` (the ``-k openai_judge`` gate).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from odyssey.runners.agents.completion_gate import ChunkCompletionGate
+from odyssey.runners.agents.openai_judge import (
+    OpenAICompatCompletionJudge,
+    parse_yes_no,
+)
+from odyssey.runners.agents.runtime import CompletionDetector
+
+BASE_URL = "http://127.0.0.1:8001/v1"
+
+
+def _reply(content: str) -> dict[str, Any]:
+    return {"choices": [{"message": {"content": content}}]}
+
+
+def _judge(transport, **kwargs: Any) -> OpenAICompatCompletionJudge:
+    return OpenAICompatCompletionJudge(
+        base_url=BASE_URL, model="nvidia/Cosmos3-Edge", transport=transport, **kwargs
+    )
+
+
+def _image():
+    np = pytest.importorskip("numpy")
+    return np.zeros((4, 4, 3), np.uint8)
+
+
+# ---------------------------------------------------------------------------
+# Reply parsing.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("YES", True),
+        ("yes.", True),
+        ("Yes, the banana is in the bowl.", True),
+        ("NO", False),
+        ("No — the gripper is still empty.", False),
+        # First committed token wins over later hedging.
+        ("No. Well, possibly yes.", False),
+        # Unparseable rambling -> conservative NO.
+        ("The scene shows a robot arm above a table.", False),
+        ("", False),
+    ],
+)
+def test_openai_judge_parse_yes_no(text: str, expected: bool) -> None:
+    assert parse_yes_no(text) is expected
+
+
+# ---------------------------------------------------------------------------
+# Payload shape.
+# ---------------------------------------------------------------------------
+
+def test_openai_judge_payload_carries_image_and_instruction() -> None:
+    judge = _judge(transport=lambda p: _reply("NO"))
+    payload = judge.build_payload(_image(), "place the cup on the shelf")
+
+    assert payload["model"] == "nvidia/Cosmos3-Edge"
+    assert payload["temperature"] == 0.0
+    (message,) = payload["messages"]
+    assert message["role"] == "user"
+    image_part, text_part = message["content"]
+    assert image_part["type"] == "image_url"
+    assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+    assert text_part["type"] == "text"
+    assert "place the cup on the shelf" in text_part["text"]
+    assert "YES or NO" in text_part["text"]
+
+
+def test_openai_judge_custom_prompt_template() -> None:
+    judge = _judge(transport=lambda p: _reply("NO"),
+                   prompt_template="Done with {instruction}? YES/NO")
+    payload = judge.build_payload(_image(), "grasp")
+    assert payload["messages"][0]["content"][1]["text"] == "Done with grasp? YES/NO"
+
+
+# ---------------------------------------------------------------------------
+# is_complete — verdicts + failure semantics.
+# ---------------------------------------------------------------------------
+
+def test_openai_judge_yes_verdict_is_complete() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def transport(payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(payload)
+        return _reply("YES")
+
+    judge = _judge(transport=transport)
+    assert judge.is_complete(_image(), "grasp the bowl") is True
+    assert len(calls) == 1
+
+
+def test_openai_judge_no_verdict_is_not_complete() -> None:
+    judge = _judge(transport=lambda p: _reply("NO"))
+    assert judge.is_complete(_image(), "grasp the bowl") is False
+
+
+def test_openai_judge_transport_failure_judges_not_complete() -> None:
+    def transport(payload: dict[str, Any]) -> dict[str, Any]:
+        raise ConnectionError("endpoint down")
+
+    judge = _judge(transport=transport)
+    # Never raises — a flaky judge must not abort the episode.
+    assert judge.is_complete(_image(), "grasp") is False
+
+
+def test_openai_judge_malformed_response_judges_not_complete() -> None:
+    judge = _judge(transport=lambda p: {"unexpected": "shape"})
+    assert judge.is_complete(_image(), "grasp") is False
+
+
+# ---------------------------------------------------------------------------
+# Auth wiring.
+# ---------------------------------------------------------------------------
+
+def test_openai_judge_api_key_env_sets_bearer_header(monkeypatch) -> None:
+    monkeypatch.setenv("JUDGE_API_KEY", "sk-test-123")
+    judge = _judge(transport=lambda p: _reply("NO"), api_key_env="JUDGE_API_KEY")
+    assert judge._headers["Authorization"] == "Bearer sk-test-123"
+
+
+def test_openai_judge_no_key_means_no_auth_header() -> None:
+    judge = _judge(transport=lambda p: _reply("NO"))
+    assert "Authorization" not in judge._headers
+
+
+# ---------------------------------------------------------------------------
+# Protocol + gate integration.
+# ---------------------------------------------------------------------------
+
+def test_openai_judge_satisfies_completion_detector_protocol() -> None:
+    judge = _judge(transport=lambda p: _reply("YES"))
+    assert isinstance(judge, CompletionDetector)
+
+
+def test_openai_judge_drops_into_chunk_completion_gate() -> None:
+    verdicts = iter(["NO", "YES"])
+    judge = _judge(transport=lambda p: _reply(next(verdicts)))
+    gate = ChunkCompletionGate(detector=judge, n_action_steps=2)
+
+    image = _image()
+    # Steps 1-2: first boundary -> judge says NO -> keep going.
+    assert gate.update(image, "grasp") is False
+    assert gate.update(image, "grasp") is False
+    # Steps 3-4: second boundary -> judge says YES -> hand back.
+    assert gate.update(image, "grasp") is False  # mid-chunk, no judge call
+    assert gate.update(image, "grasp") is True
+
+
+def test_openai_judge_extra_body_merges_into_payload() -> None:
+    """extra_body keys ride top-level on every request (e.g. vLLM-Omni's
+    ``modalities: ["text"]`` routing knob) without clobbering the core fields."""
+    judge = _judge(
+        transport=lambda p: _reply("YES"),
+        extra_body={"modalities": ["text"], "model": "should-not-win"},
+    )
+    payload = judge.build_payload(_image(), "grasp the capsule")
+    assert payload["modalities"] == ["text"]
+    # Core fields always win over extra_body on collision.
+    assert payload["model"] != "should-not-win"
+    assert payload["messages"]

--- a/tests/unit/test_pi05_libero_eval.py
+++ b/tests/unit/test_pi05_libero_eval.py
@@ -221,3 +221,119 @@ def test_argv_parses_back_into_the_recipe() -> None:
     assert args.port == 9000
     assert args.n_action_steps == 10
     assert args.translation_only is True
+
+
+# ---------------------------------------------------------------------------
+# Recovery wiring — flags parse, round-trip through the builder, shadow mode
+# logs without intervening.
+# ---------------------------------------------------------------------------
+
+
+def test_parser_accepts_recovery_flags_defaulting_off() -> None:
+    args = E.build_parser().parse_args(
+        ["--task", "libero_object", "--checkpoint", "/ckpt"]
+    )
+    assert args.recovery is False and args.shadow_mode is False
+    assert args.recovery_mode == "command" and args.recovery_dir == ""
+
+
+def test_argv_roundtrips_recovery_keys_through_builder() -> None:
+    task = _eval_task(config={
+        "pilot": "pi05",
+        "checkpoint": "lerobot/pi05_libero",
+        "shadow_mode": "true",
+        "specialist_base_url": "http://judge:8002/v1",
+        "poll_every_chunks": 3,
+        "log_actions": "true",
+    })
+    argv = build_pi05_libero_argv(
+        spec=task, checkpoint=Path("lerobot/pi05_libero"), video_dir=None,
+    )
+    args = E.build_parser().parse_args(argv)
+    assert args.shadow_mode is True
+    assert args.specialist_base_url == "http://judge:8002/v1"
+    assert args.poll_every_chunks == 3 and args.log_actions is True
+
+
+class _RecordingChunkPilot:
+    """make_pi05_pilot stand-in: constant-motion chunks + call recording."""
+
+    def __init__(self, n: int = 4) -> None:
+        self._n = n
+        self._cursor = n  # empty buffer: first act "re-queries"
+        self.flush_calls = 0
+        self.reset_calls = 0
+
+    @property
+    def steps_remaining(self) -> int:
+        return 0 if self._cursor >= self._n else self._n - self._cursor
+
+    def reset(self) -> None:
+        self.reset_calls += 1
+        self._cursor = self._n
+
+    def flush(self) -> None:
+        self.flush_calls += 1
+        self._cursor = self._n
+
+    def act(self, raw_obs: Any, instruction: str) -> Any:
+        import numpy as np
+        if self._cursor >= self._n:
+            self._cursor = 0
+        self._cursor += 1
+        return np.array([0.5, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0], dtype=np.float32)
+
+
+class _StaticLiberoEnv:
+    def _obs(self) -> dict[str, Any]:
+        import numpy as np
+        return {
+            "robot0_eef_pos": np.zeros(3),
+            "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+            "robot0_gripper_qpos": np.array([0.04, -0.04]),
+            "agentview_image": np.zeros((4, 4, 3), dtype=np.uint8),
+            "robot0_eye_in_hand_image": np.zeros((4, 4, 3), dtype=np.uint8),
+        }
+
+    def reset(self) -> dict[str, Any]:
+        return self._obs()
+
+    def set_init_state(self, state: Any) -> None:
+        pass
+
+    def step(self, action: Any):
+        return self._obs(), 0.0, False, {}
+
+    def close(self) -> None:
+        pass
+
+
+def test_run_eval_shadow_mode_logs_but_never_intervenes(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    import odyssey.runners.models.pi05 as pi05_mod
+    from odyssey.runners.evals import libero as runner_mod
+
+    pilot = _RecordingChunkPilot(n=4)
+    monkeypatch.setattr(pi05_mod, "make_pi05_pilot", lambda **kwargs: pilot)
+    monkeypatch.setattr(
+        runner_mod, "_make_libero_env", lambda *a, **k: (_StaticLiberoEnv(), object(), [0])
+    )
+    monkeypatch.setattr(runner_mod, "_resolve_libero_instruction", lambda *a, **k: "pick")
+
+    args = E.build_parser().parse_args([
+        "--task", "libero_object", "--checkpoint", "/ckpt",
+        "--num_episodes", "1", "--max_steps_per_episode", "30",
+        "--num_warmup_steps", "0", "--n_action_steps", "4",
+        "--shadow_mode", "true", "--stuck_window_steps", "6",
+        "--recovery_dir", str(tmp_path),
+    ])
+    summary = E.run_eval(args)
+
+    recovery = summary["metrics"]["recovery"]
+    assert recovery["shadow_triggers"] >= 1  # the static arm was detected
+    assert recovery["flushes"] == 0
+    assert pilot.flush_calls == 0  # never intervened
+    events = (tmp_path / "recovery_events.jsonl").read_text().splitlines()
+    assert events and all(json.loads(e)["applied"] is False
+                          for e in events if "applied" in json.loads(e))

--- a/tests/unit/test_recovery.py
+++ b/tests/unit/test_recovery.py
@@ -1,0 +1,492 @@
+"""Tests for the closed-loop recovery core (``runners/agents/recovery.py``).
+
+Everything is pure Python driven with plain fakes — no env, no GPU, no HTTP.
+The specialist is a scripted fake satisfying ``SpecialistGateLike``; verdicts
+are ``SimpleNamespace`` objects (the policy reads attributes, not a class).
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from odyssey.runners.agents.recovery import (
+    BoundarySnapshot,
+    ChunkLedger,
+    RecoveryController,
+    RecoveryPolicy,
+    RolloutLog,
+    StuckMonitor,
+    _quat_error_axis_angle,
+)
+
+# ---------------------------------------------------------------------------
+# Fakes + tiny builders.
+# ---------------------------------------------------------------------------
+
+IDENTITY = (0.0, 0.0, 0.0, 1.0)
+OPEN_GRIPPER = (0.04, -0.04)
+STILL = [0.5, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]  # pushes +x, arm won't move
+IDLE = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]
+
+
+def _snapshot(chunk: int, *, step: int | None = None, pos=(0.0, 0.0, 0.0)) -> BoundarySnapshot:
+    return BoundarySnapshot(
+        step=chunk * 4 if step is None else step,
+        chunk_index=chunk,
+        eef_pos=pos,
+        eef_quat_xyzw=IDENTITY,
+        gripper_qpos=OPEN_GRIPPER,
+    )
+
+
+class _FakeGate:
+    """SpecialistGateLike: records submits, replays scripted poll verdicts."""
+
+    def __init__(self, verdicts: list[Any] | None = None) -> None:
+        self.verdicts = list(verdicts or [])
+        self.submits: list[tuple[int, str]] = []
+        self.episodes: list[int] = []
+        self.closed = False
+
+    def begin_episode(self, episode: int) -> None:
+        self.episodes.append(episode)
+
+    def submit(self, *, chunk_index: int, frame: Any, instruction: str) -> bool:
+        self.submits.append((chunk_index, instruction))
+        return True
+
+    def poll(self) -> Any | None:
+        return self.verdicts.pop(0) if self.verdicts else None
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _policy(
+    *,
+    specialist: _FakeGate | None = None,
+    shadow: bool = False,
+    mode: str = "command",
+    max_recoveries: int = 3,
+    settle_steps: int = 0,
+    window_steps: int = 3,
+) -> RecoveryPolicy:
+    return RecoveryPolicy(
+        ledger=ChunkLedger(),
+        monitor=StuckMonitor(window_steps=window_steps, eps_m=0.005, min_commanded=0.05),
+        controller=RecoveryController(max_steps=8),
+        specialist=specialist,
+        mode=mode,
+        shadow=shadow,
+        max_recoveries=max_recoveries,
+        settle_steps=settle_steps,
+    )
+
+
+def _boundary(policy: RecoveryPolicy, *, step: int, pos=(0.0, 0.0, 0.0)) -> None:
+    policy.on_chunk_boundary(
+        step=step,
+        frame="frame",
+        instruction="pick up the bowl",
+        eef_pos=pos,
+        eef_quat_xyzw=IDENTITY,
+        gripper_qpos=OPEN_GRIPPER,
+    )
+
+
+def _drive_stuck(policy: RecoveryPolicy, *, steps: int = 3, start_step: int = 0):
+    """Feed `steps` non-moving-but-commanded steps; return the last decision."""
+    decision = None
+    for i in range(steps):
+        decision = policy.after_step(
+            step=start_step + i,
+            action=STILL,
+            eef_pos=(0.0, 0.0, 0.0),
+            chunk_start=(i == 0),
+        )
+    assert decision is not None
+    return decision
+
+
+# ---------------------------------------------------------------------------
+# ChunkLedger.
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_last_good_skips_flagged_boundaries() -> None:
+    ledger = ChunkLedger()
+    for chunk in range(3):
+        ledger.record(_snapshot(chunk))
+    ledger.mark(2, tier="kinematic", ok=False)
+    good = ledger.last_good()
+    assert good is not None and good.chunk_index == 1
+
+
+def test_ledger_mark_from_taints_everything_since() -> None:
+    ledger = ChunkLedger()
+    for chunk in range(3):
+        ledger.record(_snapshot(chunk))
+    ledger.mark_from(1, tier="specialist", ok=False)
+    good = ledger.last_good()
+    assert good is not None and good.chunk_index == 0
+
+
+def test_ledger_late_specialist_verdict_lands_on_the_right_chunk() -> None:
+    ledger = ChunkLedger()
+    ledger.record(_snapshot(0))
+    ledger.record(_snapshot(1))
+    ledger.mark(0, tier="specialist", ok=True)  # late clean verdict
+    ledger.mark(1, tier="specialist", ok=False)
+    good = ledger.last_good()
+    assert good is not None and good.chunk_index == 0
+    assert good.specialist_ok is True
+
+
+def test_ledger_capacity_evicts_oldest() -> None:
+    ledger = ChunkLedger(capacity=2)
+    for chunk in range(3):
+        ledger.record(_snapshot(chunk))
+    latest = ledger.latest()
+    assert latest is not None and latest.chunk_index == 2
+    ledger.mark_from(1, tier="kinematic", ok=False)  # taints both survivors
+    assert ledger.last_good() is None  # chunk 0 was evicted
+
+
+def test_ledger_reset_and_unknown_tier() -> None:
+    ledger = ChunkLedger()
+    ledger.record(_snapshot(0))
+    ledger.reset()
+    assert ledger.latest() is None
+    with pytest.raises(ValueError, match="tier"):
+        ledger.mark(0, tier="vibes", ok=False)
+
+
+# ---------------------------------------------------------------------------
+# StuckMonitor.
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_kinematic_trigger_when_commanded_but_no_displacement() -> None:
+    monitor = StuckMonitor(window_steps=3, eps_m=0.005, min_commanded=0.05)
+    signals = [
+        monitor.update(action=STILL, eef_pos=(0.1, 0.2, 0.3), chunk_start=False)
+        for _ in range(3)
+    ]
+    assert [s.kinematic for s in signals] == [False, False, True]
+    assert signals[-1].cause == "kinematic"
+
+
+def test_monitor_silent_during_warmup_window() -> None:
+    monitor = StuckMonitor(window_steps=5)
+    for _ in range(4):  # window never fills
+        signal = monitor.update(action=STILL, eef_pos=(0.0, 0.0, 0.0), chunk_start=False)
+    assert not signal.triggered
+
+
+def test_monitor_no_trigger_when_arm_moves() -> None:
+    monitor = StuckMonitor(window_steps=3, eps_m=0.005)
+    for i in range(5):
+        signal = monitor.update(
+            action=STILL, eef_pos=(0.01 * i, 0.0, 0.0), chunk_start=False
+        )
+        assert not signal.kinematic
+
+
+def test_monitor_no_trigger_when_no_motion_commanded() -> None:
+    monitor = StuckMonitor(window_steps=3, min_commanded=0.05)
+    for _ in range(5):  # arm static, but nothing was commanded either
+        signal = monitor.update(action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=False)
+        assert not signal.kinematic
+
+
+def test_monitor_continuity_fires_on_chunk_start_discrepancy_only() -> None:
+    monitor = StuckMonitor(window_steps=3, continuity_eps=0.5, continuity_tail=2)
+    head = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -1.0]
+    # The arm keeps moving throughout so the kinematic tier stays silent and
+    # the continuity flag is observed in isolation.
+    for i in range(2):  # previous chunk's tail: idle pose deltas
+        monitor.update(action=IDLE, eef_pos=(0.01 * i, 0.0, 0.0), chunk_start=False)
+
+    mid = monitor.update(action=head, eef_pos=(0.02, 0.0, 0.0), chunk_start=False)
+    assert not mid.continuity  # same discrepancy mid-chunk: not the tier's business
+
+    monitor.reset()
+    for i in range(2):
+        monitor.update(action=IDLE, eef_pos=(0.01 * i, 0.0, 0.0), chunk_start=False)
+    boundary = monitor.update(action=head, eef_pos=(0.02, 0.0, 0.0), chunk_start=True)
+    assert boundary.continuity and boundary.cause == "continuity"
+
+
+def test_monitor_continuity_disabled_at_zero_eps() -> None:
+    monitor = StuckMonitor(window_steps=3)  # continuity_eps defaults to 0
+    for _ in range(3):
+        monitor.update(action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=False)
+    signal = monitor.update(
+        action=[9.0] * 6 + [-1.0], eef_pos=(0.0, 0.0, 0.0), chunk_start=True
+    )
+    assert not signal.continuity
+
+
+# ---------------------------------------------------------------------------
+# RecoveryController + quaternion helpers.
+# ---------------------------------------------------------------------------
+
+
+def test_quat_error_axis_angle_identity_and_known_rotation() -> None:
+    assert _quat_error_axis_angle(IDENTITY, IDENTITY) == (0.0, 0.0, 0.0)
+    quarter_z = (0.0, 0.0, math.sin(math.pi / 4), math.cos(math.pi / 4))  # 90° about z
+    rx, ry, rz = _quat_error_axis_angle(quarter_z, IDENTITY)
+    assert (rx, ry) == pytest.approx((0.0, 0.0), abs=1e-9)
+    assert rz == pytest.approx(math.pi / 2, abs=1e-9)
+
+
+def test_controller_action_points_toward_target_and_clips() -> None:
+    controller = RecoveryController(kp_pos=8.0, max_action=1.0)
+    controller.start(_snapshot(0, pos=(1.0, 0.0, 0.0)))  # 1 m away in +x
+    action = controller.action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY)
+    assert action is not None
+    assert action[0] == pytest.approx(1.0)  # kp*1.0 = 8 clipped to +1
+    assert action[1:6] == pytest.approx([0.0] * 5)
+    assert action[6] == -1.0  # snapshot gripper open (width 0.08)
+
+
+def test_controller_arrives_within_tolerance() -> None:
+    controller = RecoveryController(pos_tol_m=0.01, rot_tol_rad=0.15)
+    controller.start(_snapshot(0, pos=(0.0, 0.0, 0.0)))
+    assert controller.action(eef_pos=(0.001, 0.0, 0.0), eef_quat_xyzw=IDENTITY) is None
+    assert controller.outcome == "arrived"
+    assert not controller.active
+
+
+def test_controller_exhausts_at_max_steps() -> None:
+    controller = RecoveryController(max_steps=2)
+    controller.start(_snapshot(0, pos=(5.0, 0.0, 0.0)))  # unreachable
+    assert controller.action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY) is not None
+    assert controller.action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY) is not None
+    assert controller.action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY) is None
+    assert controller.outcome == "exhausted"
+    assert controller.steps_used == 2
+
+
+def test_controller_gripper_matches_snapshot_width() -> None:
+    controller = RecoveryController(gripper_closed_below=0.03)
+    closed = _snapshot(0, pos=(1.0, 0.0, 0.0))
+    closed.gripper_qpos = (0.01, -0.01)  # width 0.02 -> was holding something
+    controller.start(closed)
+    action = controller.action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY)
+    assert action is not None and action[6] == 1.0  # +1 closes in LIBERO
+
+
+# ---------------------------------------------------------------------------
+# RecoveryPolicy.
+# ---------------------------------------------------------------------------
+
+
+def test_policy_tier1_trigger_yields_flush_decision() -> None:
+    policy = _policy()
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    decision = _drive_stuck(policy)
+    assert decision.kind == "flush" and decision.cause == "kinematic"
+    assert policy.metrics()["flushes"] == 1
+
+
+def test_policy_specialist_stuck_yields_rollback_to_last_good() -> None:
+    # Realistic timeline: the verdict about chunk k's frame lands one boundary
+    # late. Chunk 0 is vouched clean; chunk 1 is judged stuck -> roll back to 0.
+    clean0 = SimpleNamespace(episode=1, chunk_index=0, stuck=False)
+    stuck1 = SimpleNamespace(episode=1, chunk_index=1, stuck=True)
+    gate = _FakeGate(verdicts=[None, clean0, stuck1])
+    policy = _policy(specialist=gate)
+    policy.begin_episode(1)
+
+    _boundary(policy, step=0, pos=(0.0, 0.0, 0.0))  # chunk 0 (the clean one)
+    policy.after_step(step=0, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True)
+    _boundary(policy, step=1, pos=(0.5, 0.0, 0.0))  # chunk 1: clean0 drained
+    policy.after_step(step=1, action=IDLE, eef_pos=(0.5, 0.0, 0.0), chunk_start=True)
+    _boundary(policy, step=2, pos=(0.6, 0.0, 0.0))  # chunk 2: stuck1 drained
+    decision = policy.after_step(
+        step=2, action=IDLE, eef_pos=(0.6, 0.0, 0.0), chunk_start=True
+    )
+
+    assert decision.kind == "rollback" and decision.cause == "specialist"
+    assert decision.snapshot is not None and decision.snapshot.chunk_index == 0
+    assert policy.recovering  # command mode started the controller
+    assert [chunk for chunk, _ in gate.submits] == [0, 1, 2]
+    assert policy.metrics()["recoveries_triggered"] == 1
+
+
+def test_policy_rollback_without_good_snapshot_degrades_to_flush() -> None:
+    # Stuck since the very first chunk: everything is tainted, nothing to
+    # return to -> the rollback degrades to a flush.
+    verdict = SimpleNamespace(episode=1, chunk_index=0, stuck=True)
+    gate = _FakeGate(verdicts=[verdict])
+    policy = _policy(specialist=gate)
+    policy.begin_episode(1)
+    _boundary(policy, step=0)  # drains the verdict about chunk 0 immediately
+    decision = policy.after_step(
+        step=0, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True
+    )
+    assert decision.kind == "flush"
+    assert any(e.get("reason") == "no_good_snapshot" for e in policy.events)
+
+
+def test_policy_shadow_mode_logs_but_never_intervenes() -> None:
+    policy = _policy(shadow=True)
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    decision = _drive_stuck(policy)
+    assert decision.kind == "none"
+    assert not policy.recovering
+    assert policy.metrics()["shadow_triggers"] == 1
+    assert policy.metrics()["flushes"] == 0
+    assert [e["applied"] for e in policy.events] == [False]
+
+
+def test_policy_budget_exhaustion_stops_intervening() -> None:
+    policy = _policy(max_recoveries=1)
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    first = _drive_stuck(policy)
+    assert first.kind == "flush"
+    second = _drive_stuck(policy, start_step=10)
+    assert second.kind == "none"
+    assert any(e.get("reason") == "recovery_budget_exhausted" for e in policy.events)
+
+
+def test_policy_muting_during_command_recovery() -> None:
+    verdict = SimpleNamespace(episode=1, chunk_index=1, stuck=True)
+    gate = _FakeGate(verdicts=[None, verdict])
+    policy = _policy(specialist=gate, settle_steps=2)
+    policy.begin_episode(1)
+    _boundary(policy, step=0, pos=(0.0, 0.0, 0.0))
+    policy.after_step(step=0, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True)
+    _boundary(policy, step=1, pos=(5.0, 0.0, 0.0))
+    decision = policy.after_step(
+        step=1, action=IDLE, eef_pos=(5.0, 0.0, 0.0), chunk_start=True
+    )
+    assert decision.kind == "rollback" and policy.recovering
+
+    # While recovering, stuck-looking steps yield no new decisions.
+    muted = policy.after_step(
+        step=2, action=STILL, eef_pos=(5.0, 0.0, 0.0), chunk_start=False
+    )
+    assert muted.kind == "none"
+
+    # Drive to arrival (target is chunk 0 at origin; current already there).
+    assert policy.recovery_action(eef_pos=(0.0, 0.0, 0.0), eef_quat_xyzw=IDENTITY) is None
+    assert not policy.recovering
+    assert any(e.get("outcome") == "arrived" for e in policy.events)
+
+    # Settle window: two more stuck-ish steps stay muted.
+    for step in (3, 4):
+        assert (
+            policy.after_step(
+                step=step, action=STILL, eef_pos=(0.0, 0.0, 0.0), chunk_start=False
+            ).kind
+            == "none"
+        )
+
+
+def test_policy_teleport_mode_returns_rollback_without_driving() -> None:
+    verdict = SimpleNamespace(episode=1, chunk_index=1, stuck=True)
+    gate = _FakeGate(verdicts=[None, verdict])
+    policy = _policy(specialist=gate, mode="teleport")
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    policy.after_step(step=0, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True)
+    _boundary(policy, step=1)
+    decision = policy.after_step(
+        step=1, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True
+    )
+    assert decision.kind == "rollback"
+    assert not policy.recovering  # the recipe performs the state restore
+    policy.note_teleport(applied=True)
+    assert any(e.get("outcome") == "teleported" for e in policy.events)
+
+
+def test_policy_stale_verdict_after_rollback_discarded() -> None:
+    stuck1 = SimpleNamespace(episode=1, chunk_index=1, stuck=True)
+    stale = SimpleNamespace(episode=1, chunk_index=1, stuck=True)  # pre-rollback frame
+    wrong_ep = SimpleNamespace(episode=99, chunk_index=5, stuck=True)
+    gate = _FakeGate(verdicts=[None, stuck1, stale, wrong_ep])
+    policy = _policy(specialist=gate, mode="teleport")
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    policy.after_step(step=0, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True)
+    _boundary(policy, step=1)
+    decision = policy.after_step(
+        step=1, action=IDLE, eef_pos=(0.0, 0.0, 0.0), chunk_start=True
+    )
+    assert decision.kind == "rollback"  # rolled back to chunk 0
+
+    _boundary(policy, step=2)  # drains `stale` (chunk 1 <= rollback target horizon? no: 1 > 0)
+    _boundary(policy, step=3)  # drains `wrong_ep`
+    assert policy.metrics()["stale_verdicts"] >= 1
+    assert any(e["kind"] == "stale_verdict" for e in policy.events)
+
+
+def test_policy_events_are_json_serializable_and_metrics_counts() -> None:
+    policy = _policy()
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    _drive_stuck(policy)
+    policy.end_episode(success=True)
+
+    json.dumps(policy.events)  # must not raise
+    metrics = policy.metrics()
+    assert metrics["flushes"] == 1
+    assert metrics["episodes_with_recovery"] == 1
+    assert metrics["post_recovery_successes"] == 1
+
+
+def test_policy_write_events_appends_jsonl(tmp_path: Path) -> None:
+    policy = _policy()
+    policy.begin_episode(1)
+    _boundary(policy, step=0)
+    _drive_stuck(policy)
+    out = policy.write_events(tmp_path / "recovery" / "recovery_events.jsonl")
+    assert out is not None and out.exists()
+    lines = [json.loads(line) for line in out.read_text().splitlines()]
+    assert lines and lines[0]["kind"] == "flush"
+
+
+def test_policy_close_closes_specialist() -> None:
+    gate = _FakeGate()
+    policy = _policy(specialist=gate)
+    policy.close()
+    assert gate.closed
+
+
+# ---------------------------------------------------------------------------
+# RolloutLog.
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_log_saves_npz_frames_and_actions(tmp_path: Path) -> None:
+    np = pytest.importorskip("numpy")
+    log = RolloutLog(tmp_path / "corpus")
+    log.begin_episode(3)
+    frame = np.zeros((4, 4, 3), dtype=np.uint8)
+    log.add(frame=frame, action=[0.1] * 7)
+    log.add(frame=frame, action=[0.2] * 7)
+
+    path = log.save_episode(success=True)
+
+    assert path is not None and path.name == "episode_03_PASS.npz"
+    data = np.load(path)
+    assert data["frames"].shape == (2, 4, 4, 3)
+    assert data["actions"].shape == (2, 7)
+    assert data["actions"].dtype == np.float32
+
+
+def test_rollout_log_empty_episode_saves_nothing(tmp_path: Path) -> None:
+    log = RolloutLog(tmp_path)
+    log.begin_episode(1)
+    assert log.save_episode(success=False) is None

--- a/tests/unit/test_recovery_wiring.py
+++ b/tests/unit/test_recovery_wiring.py
@@ -1,0 +1,95 @@
+"""Tests for the shared recipe recovery glue (``evals/recovery_wiring.py``).
+
+The end-to-end loop behavior is pinned through the recipes' own tests
+(``test_gr00t_libero_eval.py`` / ``test_pi05_libero_eval.py``); these cover
+the assembly surface directly: enablement, policy construction (with and
+without a specialist endpoint), the proprio/state helpers.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from odyssey.runners.agents.recovery import RecoveryPolicy
+from odyssey.runners.evals import recovery_wiring as rw
+
+
+def _args(**overrides: Any) -> argparse.Namespace:
+    ap = argparse.ArgumentParser()
+    rw.add_recovery_args(
+        ap, bool_type=lambda v: str(v).strip().lower() in ("1", "true", "yes", "on")
+    )
+    ns = ap.parse_args([])
+    for key, value in overrides.items():
+        setattr(ns, key, value)
+    return ns
+
+
+def test_recovery_disabled_by_default_and_make_returns_none() -> None:
+    args = _args()
+    assert rw.recovery_enabled(args) is False
+    assert rw.make_recovery(args) is None
+    assert rw.make_rollout_log(args) is None
+
+
+def test_make_recovery_without_specialist_builds_policy() -> None:
+    policy = rw.make_recovery(_args(recovery=True))
+    assert isinstance(policy, RecoveryPolicy)
+    assert not policy.recovering
+    policy.close()  # no specialist: close is a no-op, must not raise
+
+
+def test_make_recovery_shadow_only_counts_as_enabled() -> None:
+    policy = rw.make_recovery(_args(shadow_mode=True))
+    assert isinstance(policy, RecoveryPolicy)
+    policy.close()
+
+
+def test_make_recovery_with_specialist_wires_gate_and_judge() -> None:
+    policy = rw.make_recovery(
+        _args(recovery=True, specialist_base_url="http://judge:8002/v1")
+    )
+    assert isinstance(policy, RecoveryPolicy)
+    # The gate exists and its lifecycle flows through the policy.
+    assert policy._specialist is not None
+    policy.close()
+
+
+def test_proprio_extracts_plain_float_lists() -> None:
+    import numpy as np
+
+    obs = {
+        "robot0_eef_pos": np.array([0.1, 0.2, 0.3]),
+        "robot0_eef_quat": np.array([0.0, 0.0, 0.0, 1.0]),
+        "robot0_gripper_qpos": np.array([0.04, -0.04]),
+    }
+    pos, quat, grip = rw.proprio(obs)
+    assert pos == [0.1, 0.2, 0.3]
+    assert quat == [0.0, 0.0, 0.0, 1.0]
+    assert grip == [0.04, -0.04]
+    assert all(isinstance(v, float) for v in pos + quat + grip)
+
+
+def test_maybe_sim_state_prefers_get_sim_state_then_degrades() -> None:
+    class _WithGetter:
+        def get_sim_state(self) -> str:
+            return "the-state"
+
+    class _WithSim:
+        class sim:
+            @staticmethod
+            def get_state() -> Any:
+                class _S:
+                    @staticmethod
+                    def flatten() -> str:
+                        return "flat-state"
+
+                return _S()
+
+    class _Bare:
+        pass
+
+    assert rw.maybe_sim_state(_WithGetter()) == "the-state"
+    assert rw.maybe_sim_state(_WithSim()) == "flat-state"
+    assert rw.maybe_sim_state(_Bare()) is None  # one-time warning path

--- a/tests/unit/test_specialist_gate.py
+++ b/tests/unit/test_specialist_gate.py
@@ -1,0 +1,206 @@
+"""Tests for the async SPECIALIST stuck-gate (``runners/agents/specialist_gate.py``).
+
+Determinism strategy: all semantics are pinned with an injected synchronous
+executor (``lambda job: job()``) or a deferred-list executor; only the two
+thread-mode tests touch the real worker, gated by ``threading.Event``.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Callable
+from typing import Any
+
+from odyssey.runners.agents.openai_judge import OpenAICompatCompletionJudge
+from odyssey.runners.agents.specialist_gate import (
+    STUCK_PROMPT_TEMPLATE,
+    SpecialistGate,
+    SpecialistVerdict,
+)
+
+_SYNC = lambda job: job()  # noqa: E731
+
+
+class _RecordingDetector:
+    """Detector fake: records calls, replays scripted verdicts."""
+
+    def __init__(self, verdicts: list[bool] | None = None) -> None:
+        self.calls: list[tuple[Any, str]] = []
+        self._verdicts = list(verdicts or [])
+
+    def __call__(self, frame: Any, instruction: str) -> bool:
+        idx = len(self.calls)
+        self.calls.append((frame, instruction))
+        return self._verdicts[idx] if idx < len(self._verdicts) else False
+
+
+def _image() -> Any:
+    return [[[0, 0, 0]]]  # anything; fakes never decode it
+
+
+# ---------------------------------------------------------------------------
+# Synchronous-executor semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_submit_and_poll_roundtrip_sync_executor() -> None:
+    detector = _RecordingDetector(verdicts=[True])
+    gate = SpecialistGate(detector=detector, executor=_SYNC)
+    gate.begin_episode(3)
+
+    assert gate.submit(chunk_index=0, frame="f0", instruction="pick") is True
+    verdict = gate.poll()
+
+    assert isinstance(verdict, SpecialistVerdict)
+    assert verdict.stuck is True
+    assert verdict.episode == 3 and verdict.chunk_index == 0
+    assert verdict.latency_s >= 0.0 and verdict.error is None
+    assert detector.calls == [("f0", "pick")]
+    assert gate.poll() is None  # mailbox drained
+
+
+def test_gate_skips_submit_while_in_flight() -> None:
+    deferred: list[Callable[[], None]] = []
+    gate = SpecialistGate(detector=_RecordingDetector(), executor=deferred.append)
+    gate.begin_episode(1)
+
+    assert gate.submit(chunk_index=0, frame="f", instruction="i") is True
+    assert gate.in_flight
+    # Boundaries 1..3 arrive while the call is still running: all skipped.
+    for chunk in (1, 2, 3):
+        assert gate.submit(chunk_index=chunk, frame="f", instruction="i") is False
+    assert len(deferred) == 1
+
+    deferred.pop()()  # the call finally completes
+    assert not gate.in_flight
+    assert gate.poll() is not None
+    assert gate.submit(chunk_index=4, frame="f", instruction="i") is True
+
+
+def test_gate_throttles_by_poll_every_chunks() -> None:
+    detector = _RecordingDetector()
+    gate = SpecialistGate(detector=detector, poll_every_chunks=2, executor=_SYNC)
+    gate.begin_episode(1)
+
+    accepted = [
+        gate.submit(chunk_index=chunk, frame="f", instruction="i") for chunk in range(4)
+    ]
+
+    assert accepted == [True, False, True, False]
+    assert len(detector.calls) == 2
+
+
+def test_gate_drops_cross_episode_verdicts() -> None:
+    gate = SpecialistGate(detector=_RecordingDetector(verdicts=[True]), executor=_SYNC)
+    gate.begin_episode(1)
+    gate.submit(chunk_index=0, frame="f", instruction="i")
+
+    gate.begin_episode(2)  # episode ended before the verdict was consumed
+    assert gate.poll() is None  # begin_episode drained the mailbox
+
+    # A verdict landing *after* the episode bump is dropped by poll().
+    deferred: list[Callable[[], None]] = []
+    gate2 = SpecialistGate(detector=_RecordingDetector(verdicts=[True]), executor=deferred.append)
+    gate2.begin_episode(1)
+    gate2.submit(chunk_index=0, frame="f", instruction="i")
+    gate2.begin_episode(2)
+    deferred.pop()()  # verdict tagged episode 1 lands now
+    assert gate2.poll() is None
+
+
+def test_gate_detector_exception_reports_error_not_stuck() -> None:
+    def broken(frame: Any, instruction: str) -> bool:
+        raise RuntimeError("endpoint down")
+
+    gate = SpecialistGate(detector=broken, executor=_SYNC)
+    gate.begin_episode(1)
+    gate.submit(chunk_index=0, frame="f", instruction="i")
+    verdict = gate.poll()
+
+    assert verdict is not None
+    assert verdict.stuck is False  # conservative: never intervene on a broken judge
+    assert verdict.error is not None and "endpoint down" in verdict.error
+    assert not gate.in_flight  # the failure released the in-flight slot
+
+
+def test_gate_wraps_openai_judge_with_stuck_template() -> None:
+    payloads: list[dict[str, Any]] = []
+
+    def transport(payload: dict[str, Any]) -> dict[str, Any]:
+        payloads.append(payload)
+        return {"choices": [{"message": {"content": "YES, clearly wedged."}}]}
+
+    judge = OpenAICompatCompletionJudge(
+        base_url="http://judge:8002/v1",
+        model="nvidia/Cosmos3-Nano",
+        prompt_template=STUCK_PROMPT_TEMPLATE,
+        max_tokens=256,
+        transport=transport,
+    )
+    gate = SpecialistGate(detector=judge, executor=_SYNC)
+    gate.begin_episode(1)
+
+    import numpy as np
+
+    gate.submit(
+        chunk_index=0,
+        frame=np.zeros((4, 4, 3), dtype=np.uint8),
+        instruction="put the bowl on the plate",
+    )
+    verdict = gate.poll()
+
+    assert verdict is not None and verdict.stuck is True  # YES == stuck
+    prompt = payloads[0]["messages"][0]["content"][1]["text"]
+    assert "FAILED or STUCK" in prompt
+    assert "put the bowl on the plate" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Real worker thread.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_thread_mode_delivers_verdict_and_close_joins() -> None:
+    release = threading.Event()
+
+    def slow_detector(frame: Any, instruction: str) -> bool:
+        assert release.wait(timeout=5.0)
+        return True
+
+    gate = SpecialistGate(detector=slow_detector)
+    gate.begin_episode(1)
+    assert gate.submit(chunk_index=0, frame="f", instruction="i") is True
+    assert gate.poll() is None  # nothing yet: the sim loop is not blocked
+
+    release.set()
+    deadline = threading.Event()
+    verdict = None
+    for _ in range(100):
+        verdict = gate.poll()
+        if verdict is not None:
+            break
+        deadline.wait(0.02)
+    assert verdict is not None and verdict.stuck is True
+
+    gate.close()
+    gate.close()  # idempotent
+    assert gate.submit(chunk_index=1, frame="f", instruction="i") is False  # closed
+
+
+def test_gate_never_blocks_when_judge_slower_than_chunks() -> None:
+    release = threading.Event()
+    calls: list[int] = []
+
+    def glacial(frame: Any, instruction: str) -> bool:
+        calls.append(1)
+        assert release.wait(timeout=5.0)
+        return False
+
+    gate = SpecialistGate(detector=glacial)
+    gate.begin_episode(1)
+    results = [gate.submit(chunk_index=c, frame="f", instruction="i") for c in range(5)]
+    assert results == [True, False, False, False, False]  # 1 accepted, 4 skipped
+
+    release.set()
+    gate.close()
+    assert sum(calls) == 1  # the backlog never formed


### PR DESCRIPTION
## What

Iteration 1 of the closed-loop recovery experiment (`docs/experiment-recovery-design-vla.md`): a tiered stuck detector runs inside the LIBERO eval loop of both chunk-emitting pilots (GR00T, pi0.5); on trigger it **truncates** the stale chunk ([VLA-Corrector](https://arxiv.org/abs/2607.01804)'s event-triggered truncation, via a new `ChunkPilotAdapter.flush()`) and — on a SPECIALIST VLM verdict — **rolls the arm back** to the last chunk boundary whose verdicts were clean. The SPECIALIST (any OpenAI-compat reasoner; default `nvidia/Cosmos3-Nano`) is polled **asynchronously** at chunk boundaries: the sim never blocks on the VLM.

Everything ships behind default-off flags — with no recovery key set, both recipes are behavior-identical to today (pinned by equivalence tests).

## Pieces

- `runners/agents/recovery.py` (strict-clean, stdlib-only): `ChunkLedger` (boundary snapshots; `last_good()` = 'last successful chunk'), `StuckMonitor` (tier 1 kinematic + tier 2 inter-chunk continuity), `RecoveryController` (EE-space P-controller, 7-D OSC deltas), `RecoveryPolicy` (flush vs rollback, shadow mode, budget, staleness, events + metrics), `RolloutLog` (per-step (frame, action) npz — the LVM training corpus for PR 2).
- `runners/agents/specialist_gate.py`: async `SpecialistGate` (worker thread + mailbox, at-most-one in flight, skip-never-queue) over the OpenAI-compat judge with the reasoner probe's calibrated stuck prompt.
- `ChunkPilotAdapter.flush()` + **GR00T recipe migrated onto the adapter** (bit-for-bit equivalence-tested vs the old inline chunk loop).
- Both recipes wired via shared `evals/recovery_wiring.py` (one argparse block, one assembly path); `LiberoRunner` resolves `--recovery_dir` (the `--video_dir` pattern) and registers artifacts.
- Examples: `examples/reasoner-probe/` (Phase 0 judge calibration, ported pilot-neutral from cosmos3-integration) + `examples/recovery-gr00t-libero/` (arms A baseline / B shadow / C kinematic / D delegation; shipped as shadow).

## Verification

- ~90 new unit tests; full suite **638 passed** on 3.10; `ruff` + strict `mypy` clean per commit.
- Recovery-off inertness: adapter-migration equivalence tests + recovery-off end-to-end test (no extra queries, no artifacts).
- **Not in this PR**: GPU validation (phases 0/2/3 — judge calibration on rollout videos, shadow runs, live arms) runs on the VM next; command-mode controller gains and teleport state-restore are flagged as the known hardware risks in the design doc.

Design + prior-art trail: `docs/experiment-recovery-design-vla.md` (VLA-Corrector adoption: truncation now, LVM tier PR 2, OGG never — impossible through served pilots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)