### PR TITLE
feat(training): Cosmos 3 SFT runner (cosmos-framework)

### DIFF
--- a/examples/drugsort-cosmos3-train/eval_openloop_gt_cosmos3.py
+++ b/examples/drugsort-cosmos3-train/eval_openloop_gt_cosmos3.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Open-loop ground-truth eval of a fine-tuned **Cosmos 3** drug-sort pilot.
+
+The Cosmos-3 counterpart to ``scripts/eval_openloop_gt.py`` (which targets a
+GR00T zmq server in joint space). Same idea — replay recorded observations from
+held-out episodes, ask the policy for its predicted action chunk, score it
+against the expert ground truth — but two things differ because Cosmos 3 is a
+different animal:
+
+1. **Wire protocol.** Cosmos 3 serves over cosmos-framework's HTTP
+   ``action_policy_server_libero`` (base64-PNG ``concat_view`` request, JSON
+   ``/predict`` -> ``{"action": [[...], ...]}``), NOT GR00T's zmq/msgpack. We
+   reuse Odyssey's own client glue (``Cosmos3HttpClient`` +
+   ``build_cosmos3_predict_request`` + ``cosmos3_chunk_from_response``).
+
+2. **Action space.** The drug-sort SFT recipe (``action_policy_drugsort_nano``,
+   ``DrugsortURDataset``) emits 10-D ``frame_wise_relative`` cartesian rows
+   ``[dpos(3), rot6d(6), gripper(1)]`` — EE-space deltas obtained by FK on the
+   arm joints. The recorded expert ``action`` is 7-D **absolute joint targets**
+   ``[6 arm joints, gripper]``. So to compare like-with-like we run the SAME
+   transform the dataset uses at train time on the GT joint chunk (MuJoCo FK ->
+   ``pose_abs_to_rel(rot6d, backward_framewise)`` + gripper invert) and compare
+   the two in EE-delta space:
+     * translation MAE (metres) over the dpos block
+     * rotation geodesic error (degrees) from the rot6d block
+     * gripper open/close agreement (binarised at 0.5)
+
+Why open-loop: needs no MuJoCo *rollout*, no browser, no physics GT — only the
+dataset (parquet + mp4) and a running policy server. It's the fastest signal
+that a checkpoint learned the task shape; it does NOT measure task success (use
+the closed-loop harness for that).
+
+Serving: with ``--serve`` (the default) this script BOOTS the cosmos-framework
+``action_policy_server_libero`` on ``--checkpoint``, waits for ``GET /info``,
+runs, then tears it down — so it satisfies Odyssey's ``custom`` eval-runner
+contract (``--checkpoint`` / ``--out-json``, script owns serving). Pass
+``--no-serve`` to score against a server you started yourself.
+
+Note the dataset the eval READS is the **LeRobot v2.1** original
+(``…/ur10e_partial_cond_aug`` — per-episode ``data/chunk-000/episode_*.parquet``
+and ``videos/…/episode_*.mp4``); the v3.0 *conversion* is only what
+cosmos-framework's TRAIN loader needs, and its consolidated ``file-000`` layout
+is not what ``_read_episode`` below walks. Point ``--dataset`` at the v2.1 dir.
+
+Only ``numpy`` is needed to import the pure metric/transform helpers (unit-tested
+in ``tests/unit/test_eval_openloop_gt_cosmos3.py``); the CLI additionally uses
+pyarrow, imageio, mujoco + cosmos-framework (FK) and Odyssey's cosmos3 client —
+all imported lazily inside ``main``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# ── Pure metric + transform functions (numpy-only; unit-tested) ────────────────
+
+ARM_JOINTS = 6
+# Action-row widths we compare. The GT (FK'd from joints) is 10-D
+# [dpos(3), rot6d(6), gripper(1)]; the cosmos server returns a DECODED env-native
+# 7-D row [dpos(3), axis-angle(3), gripper(1)] for the robomind-ur domain (verified
+# on the first GPU rollout). Both decode to (dpos, R, gripper) for a width-agnostic
+# comparison.
+_ROW_ROT6D = 10
+_ROW_AXISANGLE = 7
+
+
+def rot6d_to_matrix(rot6d: np.ndarray) -> np.ndarray:
+    """Gram-Schmidt a 6-D rotation representation into a 3x3 rotation matrix.
+
+    ``rot6d`` is the first two columns of R stacked (Zhou et al. 2019): the
+    model/dataset convention used by the cosmos LIBERO/drug-sort recipes. Column
+    1 is normalised; column 2 is orthogonalised against it; column 3 = c1 x c2.
+    """
+    v = np.asarray(rot6d, dtype=np.float64).reshape(6)
+    a1, a2 = v[:3], v[3:]
+    b1 = a1 / (np.linalg.norm(a1) + 1e-12)
+    a2 = a2 - (b1 @ a2) * b1
+    b2 = a2 / (np.linalg.norm(a2) + 1e-12)
+    b3 = np.cross(b1, b2)
+    return np.stack([b1, b2, b3], axis=1)
+
+
+def axis_angle_to_matrix(aa: np.ndarray) -> np.ndarray:
+    """Rodrigues: a 3-vector axis-angle (magnitude = angle in rad) -> 3x3 R."""
+    v = np.asarray(aa, dtype=np.float64).reshape(3)
+    theta = float(np.linalg.norm(v))
+    if theta < 1e-12:
+        return np.eye(3)
+    k = v / theta
+    kx = np.array([[0, -k[2], k[1]], [k[2], 0, -k[0]], [-k[1], k[0], 0]], dtype=np.float64)
+    return np.eye(3) + np.sin(theta) * kx + (1 - np.cos(theta)) * (kx @ kx)
+
+
+def _row_to_pose(row: np.ndarray) -> tuple[np.ndarray, np.ndarray, float]:
+    """Decode one action row -> (dpos(3), R(3x3), gripper) for either width.
+
+    Width 10 = ``[dpos(3), rot6d(6), gripper(1)]`` (GT); width 7 =
+    ``[dpos(3), axis-angle(3), gripper(1)]`` (cosmos server, robomind-ur). A row
+    wider than 10 is treated as 10-D + padding; a 7..9 row as axis-angle.
+    """
+    v = np.asarray(row, dtype=np.float64).ravel()
+    dpos = v[:3]
+    if v.shape[0] >= _ROW_ROT6D:
+        return dpos, rot6d_to_matrix(v[3:9]), float(v[9])
+    return dpos, axis_angle_to_matrix(v[3:6]), float(v[6])
+
+
+def geodesic_deg_mat(rp: np.ndarray, rg: np.ndarray) -> float:
+    """Geodesic angle (degrees) between two rotation matrices, clamped."""
+    cos = (np.trace(rp.T @ rg) - 1.0) / 2.0
+    return float(np.degrees(np.arccos(np.clip(cos, -1.0, 1.0))))
+
+
+def cartesian_chunk_metrics(pred: np.ndarray, gt: np.ndarray) -> tuple[float, float, float]:
+    """Per-chunk (translation MAE m, rotation geodesic deg, gripper agreement).
+
+    ``pred`` / ``gt`` are ``(H, W)`` rows — W may differ between the two (the
+    cosmos server returns decoded 7-D axis-angle rows, the FK'd GT is 10-D rot6d);
+    each row is decoded to ``(dpos, R, gripper)`` so the comparison is
+    width-agnostic. Compared over the overlapping horizon; empty overlap -> NaN.
+    """
+    pred = np.asarray(pred, dtype=np.float64)
+    gt = np.asarray(gt, dtype=np.float64)
+    pred = pred.reshape(1, -1) if pred.ndim == 1 else pred
+    gt = gt.reshape(1, -1) if gt.ndim == 1 else gt
+    h = min(pred.shape[0], gt.shape[0])
+    if h == 0:
+        return float("nan"), float("nan"), float("nan")
+    trans, rot, grip = [], [], []
+    for t in range(h):
+        pp, pr, pgrip = _row_to_pose(pred[t])
+        gp, gr, ggrip = _row_to_pose(gt[t])
+        trans.append(float(np.abs(pp - gp).mean()))
+        rot.append(geodesic_deg_mat(pr, gr))
+        grip.append(float((pgrip >= 0.5) == (ggrip >= 0.5)))
+    return float(np.mean(trans)), float(np.mean(rot)), float(np.mean(grip))
+
+
+def aggregate(trans: list[float], rot: list[float], grip: list[float]) -> dict:
+    """Reduce per-tick records to a run summary (nan-safe means)."""
+    t = np.asarray(trans, dtype=np.float64) if trans else np.empty(0)
+    r = np.asarray(rot, dtype=np.float64) if rot else np.empty(0)
+    g = np.asarray(grip, dtype=np.float64) if grip else np.empty(0)
+    return {
+        "n_ticks": int(t.size),
+        "trans_mae_m": float(np.nanmean(t)) if t.size else float("nan"),
+        "rot_geodesic_deg": float(np.nanmean(r)) if r.size else float("nan"),
+        "gripper_agreement": float(np.nanmean(g)) if g.size else float("nan"),
+    }
+
+
+# ── FK GT transform (mirrors DrugsortURDataset._build_raw_action) ──────────────
+
+def gt_ee_delta_chunk(joint_chunk: np.ndarray, fk) -> np.ndarray:
+    """Turn a recorded ``(H+1, 7)`` joint-action chunk into ``(H, 10)`` EE deltas.
+
+    ``joint_chunk`` rows are ``[6 arm joints, gripper]`` absolute targets. ``fk``
+    is a callable ``arm_q(K,6) -> (positions(K,3), rotations(K,3,3))`` (MuJoCo FK
+    on the UR5e). Mirrors the training transform EXACTLY: absolute EE poses ->
+    ``pose_abs_to_rel(rot6d, backward_framewise)`` (imported lazily here) and
+    gripper inverted ``1 - q_grip``. Returns ``[dpos(3), rot6d(6), gripper(1)]``
+    — the same space Cosmos 3 predicts.
+    """
+    from cosmos_framework.data.generator.action.pose_utils import pose_abs_to_rel
+
+    q = np.asarray(joint_chunk, dtype=np.float32)
+    horizon = len(q) - 1
+    pos, rot = fk(q[:, :ARM_JOINTS])
+    poses_abs = np.tile(np.eye(4, dtype=np.float32), (horizon + 1, 1, 1))
+    poses_abs[:, :3, 3] = pos
+    poses_abs[:, :3, :3] = rot
+    poses_rel = pose_abs_to_rel(poses_abs, rotation_format="rot6d", pose_convention="backward_framewise")
+    gripper = (1.0 - q[:horizon, ARM_JOINTS:ARM_JOINTS + 1]).astype(np.float32)
+    return np.concatenate([np.asarray(poses_rel, dtype=np.float32), gripper], axis=-1)  # (H,10)
+
+
+# ── Dataset IO (v2.1 layout — heavy deps lazy) ─────────────────────────────────
+
+def _read_episode(dataset: Path, ep: int):
+    """Return (state[N,S], action[N,7], {view: frames[N,H,W,3]}) for one episode."""
+    import imageio.v3 as iio
+    import pyarrow.parquet as pq
+
+    pqf = dataset / "data" / "chunk-000" / f"episode_{ep:06d}.parquet"
+    t = pq.read_table(pqf)
+    state = np.asarray(t.column("observation.state").to_pylist(), dtype=np.float32)
+    action = np.asarray(t.column("action").to_pylist(), dtype=np.float32)
+    frames: dict[str, np.ndarray] = {}
+    for key in ("exterior", "wrist"):
+        mp4 = dataset / "videos" / "chunk-000" / f"observation.images.{key}" / f"episode_{ep:06d}.mp4"
+        if mp4.is_file():
+            frames[key] = np.asarray(iio.imread(mp4, plugin="pyav"))
+    return state, action, frames
+
+
+def _make_ur5e_fk():
+    """Build the UR5e MuJoCo FK callable by reusing RoboMINDURDataset's kinematics."""
+    import mujoco
+    from cosmos_framework.data.generator.action.datasets.robomind_ur_dataset import (
+        RoboMINDURDataset,
+    )
+
+    mj_model, mj_data, ee_site_id = RoboMINDURDataset._init_mujoco()
+
+    def fk(arm_q: np.ndarray):
+        arm_q = np.asarray(arm_q, dtype=np.float32)
+        k = len(arm_q)
+        positions = np.empty((k, 3), dtype=np.float32)
+        rotations = np.empty((k, 3, 3), dtype=np.float32)
+        for i in range(k):
+            mj_data.qpos[:ARM_JOINTS] = arm_q[i]
+            mujoco.mj_forward(mj_model, mj_data)
+            positions[i] = mj_data.site_xpos[ee_site_id]
+            rotations[i] = mj_data.site_xmat[ee_site_id].reshape(3, 3)
+        return positions, rotations
+
+    return fk
+
+
+# ── Optional server lifecycle (custom-runner contract) ─────────────────────────
+
+def _serve_cosmos(checkpoint: str, port: int, log_path: Path):
+    """Boot action_policy_server_libero on ``checkpoint``; return the Popen."""
+    import subprocess
+
+    cmd = [
+        sys.executable, "-m", "cosmos_framework.scripts.action_policy_server_libero",
+        "--checkpoint-path", checkpoint, "--port", str(port),
+    ]
+    log = open(log_path, "w")  # noqa: SIM115 — handle must outlive this fn (Popen stdout)
+    print(f"[cosmos-openloop] serving: {' '.join(cmd)} (log {log_path})")
+    return subprocess.Popen(cmd, stdout=log, stderr=subprocess.STDOUT)
+
+
+def _wait_info(client, timeout_s: float) -> bool:
+    """Poll GET /info until the server answers or ``timeout_s`` elapses."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            client.info()
+            return True
+        except Exception:
+            time.sleep(3.0)
+    return False
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Cosmos3 open-loop GT eval")
+    ap.add_argument("--dataset", required=True, help="LeRobot v2.1 dir (…/ur10e_partial_cond_aug)")
+    ap.add_argument("--checkpoint", default="", help="export dir to serve (with --serve)")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=8000)
+    ap.add_argument("--serve", dest="serve", action="store_true", default=True,
+                    help="boot the cosmos server on --checkpoint (default)")
+    ap.add_argument("--no-serve", dest="serve", action="store_false",
+                    help="score against an already-running server")
+    # Flag names use underscores so the odyssey `custom` runner's verbatim
+    # `--<config-key> value` passthrough (domain_name / held_out / …) matches.
+    ap.add_argument("--domain_name", default="robomind-ur",
+                    help="domain tag sent with each /predict (drug-sort trains under robomind-ur)")
+    ap.add_argument("--image_size", type=int, default=256)
+    ap.add_argument("--episodes", type=int, nargs="*", default=None)
+    ap.add_argument("--held_out", type=int, default=4,
+                    help="eval the LAST N episodes when --episodes is unset (fit-eval caveat: "
+                         "they are in the train split — a sanity signal, not generalization)")
+    ap.add_argument("--stride", type=int, default=8)
+    ap.add_argument("--horizon", type=int, default=16)
+    ap.add_argument("--instruction", default="pick up the vial and place it in the rack")
+    ap.add_argument("--server-timeout-s", type=float, default=600.0)
+    ap.add_argument("--out-json", default="")
+    # tolerate the odyssey custom-runner's extra passthrough flags.
+    args, _unknown = ap.parse_known_args()
+
+    dataset = Path(args.dataset)
+    if not (dataset / "meta" / "info.json").is_file():
+        print(f"ERROR: not a LeRobot dataset dir: {dataset}", file=sys.stderr)
+        return 2
+    info = json.loads((dataset / "meta" / "info.json").read_text())
+    total = int(info["total_episodes"])
+    eps = args.episodes if args.episodes is not None else list(range(max(0, total - args.held_out), total))
+
+    from odyssey.runners.evals.cosmos3_transforms import (
+        build_cosmos3_predict_request,
+        cosmos3_chunk_from_response,
+    )
+    from odyssey.runners.models.cosmos3 import Cosmos3HttpClient
+
+    proc = None
+    try:
+        client = Cosmos3HttpClient(host=args.host, port=args.port, timeout_seconds=args.server_timeout_s)
+        if args.serve:
+            if not args.checkpoint:
+                print("ERROR: --serve needs --checkpoint", file=sys.stderr)
+                return 2
+            log_path = (
+                Path(args.out_json).with_suffix(".server.log") if args.out_json
+                else Path("/tmp/cosmos_server.log")
+            )
+            proc = _serve_cosmos(args.checkpoint, args.port, log_path)
+            if not _wait_info(client, args.server_timeout_s):
+                print("ERROR: cosmos server did not come up (see server log)", file=sys.stderr)
+                return 3
+        else:
+            client.info()  # fail fast if nothing is listening
+
+        fk = _make_ur5e_fk()
+        all_t: list[float] = []
+        all_r: list[float] = []
+        all_g: list[float] = []
+        per_ep: list[dict] = []
+        for ep in eps:
+            state, action, frames = _read_episode(dataset, ep)
+            n = state.shape[0]
+            ep_t: list[float] = []
+            ep_r: list[float] = []
+            ep_g: list[float] = []
+            for t in range(0, n - 1, args.stride):
+                if not all(t < v.shape[0] for v in frames.values()):
+                    break
+                req = build_cosmos3_predict_request(
+                    image=frames["exterior"][t],
+                    wrist_image=frames["wrist"][t] if "wrist" in frames else None,
+                    instruction=args.instruction,
+                    domain_name=args.domain_name,
+                    image_size=args.image_size,
+                )
+                pred = cosmos3_chunk_from_response(client.infer(req))[: args.horizon]
+                gt_joint = action[t : t + args.horizon + 1]
+                if len(gt_joint) < 2:
+                    break
+                gt = gt_ee_delta_chunk(gt_joint, fk)
+                tm, rm, gm = cartesian_chunk_metrics(pred, gt)
+                ep_t.append(tm)
+                ep_r.append(rm)
+                ep_g.append(gm)
+            s = aggregate(ep_t, ep_r, ep_g)
+            s["episode"] = ep
+            per_ep.append(s)
+            all_t.extend(ep_t)
+            all_r.extend(ep_r)
+            all_g.extend(ep_g)
+            print(f"[cosmos-openloop] ep {ep:03d}: ticks={s['n_ticks']:3d} "
+                  f"trans_MAE={s['trans_mae_m']:.4f} m  rot={s['rot_geodesic_deg']:.2f} deg  "
+                  f"grip={s['gripper_agreement'] * 100:5.1f}%")
+
+        summary = aggregate(all_t, all_r, all_g)
+        summary["episodes"] = per_ep
+        summary["dataset"] = str(dataset)
+        # odyssey custom-runner metric contract: fold flat metrics under "metrics".
+        summary["metrics"] = {
+            "trans_mae_m": summary["trans_mae_m"],
+            "rot_geodesic_deg": summary["rot_geodesic_deg"],
+            "gripper_agreement": summary["gripper_agreement"],
+        }
+        print("\n[cosmos-openloop] ===== SUMMARY =====")
+        print(f"[cosmos-openloop] ticks={summary['n_ticks']}  trans_MAE={summary['trans_mae_m']:.4f} m  "
+              f"rot={summary['rot_geodesic_deg']:.2f} deg  grip={summary['gripper_agreement'] * 100:.1f}%")
+        if args.out_json:
+            Path(args.out_json).write_text(json.dumps(summary, indent=2) + "\n")
+            print(f"[cosmos-openloop] wrote {args.out_json}")
+        return 0
+    finally:
+        if proc is not None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=30)
+            except Exception:
+                proc.kill()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/drugsort-cosmos3-train/eval_openloop_gt_cosmos3.py
+++ b/examples/drugsort-cosmos3-train/eval_openloop_gt_cosmos3.py
@@ -285,6 +285,13 @@ def main() -> int:
     total = int(info["total_episodes"])
     eps = args.episodes if args.episodes is not None else list(range(max(0, total - args.held_out), total))
 
+    # Make `odyssey` importable when launched under an arbitrary interpreter: the
+    # `custom` eval runner runs this via `eval_python` (e.g. the cosmos-framework
+    # venv), which need not have odyssey installed nor PYTHONPATH forwarded to the
+    # child. Fall back to the repo's own src/ (this file is examples/<m>/<f>.py).
+    _src = Path(__file__).resolve().parents[2] / "src"
+    if _src.is_dir() and str(_src) not in sys.path:
+        sys.path.insert(0, str(_src))
     from odyssey.runners.evals.cosmos3_transforms import (
         build_cosmos3_predict_request,
         cosmos3_chunk_from_response,

--- a/examples/drugsort-cosmos3-train/mission.yaml
+++ b/examples/drugsort-cosmos3-train/mission.yaml
@@ -1,0 +1,133 @@
+# Cosmos 3 (WAM) UR5e drug-sort action-policy fine-tune (single-GPU smoke).
+#
+# Fine-tunes an NVIDIA Cosmos 3 Nano action policy on the UR5e drug-sort
+# LeRobot-v3 demonstrations via the odyssey `cosmos3` training runner ->
+# cosmos-framework's three entry points (convert_model_to_dcp -> train ->
+# export_model).
+#
+# This mission drives a CUSTOM cosmos-framework experiment authored for the
+# UR5e drug-sort embodiment (NOT one of the shipped LIBERO/DROID recipes):
+#   * experiment  : action_policy_drugsort_nano
+#   * dataset     : DrugsortURDataset (RoboMIND-UR FK -> 10D rot6d cartesian
+#                   action, single `exterior` third-person cam, domain robomind-ur)
+#   * env var     : DRUGSORT_ROOT (the recipe interpolates ${oc.env:DRUGSORT_ROOT})
+# See cosmos-framework:
+#   cosmos_framework/data/generator/action/datasets/drugsort_ur_dataset.py
+#   cosmos_framework/configs/.../posttrain_config/action_policy_drugsort_nano.py
+#   examples/toml/sft_config/action_policy_drugsort_nano.toml
+#
+# The drug-sort dataset was converted from LeRobot v2.1 -> v3.0 first (cosmos
+# reads v3.0): lerobot/datasets/v30/convert_dataset_v21_to_v30.py.
+#
+# Validate without a GPU:
+#   odyssey validate mission.yaml
+#   odyssey run mission.yaml --use-mock-runner
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: cosmos3-drugsort-nano-finetune
+  description: >-
+    Fine-tune a Cosmos 3 Nano action policy on the UR5e drug-sort LeRobot-v3
+    demos via a custom cosmos-framework experiment (action_policy_drugsort_nano).
+  tags: [cosmos3, wam, nvidia, cosmos-framework, drugsort, ur5e, lerobot, training]
+
+objective: |
+  Post-train Cosmos3-Nano into a UR5e drug-sort action policy on the 60-episode
+  LeRobot-v3 demonstrations (pick up the vial and place it in the rack), so the
+  exported checkpoint can be served through cosmos-framework's action policy
+  server for closed-loop rollout.
+
+acceptance_criteria: |
+  The fine-tune produces an exported HF-safetensors checkpoint under the task
+  output_dir (<run>/model). For the single-GPU smoke the bar is simply: the three
+  subprocesses (convert_model_to_dcp -> train -> export_model) complete and the
+  train loss is logged for 10 iterations.
+
+robot:
+  # UR5e + Robotiq 2F-85 (robot_type ur5e_robotiq_2f85 in the dataset).
+  embodiment: ur5e
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        # DCP conversion (step 1) starts from this base Cosmos 3 checkpoint.
+        base: nvidia/Cosmos3-Nano
+
+tasks:
+  - name: finetune-cosmos3-drugsort
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    dataset:
+      source: local
+      # ABSOLUTE path to the CONVERTED LeRobot-v3 drug-sort dir ON THE H100 box.
+      # (Original v2.1 lives at .../ur10e_partial_cond_aug; this is the v3.0 copy.)
+      ref: /home/ubuntu/data/ur10e_drugsort_v0/ur10e_drugsort_v30
+      format: lerobot
+    config:
+      # Route this wildcard training task to the Cosmos 3 runner.
+      runner: cosmos3
+      # The custom SFT recipe TOML under $COSMOS_FRAMEWORK_REPO_PATH/examples/toml/sft_config/.
+      config_name: action_policy_drugsort_nano
+      # The recipe interpolates ${oc.env:DRUGSORT_ROOT} for the dataset path.
+      dataset_env: DRUGSORT_ROOT
+      # Base handed to convert_model_to_dcp (step 1).
+      base_model: Cosmos3-Nano
+      # Single-GPU smoke.
+      nproc_per_node: 1
+      # Wan2.2 VAE weights the tokenizer needs (hf download Wan-AI/Wan2.2-TI2V-5B Wan2.2_VAE.pth).
+      wan_vae_path: /home/ubuntu/cosmos-framework/examples/checkpoints/wan22_vae/Wan2.2_VAE.pth
+
+      # --- Hydra dotlist overrides forwarded to cosmos_framework.scripts.train --
+      # (the runner emits these as trailing `key.path=value` positionals).
+      # Smoke: 10 iterations. Remove / raise for a real run.
+      trainer:
+        max_iter: 10
+      # SINGLE-GPU FIT KNOBS. Cosmos3-Nano bundles an 8B Qwen3-VL backbone; with
+      # shard_degree=1 the unsharded model is ~63 GB, so a full-finetune optimizer
+      # does NOT fit one 80 GB H100 (NVIDIA trains this with HSDP 2x8). LoRA shrinks
+      # the optimizer to a sliver and the packed-token cut slashes activation memory.
+      # Drop this whole block for a real multi-GPU run.
+      model:
+        config:
+          lora_enabled: true
+          max_num_tokens_after_packing: 8192
+          # EMA keeps a FULL fp32 copy of the net (~2x model memory) — the single
+          # biggest OOM driver on one GPU. Off for the smoke (no eval-quality need).
+          ema:
+            enabled: false
+      dataloader_train:
+        max_samples_per_batch: 1
+
+  # Open-loop ground-truth eval of the EXPORTED checkpoint (spec requires exactly
+  # one evaluation task). The `custom` runner invokes the eval script as:
+  #   <eval_python> <eval_script> --checkpoint <export> --out-json <path> [--k v ...]
+  # The script BOOTS cosmos-framework's action_policy_server_libero on the export,
+  # replays held-out episodes, and scores the predicted 10-D EE-delta chunk vs the
+  # FK'd expert action (trans MAE / rot geodesic / gripper agreement). It reads the
+  # LeRobot **v2.1** original (per-episode parquet+mp4), NOT the v3.0 train copy.
+  - name: eval-openloop-cosmos3-drugsort
+    kind: evaluation
+    evaluation_type: custom
+    benchmark_name: drugsort-openloop-gt
+    num_episodes: 4
+    config:
+      eval_script: examples/drugsort-cosmos3-train/eval_openloop_gt_cosmos3.py
+      # Run the eval under the cosmos-framework venv (mujoco FK + server live there).
+      eval_python: /home/ubuntu/cosmos-framework/.venv/bin/python
+      # v2.1 ORIGINAL dataset dir (the eval's per-episode IO layout).
+      dataset: /home/ubuntu/data/ur10e_drugsort_v0/ur10e_partial_cond_aug
+      domain_name: robomind-ur
+      host: 127.0.0.1
+      port: 8000
+      held_out: 4
+      stride: 8
+
+leaderboard:
+  publish: false
+
+graph:
+  contribute: false

--- a/examples/quickstart-cosmos3-train/README.md
+++ b/examples/quickstart-cosmos3-train/README.md
@@ -75,7 +75,7 @@ through from your shell:
 
 | Var | Set by | Meaning |
 |-----|--------|---------|
-| `DATASET_PATH` | `dataset.ref` (or `config.dataset_path`) | LeRobot-v3 dataset root (parent of `success/`) |
+| `DATASET_PATH` / `LIBERO_ROOT` | `dataset.ref` (or `config.dataset_path`), under the name in `config.dataset_env` | LeRobot-v3 dataset path. **Recipe-specific var name**: DROID reads `DATASET_PATH` (default); LIBERO reads `LIBERO_ROOT` (the suite dir, e.g. `<dir>/libero_10`). Set `config: {dataset_env: LIBERO_ROOT}` for LIBERO. |
 | `BASE_CHECKPOINT_PATH` | `config.base_checkpoint_path`, else `<output>/base_checkpoint_dcp` | DCP dir (step 1 output) |
 | `IMAGINAIRE_OUTPUT_ROOT` | task `output_dir` | where train writes the run dir |
 | `NPROC_PER_NODE` | `config.nproc_per_node` (default 8) | torchrun workers |
@@ -86,7 +86,8 @@ through from your shell:
 ### Control keys (consumed by the runner, never forwarded as overrides)
 
 `config_name`, `runner`, `base_model`, `convert_dcp`, `export`, `nproc_per_node`,
-`base_checkpoint_path`, `wan_vae_path`, `filter_dir`, `dataset_path`.
+`base_checkpoint_path`, `wan_vae_path`, `filter_dir`, `dataset_path`,
+`dataset_env`.
 
 ## Validate without a GPU
 

--- a/examples/quickstart-cosmos3-train/README.md
+++ b/examples/quickstart-cosmos3-train/README.md
@@ -1,0 +1,119 @@
+# Cosmos 3 (WAM) action-policy fine-tune quickstart (training)
+
+Fine-tune an NVIDIA **Cosmos 3** action policy on a LeRobot-v3 demonstration set
+through the odyssey `cosmos3` training runner. The runner shells out to
+**cosmos-framework**'s own entry points — `convert_model_to_dcp` → `train`
+(under `torchrun`) → `export_model` — so the actual training happens in your
+cosmos-framework checkout.
+
+This is the **training** counterpart to the eval-only `pilot: cosmos3` path
+(LIBERO / RoboLab). Once this produces an export, `pilot: cosmos3` scores it for
+real instead of running out-of-distribution against a DROID-only checkpoint.
+
+> **Status:** the odyssey-side wiring (three-step subprocess orchestration, argv
+> build, env bridging, run-dir + checkpoint capture, stdout→progress parsing) is
+> complete and unit-tested on CPU (`tests/unit/test_cosmos3_train.py`). It has
+> **not** been run end-to-end on a GPU box yet — treat the cosmos-framework flag
+> names and env vars below as the contract to confirm on the first smoke.
+
+## What you need
+
+- A multi-GPU box. The reference LIBERO-Nano recipe is 8 GPUs/node (the paper
+  used far more); a single-node **smoke** with `trainer.max_iter=10` fits fewer.
+- **cosmos-framework** installed and checked out:
+  ```bash
+  git clone https://github.com/NVIDIA/cosmos-framework
+  cd cosmos-framework && pip install -e .
+  export COSMOS_FRAMEWORK_REPO_PATH=$(pwd)   # runner defaults to /srv/cosmos-framework
+  ```
+- The **LeRobot v3.0** dataset unpacked on the box (e.g.
+  `nvidia/LIBERO_LeRobot_v3` / `nvidia/Cosmos3-DROID`). FOOTGUN: `DATASET_PATH`
+  must point at the **PARENT of the `success/` folder** — i.e. the named dataset
+  dir itself — and the loader infers its schema from that **dir name**, so keep
+  the vendor naming (e.g. `droid_plus_lerobot_640x360_20260412`).
+- The Wan2.2 VAE weights (`WAN_VAE_PATH`) and, for DROID recipes, the DROID
+  filters dir (`FILTER_DIR`).
+
+## Option A: run `odyssey` from inside the cosmos-framework venv
+
+cosmos-framework lives in its own heavy venv. `run_training_subprocess` launches
+every child (torchrun workers included) via `sys.executable`, so the simplest,
+zero-core-change setup is to **install odyssey into that venv and run it from
+there** (the UR10e remote-venv pattern):
+
+```bash
+source /path/to/cosmos-framework/.venv/bin/activate
+pip install -e /path/to/odyssey
+odyssey run examples/quickstart-cosmos3-train/mission.yaml
+```
+
+## Why cosmos-framework is config-name-driven (and GR00T isn't)
+
+GR00T / OpenVLA take a flat bag of `--flag value` overrides. cosmos-framework —
+like π0.5 — selects a **registered SFT recipe TOML** by name; it bundles the data
+pipeline, weight loader and optimizer. So fine-tuning a *new* dataset/embodiment
+means adding a recipe under `examples/toml/sft_config/` whose interpolated env
+paths point at your data/checkpoints.
+
+`config.config_name` in the mission names that recipe (bare, no `.toml`):
+`action_policy_libero_nano`, `action_policy_droid_nano`, … Everything else under
+`config:` (minus the control keys below) is forwarded as a **dotted CLI override**
+(`trainer.max_iter` → `--trainer.max-iter`; booleans become `--flag`/`--no-flag`).
+
+## The three steps the runner runs
+
+| # | cosmos-framework entry | torchrun | Skipped when |
+|---|------------------------|----------|--------------|
+| 1 | `convert_model_to_dcp` | no  | `$BASE_CHECKPOINT_PATH` exists, or `config: {convert_dcp: false}` |
+| 2 | `train --sft-toml=<recipe>` | **yes** (`nproc_per_node`) | never |
+| 3 | `export_model` | no  | `config: {export: false}` |
+
+### Env vars the recipe TOML interpolates (`${oc.env:...}`)
+
+The runner sets these from the resolved mission refs; anything omitted falls
+through from your shell:
+
+| Var | Set by | Meaning |
+|-----|--------|---------|
+| `DATASET_PATH` | `dataset.ref` (or `config.dataset_path`) | LeRobot-v3 dataset root (parent of `success/`) |
+| `BASE_CHECKPOINT_PATH` | `config.base_checkpoint_path`, else `<output>/base_checkpoint_dcp` | DCP dir (step 1 output) |
+| `IMAGINAIRE_OUTPUT_ROOT` | task `output_dir` | where train writes the run dir |
+| `NPROC_PER_NODE` | `config.nproc_per_node` (default 8) | torchrun workers |
+| `WAN_VAE_PATH` | `config.wan_vae_path` (or shell) | Wan2.2 VAE weights |
+| `FILTER_DIR` | `config.filter_dir` (or shell) | DROID filters (DROID recipes) |
+| `HF_TOKEN` | shell | HF auth (gated weights) |
+
+### Control keys (consumed by the runner, never forwarded as overrides)
+
+`config_name`, `runner`, `base_model`, `convert_dcp`, `export`, `nproc_per_node`,
+`base_checkpoint_path`, `wan_vae_path`, `filter_dir`, `dataset_path`.
+
+## Validate without a GPU
+
+```bash
+odyssey validate examples/quickstart-cosmos3-train/mission.yaml
+odyssey run examples/quickstart-cosmos3-train/mission.yaml --use-mock-runner
+```
+
+## train → serve → eval hand-off
+
+The mission's second task scores the export on LIBERO with `pilot: cosmos3`.
+Cosmos 3 does **not** auto-serve in-process (contrast GR00T): you start the
+cosmos-framework HTTP server on the export, then run the eval against it.
+
+```bash
+# 1. Train (produces <task output_dir>/.../model — the exported HF safetensors).
+odyssey run examples/quickstart-cosmos3-train/mission.yaml
+
+# 2. Serve the export (in its own shell; note the printed export path).
+python -m cosmos_framework.scripts.action_policy_server_libero \
+    --checkpoint-path <run>/model --port 8000
+
+# 3. Eval — the LIBERO task connects to 127.0.0.1:8000 (host/port in the mission).
+#    If you ran step 1 as a full mission, the eval task will have already tried to
+#    connect; run just the eval once the server is up, or split into two missions.
+```
+
+The `pilot: cosmos3` eval knobs (`host`, `port`, `n_action_steps`,
+`domain_name`, `task_id`, …) pass through verbatim to `cosmos3_libero_eval.py`;
+`n_action_steps: 0` adopts the server's own `action_chunk_size` from `GET /info`.

--- a/examples/quickstart-cosmos3-train/mission.yaml
+++ b/examples/quickstart-cosmos3-train/mission.yaml
@@ -67,10 +67,11 @@ tasks:
     dataset:
       source: local
       # ABSOLUTE path to the unpacked LeRobot-v3 dataset ON THE TRAINING BOX.
-      # FOOTGUN: point at the PARENT of the `success/` folder — i.e. the named
-      # dataset dir itself, NOT `success/`. The cosmos-framework loader infers its
-      # schema from this DIR NAME, so keep the vendor naming.
-      ref: /data/libero_lerobot_v3_20260412
+      # For LIBERO this is the SUITE dir holding meta/info.json, e.g.
+      # <dir>/libero_10. Pre-sync once:
+      #   hf download nvidia/LIBERO_LeRobot_v3 --repo-type dataset \
+      #     --include 'libero_10/**' --local-dir <dir>
+      ref: /data/LIBERO_LeRobot_v3/libero_10
       format: lerobot
     config:
       # Routes this wildcard training task to the Cosmos 3 runner (OpenVLA is the
@@ -78,7 +79,12 @@ tasks:
       runner: cosmos3
       # REQUIRED: the registered SFT recipe TOML under
       # $COSMOS_FRAMEWORK_REPO_PATH/examples/toml/sft_config/ (bare name, no .toml).
-      config_name: action_policy_libero_nano
+      # LIBERO recipes: action_policy_libero_10_nano (single suite) /
+      # action_policy_libero_all_nano (4 suites). DROID: action_policy_droid_nano.
+      config_name: action_policy_libero_10_nano
+      # The env var the recipe interpolates for the dataset path is recipe-specific:
+      # LIBERO reads LIBERO_ROOT; DROID reads DATASET_PATH (the default).
+      dataset_env: LIBERO_ROOT
       # Base model handed to convert_model_to_dcp (step 1). Defaults to the agent's
       # HF base, else Cosmos3-Nano. Set convert_dcp: false to reuse an existing DCP.
       base_model: Cosmos3-Nano

--- a/examples/quickstart-cosmos3-train/mission.yaml
+++ b/examples/quickstart-cosmos3-train/mission.yaml
@@ -1,0 +1,124 @@
+# Cosmos 3 (WAM) action-policy fine-tune quickstart (train -> serve -> eval).
+#
+# Fine-tunes an NVIDIA Cosmos 3 action policy on a LeRobot-v3 demonstration set
+# via the odyssey `cosmos3` training runner -> cosmos-framework's three entry
+# points (convert_model_to_dcp -> train -> export_model), then scores the export
+# on LIBERO with `pilot: cosmos3`.
+#
+# HOW cosmos-framework TRAINING WORKS (different from GR00T/OpenVLA, like pi0.5):
+#   cosmos-framework is CONFIG-NAME-DRIVEN. Training selects a registered SFT
+#   recipe TOML (here `action_policy_libero_nano`) under
+#   $COSMOS_FRAMEWORK_REPO_PATH/examples/toml/sft_config/. Paths inside that TOML
+#   use OmegaConf env interpolation (${oc.env:BASE_CHECKPOINT_PATH} ...), so the
+#   runner steers data / checkpoint / output through ENVIRONMENT VARIABLES, not
+#   flags. Everything under `config:` (except control keys) is forwarded as a
+#   dotted CLI override (trainer.max_iter -> --trainer.max-iter).
+#   See examples/quickstart-cosmos3-train/README.md for the full recipe.
+#
+# THE THREE STEPS the runner shells out to:
+#   1. convert_model_to_dcp  (base Cosmos3-Nano -> DCP; skipped if it exists)
+#   2. torchrun ... train --sft-toml=<recipe>   (the SFT run itself)
+#   3. export_model          (DCP -> HF safetensors the policy server loads)
+#
+# Validate without a GPU:
+#   odyssey validate mission.yaml
+#   odyssey run mission.yaml --use-mock-runner
+
+odysseyVersion: "0.1"
+kind: Mission
+
+metadata:
+  name: cosmos3-libero-nano-finetune
+  description: >-
+    Fine-tune a Cosmos 3 Nano action policy on the LIBERO LeRobot-v3 demos, then
+    score the exported checkpoint on LIBERO with pilot: cosmos3.
+  tags: [cosmos3, wam, nvidia, cosmos-framework, libero, lerobot, training]
+
+objective: |
+  Post-train Cosmos3-Nano into a LIBERO action policy on the LIBERO_LeRobot_v3
+  demonstrations so the exported checkpoint, served through cosmos-framework's
+  action_policy_server_libero, can solve the suite under closed-loop rollout.
+
+acceptance_criteria: |
+  The fine-tune produces an exported HF-safetensors checkpoint under the task
+  output_dir (<run>/model) that loads in cosmos-framework's
+  action_policy_server_libero. The honest metric is the LIBERO success rate of
+  the second task once that server is started on the export (see README for the
+  train -> serve -> eval hand-off).
+
+robot:
+  # LIBERO is a Franka-Panda suite.
+  embodiment: franka_panda
+  agents:
+    - id: pilot
+      role: PILOT
+      model:
+        source: huggingface
+        # The base Cosmos 3 checkpoint the DCP conversion (step 1) starts from.
+        # A bare `Cosmos3-Nano` also works — cosmos-framework resolves it against
+        # its own checkpoint cache; this HF id documents the pilot identity.
+        base: nvidia/Cosmos3-Nano
+
+tasks:
+  - name: finetune-cosmos3-libero
+    kind: training
+    training_type: demonstration
+    agent_id: pilot
+    dataset:
+      source: local
+      # ABSOLUTE path to the unpacked LeRobot-v3 dataset ON THE TRAINING BOX.
+      # FOOTGUN: point at the PARENT of the `success/` folder — i.e. the named
+      # dataset dir itself, NOT `success/`. The cosmos-framework loader infers its
+      # schema from this DIR NAME, so keep the vendor naming.
+      ref: /data/libero_lerobot_v3_20260412
+      format: lerobot
+    config:
+      # Routes this wildcard training task to the Cosmos 3 runner (OpenVLA is the
+      # default; GR00T / pi0.5 / cosmos3 opt in by name).
+      runner: cosmos3
+      # REQUIRED: the registered SFT recipe TOML under
+      # $COSMOS_FRAMEWORK_REPO_PATH/examples/toml/sft_config/ (bare name, no .toml).
+      config_name: action_policy_libero_nano
+      # Base model handed to convert_model_to_dcp (step 1). Defaults to the agent's
+      # HF base, else Cosmos3-Nano. Set convert_dcp: false to reuse an existing DCP.
+      base_model: Cosmos3-Nano
+      # torchrun workers for the train step. Reference recipe is 8/node; drop for a
+      # single-GPU smoke.
+      nproc_per_node: 8
+      # Env-bridged paths the recipe TOML interpolates (${oc.env:...}). WAN_VAE_PATH
+      # and HF_TOKEN can instead come from the shell — only pin here if convenient.
+      wan_vae_path: /data/cosmos3/wan22_vae/Wan2.2_VAE.pth
+      # filter_dir: /data/cosmos3/droid_filters   # DROID recipes only
+
+      # --- dotted overrides forwarded to cosmos_framework.scripts.train ---------
+      # Smoke: 10 iterations on one node. Remove for a real multi-node run.
+      trainer:
+        max_iter: 10
+      # export: true is the default (step 3) — set false to stop at the trained DCP.
+
+  # Round-trip eval: score the EXPORTED checkpoint on LIBERO via pilot: cosmos3.
+  # This connects to a cosmos-framework HTTP action_policy_server_libero that YOU
+  # start on the export between the two tasks (Cosmos 3 does NOT auto-serve
+  # in-process — contrast GR00T). See README "train -> serve -> eval". Until the
+  # server is up, run this task on its own after starting it.
+  - name: eval-cosmos3-libero
+    kind: evaluation
+    evaluation_type: libero
+    benchmark_name: libero_object
+    num_episodes: 10
+    config:
+      # Swaps the default single-model rollout for the chunk-aware Cosmos 3 pilot.
+      pilot: cosmos3
+      # Address of the PRE-STARTED action_policy_server_libero holding the export.
+      host: 127.0.0.1
+      port: 8000
+      # 0 -> adopt the server's own action_chunk_size (GET /info). Family knobs.
+      n_action_steps: 0
+      domain_name: libero
+      task_id: 0
+
+leaderboard:
+  publish: false   # Backend not live yet.
+
+graph:
+  contribute: false   # Backend not live yet.

--- a/src/odyssey/cli/commands/run.py
+++ b/src/odyssey/cli/commands/run.py
@@ -30,6 +30,7 @@ from odyssey.providers import ProviderRegistry
 from odyssey.providers.huggingface import HFDatasetProvider, HFModelProvider
 from odyssey.providers.local import LocalDatasetProvider, LocalRobotProvider
 from odyssey.runners import (
+    Cosmos3Runner,
     CPUMockRunner,
     GR00TRunner,
     OpenVLARunner,
@@ -51,14 +52,15 @@ def _build_runners() -> RunnerRegistry:
     registry = RunnerRegistry()
     # Real runners first; CPU mock as a last-resort fallback so unfamiliar
     # task types still produce *something* instead of "no runner registered."
-    # OpenVLA, GR00T and π0.5 are all wildcard training runners — registration
-    # order makes OpenVLA the default; GR00T / π0.5 are selected per-task via
-    # ``config: {runner: gr00t}`` / ``config: {runner: pi05}``. --use-mock-runner
+    # OpenVLA, GR00T, π0.5 and Cosmos 3 are all wildcard training runners —
+    # registration order makes OpenVLA the default; the others are selected
+    # per-task via ``config: {runner: gr00t|pi05|cosmos3}``. --use-mock-runner
     # forces the mock through the engine's force_runner, not by thinning this
     # registry.
     registry.register(OpenVLARunner())
     registry.register(GR00TRunner())
     registry.register(Pi05Runner())
+    registry.register(Cosmos3Runner())
     registry.register(RobosuiteRunner())
     registry.register(IsaacLabRunner())
     registry.register(LiberoRunner())

--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -26,6 +26,11 @@ from odyssey.runners.cpu_mock import CPUMockRunner
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.robolab import RobolabRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
+from odyssey.runners.models.cosmos3_train import (
+    Cosmos3Runner,
+    build_cosmos3_train_argv,
+    parse_cosmos3_train_line,
+)
 from odyssey.runners.models.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
 from odyssey.runners.models.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
 from odyssey.runners.models.pi05_train import (
@@ -43,6 +48,7 @@ from odyssey.runners.subprocess import (
 __all__ = [
     "WILDCARD_TYPE",
     "CPUMockRunner",
+    "Cosmos3Runner",
     "GR00TRunner",
     "IsaacLabRunner",
     "LineParser",
@@ -54,9 +60,11 @@ __all__ = [
     "RunnerRegistry",
     "TaskContext",
     "TrainingProcessSpec",
+    "build_cosmos3_train_argv",
     "build_gr00t_argv",
     "build_openvla_argv",
     "build_pi05_train_argv",
+    "parse_cosmos3_train_line",
     "parse_gr00t_line",
     "parse_openvla_line",
     "parse_pi05_train_line",

--- a/src/odyssey/runners/models/cosmos3_train.py
+++ b/src/odyssey/runners/models/cosmos3_train.py
@@ -107,8 +107,15 @@ _CONTROL_KEYS = frozenset(
         "wan_vae_path",
         "filter_dir",
         "dataset_path",
+        "dataset_env",
     }
 )
+
+# Which env var carries the dataset path into the recipe TOML's ``${oc.env:...}``
+# interpolation — RECIPE-SPECIFIC (verified on cosmos-framework): the DROID recipe
+# reads ``DATASET_PATH``; the LIBERO recipe reads ``LIBERO_ROOT`` (via
+# LIBEROLeRobotDataset). Override per mission with ``config: {dataset_env: ...}``.
+_DEFAULT_DATASET_ENV = "DATASET_PATH"
 
 
 # cosmos-framework's train loop logs an imaginaire-style tqdm bar plus periodic
@@ -261,22 +268,29 @@ def build_cosmos3_export_argv(
 
 
 def _dataset_env(task: TrainingTask) -> dict[str, str]:
-    """Env overlay so cosmos-framework's LeRobot loader finds the dataset.
+    """Env overlay so cosmos-framework's dataset loader finds the local dataset.
 
-    Maps a LOCAL absolute ``dataset.ref`` to ``DATASET_PATH``. FOOTGUN: point at
-    the PARENT of the ``success/`` folder (not ``success/`` itself), and keep the
-    vendor DIR NAME (e.g. ``droid_plus_lerobot_640x360_20260412``) — the loader
-    infers its schema from that name. An explicit ``config['dataset_path']``
-    wins; HF/hub refs are left for the recipe TOML to resolve.
+    The env VAR NAME is recipe-specific (``config['dataset_env']``, default
+    ``DATASET_PATH``): the DROID recipe reads ``DATASET_PATH``, the LIBERO recipe
+    reads ``LIBERO_ROOT``. The VALUE is a LOCAL absolute path — explicit
+    ``config['dataset_path']`` wins, else ``dataset.ref``.
+
+    FOOTGUN (DROID): point at the PARENT of the ``success/`` folder (not
+    ``success/`` itself), keeping the vendor DIR NAME (e.g.
+    ``droid_plus_lerobot_640x360_20260412``) — the loader infers its schema from
+    that name. FOOTGUN (LIBERO): ``LIBERO_ROOT`` is the suite dir holding
+    ``meta/info.json`` (e.g. ``<dir>/libero_10``). HF/hub refs are left for the
+    recipe TOML to resolve.
     """
     config = task.config or {}
+    env_name = str(config.get("dataset_env") or _DEFAULT_DATASET_ENV)
     if config.get("dataset_path"):
-        return {"DATASET_PATH": str(config["dataset_path"])}
+        return {env_name: str(config["dataset_path"])}
     if task.dataset is None:
         return {}
     ref = task.dataset.ref
     if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
-        return {"DATASET_PATH": os.path.normpath(ref)}
+        return {env_name: os.path.normpath(ref)}
     return {}
 
 

--- a/src/odyssey/runners/models/cosmos3_train.py
+++ b/src/odyssey/runners/models/cosmos3_train.py
@@ -12,8 +12,10 @@ Why this looks different from the GR00T / OpenVLA runners
 Like π0.5, Cosmos is **config-name-driven**: training is selected by a
 registered SFT recipe TOML (e.g. ``action_policy_libero_nano``,
 ``action_policy_droid_nano``) that bundles the data pipeline, weight loader and
-optimizer. Individual fields are tweaked by dotted CLI overrides parsed by
-OmegaConf/tyro (``trainer.max_iter`` → ``--trainer.max-iter``). Paths inside the
+optimizer. Individual fields are tweaked by trailing Hydra-style dotlist
+positionals applied after the TOML (``trainer.max_iter=10`` — NOT
+``--trainer.max-iter``; cosmos ``train.py`` reads them via argparse REMAINDER).
+Paths inside the
 TOML use OmegaConf env interpolation (``${oc.env:BASE_CHECKPOINT_PATH}`` …), so
 the runner steers data / checkpoint / output locations through **environment
 variables**, not flags — matching Odyssey's "no hardcoded env in runners; the
@@ -194,12 +196,15 @@ def _resolve_cosmos_recipe(config_name: str) -> str:
     return recipe
 
 
-def _tyro_overrides(config: dict[str, Any]) -> list[str]:
-    """Flatten ``config`` into dotted CLI overrides, skipping control keys.
+def _dotlist_overrides(config: dict[str, Any]) -> list[str]:
+    """Flatten ``config`` into Hydra-style ``key.path=value`` positionals.
 
-    Nested dicts become dotted flags (``trainer.max_iter`` →
-    ``--trainer.max-iter``); booleans become toggle flags (``--flag`` /
-    ``--no-flag``) rather than ``--flag True``, matching tyro/OmegaConf.
+    cosmos-framework's ``train.py`` consumes overrides as trailing
+    ``key.path=value`` positionals (argparse ``REMAINDER``, applied AFTER the
+    TOML via OmegaConf) — NOT ``--flag value``. So a nested ``trainer.max_iter``
+    becomes the positional ``trainer.max_iter=10`` and a bool becomes
+    ``key=true`` / ``key=false`` (OmegaConf parses those to real bools). Control
+    keys (consumed by the runner) are skipped.
     """
     argv: list[str] = []
     for key, value in _flatten_config(config):
@@ -207,11 +212,10 @@ def _tyro_overrides(config: dict[str, Any]) -> list[str]:
         # key (nested overrides like trainer.max_iter are always forwarded).
         if "." not in key and key in _CONTROL_KEYS:
             continue
-        flag = f"--{key.replace('_', '-')}"
         if isinstance(value, bool):
-            argv.append(flag if value else f"--no-{key.replace('_', '-')}")
+            argv.append(f"{key}={'true' if value else 'false'}")
         else:
-            argv += [flag, str(value)]
+            argv.append(f"{key}={value}")
     return argv
 
 
@@ -237,8 +241,10 @@ def build_cosmos3_dcp_argv(
 def build_cosmos3_train_argv(*, task: TrainingTask) -> list[str]:
     """Build the ``cosmos_framework.scripts.train`` argv (step 2).
 
-    Shape: ``--sft-toml=<recipe> [dotted overrides]``. ``config_name`` is
-    REQUIRED — it names the registered SFT recipe TOML.
+    Shape: ``--sft-toml=<recipe> [key.path=value ...]``. ``config_name`` is
+    REQUIRED — it names the registered SFT recipe TOML. Non-control ``config``
+    keys become trailing Hydra-style dotlist positionals (applied AFTER the
+    TOML), matching cosmos-framework's ``train.py`` REMAINDER override contract.
     """
     config = task.config or {}
     config_name = config.get("config_name")
@@ -250,7 +256,7 @@ def build_cosmos3_train_argv(*, task: TrainingTask) -> list[str]:
             "dataset/embodiment."
         )
     recipe = _resolve_cosmos_recipe(str(config_name))
-    return [f"--sft-toml={recipe}", *_tyro_overrides(config)]
+    return [f"--sft-toml={recipe}", *_dotlist_overrides(config)]
 
 
 def build_cosmos3_export_argv(

--- a/src/odyssey/runners/models/cosmos3_train.py
+++ b/src/odyssey/runners/models/cosmos3_train.py
@@ -1,0 +1,500 @@
+"""Cosmos 3 (WAM) SFT training runner.
+
+Fine-tunes an NVIDIA Cosmos 3 action policy by shelling out to the upstream
+**cosmos-framework** training entry points — the ``cosmos_framework`` package
+must be installed and its repo checked out on disk (clone of
+https://github.com/NVIDIA/cosmos-framework), pointed at via
+``$COSMOS_FRAMEWORK_REPO_PATH`` (default ``/srv/cosmos-framework``). The
+framework's SFT recipe TOMLs live under ``examples/toml/sft_config/`` there.
+
+Why this looks different from the GR00T / OpenVLA runners
+--------------------------------------------------------
+Like π0.5, Cosmos is **config-name-driven**: training is selected by a
+registered SFT recipe TOML (e.g. ``action_policy_libero_nano``,
+``action_policy_droid_nano``) that bundles the data pipeline, weight loader and
+optimizer. Individual fields are tweaked by dotted CLI overrides parsed by
+OmegaConf/tyro (``trainer.max_iter`` → ``--trainer.max-iter``). Paths inside the
+TOML use OmegaConf env interpolation (``${oc.env:BASE_CHECKPOINT_PATH}`` …), so
+the runner steers data / checkpoint / output locations through **environment
+variables**, not flags — matching Odyssey's "no hardcoded env in runners; the
+runner only bridges the resolved refs" convention.
+
+Three subprocesses, in order (cosmos-framework needs a DCP base checkpoint
+before training, and an exported checkpoint after):
+
+  1. ``python -m cosmos_framework.scripts.convert_model_to_dcp
+     --checkpoint-path <base> -o $BASE_CHECKPOINT_PATH`` — converts the chosen
+     base model (Cosmos3-Nano / Cosmos3-Edge) into a distributed-checkpoint dir.
+     Skipped when ``$BASE_CHECKPOINT_PATH`` already exists or
+     ``config: {convert_dcp: false}``.
+  2. ``torchrun --nproc_per_node=<N> -m cosmos_framework.scripts.train
+     --sft-toml=<recipe.toml> [dotted overrides]`` — the SFT run itself. Writes
+     into ``$IMAGINAIRE_OUTPUT_ROOT`` (pointed at the task output dir).
+  3. ``python -m cosmos_framework.scripts.export_model
+     --checkpoint-path <trained-dcp> --config-file <run>/config.yaml
+     -o <run>/model`` — exports HF safetensors that the ``pilot: cosmos3``
+     policy server (``action_policy_server_libero``) loads directly. Skipped via
+     ``config: {export: false}``.
+
+Venv note (option A): cosmos-framework usually lives in its OWN heavy venv.
+``run_training_subprocess`` launches via ``sys.executable``, so run ``odyssey``
+*from inside* that venv (the UR10e remote-venv pattern) — then every subprocess,
+torchrun workers included, inherits the correct interpreter with zero core
+changes.
+
+Dataset: **LeRobot v3.0**, consumed natively by cosmos-framework's loader — no
+Odyssey-side conversion. ``$DATASET_PATH`` must point at the PARENT of the
+``success/`` folder, and the loader infers the schema from the dataset DIR NAME
+(e.g. ``droid_plus_lerobot_640x360_20260412``), so keep the vendor naming.
+
+Routing: registered behind OpenVLA's wildcard training slot, reached via the
+task-level ``config: {runner: cosmos3}`` override — same mechanism as ``gr00t``
+and ``pi05``.
+
+Licensing note: Cosmos 3 weights are distributed under NVIDIA's terms. This
+runner contains no cosmos-framework code — it shells out to the user's own
+checkout.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from odyssey.runners.base import (
+    WILDCARD_TYPE,
+    Runner,
+    TaskContext,
+)
+
+# Shared flatten helper (dotted keys for nested dicts).
+from odyssey.runners.models.openvla import _flatten_config
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    output_path,
+    run_training_subprocess,
+)
+from odyssey.spec.refs import DatasetSource, HFModelRef
+from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_REPO_PATH = "/srv/cosmos-framework"
+_RECIPE_REL = "examples/toml/sft_config"
+
+_DCP_MODULE = "cosmos_framework.scripts.convert_model_to_dcp"
+_TRAIN_MODULE = "cosmos_framework.scripts.train"
+_EXPORT_MODULE = "cosmos_framework.scripts.export_model"
+
+_DEFAULT_NPROC = 8
+_DEFAULT_BASE_MODEL = "Cosmos3-Nano"
+
+# Config keys the runner consumes directly — never forwarded as tyro overrides
+# on the train step.
+_CONTROL_KEYS = frozenset(
+    {
+        "config_name",
+        "runner",
+        "base_model",
+        "convert_dcp",
+        "export",
+        "nproc_per_node",
+        "base_checkpoint_path",
+        "wan_vae_path",
+        "filter_dir",
+        "dataset_path",
+    }
+)
+
+
+# cosmos-framework's train loop logs an imaginaire-style tqdm bar plus periodic
+# metric dicts, e.g.:
+#   "iter=1000 loss=0.234 ..."
+#   " 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]"
+#   "Saving checkpoint to outputs/train/.../iter_000001000"
+#   "Loading LeRobot dataset ..."
+_COSMOS_LOSS_RE = re.compile(r"(?:'loss':|\bloss=)\s*([\d.eE+-]+)")
+_COSMOS_ITER_RE = re.compile(r"(?:'iter':|\biter=|\bStep\s+)\s*(\d+)", re.IGNORECASE)
+_COSMOS_TQDM_RE = re.compile(r"\b(\d+)/(\d+)\s*\[")
+_COSMOS_SAVE_RE = re.compile(r"(?i)\b(saving|saved|wrote)\b.*\bcheckpoint\b")
+_COSMOS_DCP_RE = re.compile(r"(?i)\b(convert\w*|writing|loading)\b.*\bdcp\b")
+_COSMOS_DATASET_RE = re.compile(r"(?i)\b(loading|building)\b.*\b(dataset|lerobot)\b")
+
+
+def parse_cosmos3_train_line(line: str) -> dict[str, Any] | None:
+    """Extract a progress-event dict from a cosmos-framework stdout line.
+
+    Public for tests and for users embedding cosmos stdout parsing in a custom
+    runner. Precedence mirrors the GR00T / π0.5 parsers: a metric line
+    (loss / iter) wins over the coarse phase markers.
+    """
+    loss_match = _COSMOS_LOSS_RE.search(line)
+    iter_match = _COSMOS_ITER_RE.search(line)
+    if loss_match or iter_match:
+        payload: dict[str, Any] = {"stage": "executing", "step": "training_step"}
+        if iter_match:
+            payload["step_index"] = int(iter_match.group(1))
+        if loss_match:
+            payload["step_label"] = f"loss={loss_match.group(1)}"
+        return payload
+    tqdm_match = _COSMOS_TQDM_RE.search(line)
+    if tqdm_match:
+        return {
+            "stage": "executing",
+            "step": "training_step",
+            "step_index": int(tqdm_match.group(1)),
+            "step_total": int(tqdm_match.group(2)),
+        }
+    if _COSMOS_SAVE_RE.search(line):
+        return {"stage": "checkpoint_saving"}
+    if _COSMOS_DCP_RE.search(line):
+        return {"stage": "dataset_loading", "step": "convert_dcp"}
+    if _COSMOS_DATASET_RE.search(line):
+        return {"stage": "dataset_loading"}
+    return None
+
+
+def _resolve_repo_path() -> str:
+    """The cosmos-framework checkout root (``$COSMOS_FRAMEWORK_REPO_PATH``)."""
+    return os.getenv("COSMOS_FRAMEWORK_REPO_PATH", _DEFAULT_REPO_PATH)
+
+
+def _resolve_cosmos_recipe(config_name: str) -> str:
+    """Absolute path to an SFT recipe TOML under ``$COSMOS_FRAMEWORK_REPO_PATH``.
+
+    Accepts either a bare recipe name (``action_policy_libero_nano``) resolved
+    against ``examples/toml/sft_config/`` or an already-absolute ``.toml`` path.
+    Raises a runner-actionable error (not a bare FileNotFoundError) when the
+    checkout / recipe is missing, matching the OpenVLA / π0.5 runner contract.
+    """
+    if os.path.isabs(config_name):
+        recipe = config_name
+    else:
+        name = config_name if config_name.endswith(".toml") else f"{config_name}.toml"
+        recipe = os.path.join(_resolve_repo_path(), _RECIPE_REL, name)
+    if not os.path.isfile(recipe):
+        raise RuntimeError(
+            f"cosmos-framework SFT recipe not found at {recipe!r}; clone "
+            "https://github.com/NVIDIA/cosmos-framework and set "
+            "COSMOS_FRAMEWORK_REPO_PATH (or place it at /srv/cosmos-framework), "
+            "then set config['config_name'] to a recipe under "
+            "examples/toml/sft_config/ (e.g. 'action_policy_libero_nano')."
+        )
+    return recipe
+
+
+def _tyro_overrides(config: dict[str, Any]) -> list[str]:
+    """Flatten ``config`` into dotted CLI overrides, skipping control keys.
+
+    Nested dicts become dotted flags (``trainer.max_iter`` →
+    ``--trainer.max-iter``); booleans become toggle flags (``--flag`` /
+    ``--no-flag``) rather than ``--flag True``, matching tyro/OmegaConf.
+    """
+    argv: list[str] = []
+    for key, value in _flatten_config(config):
+        # _flatten_config yields the dotted path; only the LEAF may be a control
+        # key (nested overrides like trainer.max_iter are always forwarded).
+        if "." not in key and key in _CONTROL_KEYS:
+            continue
+        flag = f"--{key.replace('_', '-')}"
+        if isinstance(value, bool):
+            argv.append(flag if value else f"--no-{key.replace('_', '-')}")
+        else:
+            argv += [flag, str(value)]
+    return argv
+
+
+def _resolve_base_model(task: TrainingTask, agent_model_base: str | None) -> str:
+    """The base model handed to ``convert_model_to_dcp``.
+
+    Precedence: explicit ``config['base_model']`` → the agent's HF model base →
+    the ``Cosmos3-Nano`` default. cosmos-framework resolves a bare id like
+    ``Cosmos3-Nano`` against its own checkpoint cache.
+    """
+    config = task.config or {}
+    base = config.get("base_model") or agent_model_base or _DEFAULT_BASE_MODEL
+    return str(base)
+
+
+def build_cosmos3_dcp_argv(
+    *, base_model: str, base_checkpoint_path: str
+) -> list[str]:
+    """Build the ``convert_model_to_dcp`` argv (step 1)."""
+    return ["--checkpoint-path", base_model, "-o", base_checkpoint_path]
+
+
+def build_cosmos3_train_argv(*, task: TrainingTask) -> list[str]:
+    """Build the ``cosmos_framework.scripts.train`` argv (step 2).
+
+    Shape: ``--sft-toml=<recipe> [dotted overrides]``. ``config_name`` is
+    REQUIRED — it names the registered SFT recipe TOML.
+    """
+    config = task.config or {}
+    config_name = config.get("config_name")
+    if not config_name:
+        raise RuntimeError(
+            "Cosmos 3 runner: config['config_name'] is required — it names the "
+            "cosmos-framework SFT recipe TOML under examples/toml/sft_config/ "
+            "(e.g. 'action_policy_libero_nano'). Add a recipe there for a custom "
+            "dataset/embodiment."
+        )
+    recipe = _resolve_cosmos_recipe(str(config_name))
+    return [f"--sft-toml={recipe}", *_tyro_overrides(config)]
+
+
+def build_cosmos3_export_argv(
+    *, checkpoint_path: str, config_file: str, out_dir: str
+) -> list[str]:
+    """Build the ``export_model`` argv (step 3)."""
+    return [
+        "--checkpoint-path",
+        checkpoint_path,
+        "--config-file",
+        config_file,
+        "-o",
+        out_dir,
+    ]
+
+
+def _dataset_env(task: TrainingTask) -> dict[str, str]:
+    """Env overlay so cosmos-framework's LeRobot loader finds the dataset.
+
+    Maps a LOCAL absolute ``dataset.ref`` to ``DATASET_PATH``. FOOTGUN: point at
+    the PARENT of the ``success/`` folder (not ``success/`` itself), and keep the
+    vendor DIR NAME (e.g. ``droid_plus_lerobot_640x360_20260412``) — the loader
+    infers its schema from that name. An explicit ``config['dataset_path']``
+    wins; HF/hub refs are left for the recipe TOML to resolve.
+    """
+    config = task.config or {}
+    if config.get("dataset_path"):
+        return {"DATASET_PATH": str(config["dataset_path"])}
+    if task.dataset is None:
+        return {}
+    ref = task.dataset.ref
+    if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
+        return {"DATASET_PATH": os.path.normpath(ref)}
+    return {}
+
+
+def _path_env(task: TrainingTask, output_dir: Path, base_ckpt_dcp: str) -> dict[str, str]:
+    """Bridge the resolved paths into the env the recipe TOML interpolates.
+
+    Only sets what the runner resolves; anything omitted falls through from the
+    user's shell (``WAN_VAE_PATH``, ``HF_TOKEN`` are the operator's to provide).
+    """
+    config = task.config or {}
+    env: dict[str, str] = {
+        "BASE_CHECKPOINT_PATH": base_ckpt_dcp,
+        "IMAGINAIRE_OUTPUT_ROOT": str(output_dir),
+        "NPROC_PER_NODE": str(config.get("nproc_per_node", _DEFAULT_NPROC)),
+    }
+    if config.get("wan_vae_path"):
+        env["WAN_VAE_PATH"] = str(config["wan_vae_path"])
+    if config.get("filter_dir"):
+        env["FILTER_DIR"] = str(config["filter_dir"])
+    return env
+
+
+def _resolve_run_dir(output_dir: Path) -> Path | None:
+    """The cosmos-framework run dir under ``$IMAGINAIRE_OUTPUT_ROOT`` holding
+    ``config.yaml``.
+
+    cosmos-framework writes ``<output_root>/<experiment>/config.yaml`` alongside
+    a ``checkpoints/`` subtree. Return the run dir whose ``config.yaml`` is
+    newest; None if training wrote nothing. Heuristic (pinned by unit tests,
+    verified at GPU smoke) — the exact layout is the vendor's.
+    """
+    candidates = sorted(
+        output_dir.rglob("config.yaml"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0].parent if candidates else None
+
+
+def _resolve_trained_checkpoint(run_dir: Path) -> Path | None:
+    """Locate the latest trained DCP checkpoint under a run dir.
+
+    cosmos-framework saves ``.../checkpoints/iter_<NNN>`` (imaginaire style);
+    return the highest-numbered one, or the run dir's ``checkpoints`` root if no
+    numbered dir is present. None when nothing was written.
+    """
+    ckpt_root = run_dir / "checkpoints"
+    if not ckpt_root.is_dir():
+        return None
+    best: tuple[int, Path] | None = None
+    for entry in ckpt_root.iterdir():
+        if not entry.is_dir():
+            continue
+        digits = re.findall(r"\d+", entry.name)
+        if digits:
+            step = int(digits[-1])
+            if best is None or step > best[0]:
+                best = (step, entry)
+    if best is not None:
+        return best[1]
+    return ckpt_root
+
+
+class Cosmos3Runner(Runner):
+    """Fine-tune a Cosmos 3 action policy. Subprocess-based — actual training
+    happens in cosmos-framework's ``convert_model_to_dcp`` → ``train`` →
+    ``export_model`` scripts."""
+
+    @property
+    def name(self) -> str:
+        return "cosmos3"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING}
+
+    @property
+    def supported_types(self) -> set[str]:
+        # Registered behind OpenVLA's wildcard; reached via the task-level
+        # ``config: {runner: cosmos3}`` override (same pattern as GR00T / π0.5).
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, TrainingTask):
+            raise TypeError(
+                f"Cosmos3Runner expects TrainingTask, got {type(spec).__name__}"
+            )
+        if context.agent is None:
+            raise RuntimeError(
+                "Cosmos3Runner: TaskContext.agent is None — training tasks must "
+                "be invoked through the engine, which resolves the agent from "
+                "spec.robot.agents[task.agent_id]."
+            )
+
+        output_dir = output_path(context)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        config = dict(spec.config)
+        exp_name = str(config.get("exp_name") or spec.name)
+        timeout = getattr(spec, "timeout_seconds", None)
+        repo_path = _resolve_repo_path()
+
+        agent_model_base = (
+            context.agent.model.base
+            if isinstance(context.agent.model, HFModelRef)
+            else None
+        )
+        base_model = _resolve_base_model(spec, agent_model_base)
+
+        # BASE_CHECKPOINT_PATH: explicit config wins, else a per-run DCP dir.
+        base_ckpt_dcp = str(
+            config.get("base_checkpoint_path") or output_dir / "base_checkpoint_dcp"
+        )
+
+        child_env = {
+            **_dataset_env(spec),
+            **_path_env(spec, output_dir, base_ckpt_dcp),
+        }
+
+        # Step 1: convert base model → DCP (cosmos needs it before training).
+        # Skip when a prior run already produced it, or explicitly disabled.
+        if config.get("convert_dcp", True) and not os.path.isdir(base_ckpt_dcp):
+            await context.emit_progress(
+                "dataset_loading", step="convert_dcp", step_label=base_model
+            )
+            dcp_spec = TrainingProcessSpec(
+                timeout_seconds=timeout,
+                entry_module=_DCP_MODULE,
+                argv_extra=build_cosmos3_dcp_argv(
+                    base_model=base_model, base_checkpoint_path=base_ckpt_dcp
+                ),
+                env=child_env,
+                cwd=repo_path,
+                line_parser=parse_cosmos3_train_line,
+            )
+            rc = await run_training_subprocess(context, dcp_spec)
+            if context.cancelled():
+                logger.info("Cosmos 3 task %s cancelled during DCP convert", context.task.id)
+                return {"cancelled": True}
+            if rc != 0:
+                raise RuntimeError(f"cosmos-framework convert_model_to_dcp exited with code {rc}")
+        elif os.path.isdir(base_ckpt_dcp):
+            logger.info(
+                "Cosmos 3 task %s: reusing existing DCP base checkpoint at %s",
+                context.task.id,
+                base_ckpt_dcp,
+            )
+
+        # Step 2: SFT fine-tune (torchrun).
+        train_spec = TrainingProcessSpec(
+            timeout_seconds=timeout,
+            entry_module=_TRAIN_MODULE,
+            argv_extra=build_cosmos3_train_argv(task=spec),
+            env=child_env,
+            cwd=repo_path,
+            line_parser=parse_cosmos3_train_line,
+            use_torchrun=True,
+            torchrun_nproc=int(config.get("nproc_per_node", _DEFAULT_NPROC)),
+        )
+        rc = await run_training_subprocess(context, train_spec)
+        if context.cancelled():
+            logger.info("Cosmos 3 task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"cosmos-framework train exited with code {rc}")
+
+        run_dir = _resolve_run_dir(output_dir)
+        if run_dir is None:
+            raise RuntimeError(
+                f"cosmos-framework train finished but no run dir (config.yaml) "
+                f"found under {output_dir!r}"
+            )
+        trained_ckpt = _resolve_trained_checkpoint(run_dir)
+        if trained_ckpt is None:
+            raise RuntimeError(
+                f"cosmos-framework train finished but no checkpoint found under "
+                f"{run_dir / 'checkpoints'!r}"
+            )
+
+        # Step 3: export DCP → HF safetensors the policy server loads directly.
+        export_dir = str(run_dir / "model")
+        if config.get("export", True):
+            await context.emit_progress(
+                "checkpoint_saving", step="export_model", step_label=exp_name
+            )
+            export_spec = TrainingProcessSpec(
+                timeout_seconds=timeout,
+                entry_module=_EXPORT_MODULE,
+                argv_extra=build_cosmos3_export_argv(
+                    checkpoint_path=str(trained_ckpt),
+                    config_file=str(run_dir / "config.yaml"),
+                    out_dir=export_dir,
+                ),
+                env=child_env,
+                cwd=repo_path,
+                line_parser=parse_cosmos3_train_line,
+            )
+            rc = await run_training_subprocess(context, export_spec)
+            if context.cancelled():
+                logger.info("Cosmos 3 task %s cancelled during export", context.task.id)
+                return {"cancelled": True}
+            if rc != 0:
+                raise RuntimeError(f"cosmos-framework export_model exited with code {rc}")
+            checkpoint_path = export_dir
+        else:
+            # No export requested — hand back the trained DCP dir instead.
+            checkpoint_path = str(trained_ckpt)
+
+        return {
+            "checkpoint_path": checkpoint_path,
+            "agent_id": context.agent.id,
+            "exp_name": exp_name,
+            "config_name": config.get("config_name"),
+            "base_model": base_model,
+            "training_config": spec.config,
+            "training_type": (
+                spec.training_type.value
+                if isinstance(spec.training_type, TrainingType)
+                else spec.training_type
+            ),
+        }

--- a/tests/unit/test_cosmos3_train.py
+++ b/tests/unit/test_cosmos3_train.py
@@ -115,7 +115,7 @@ def test_train_argv_sft_toml_first(
     assert argv[0].endswith("action_policy_libero_nano.toml")
 
 
-def test_train_argv_passthrough_is_kebab_case(
+def test_train_argv_passthrough_is_hydra_dotlist(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _repo_with_recipe(tmp_path)
@@ -127,29 +127,31 @@ def test_train_argv_passthrough_is_kebab_case(
         }
     )
     argv = build_cosmos3_train_argv(task=task)
-    idx = argv.index("--trainer.max-iter")
-    assert argv[idx + 1] == "10"
+    # cosmos train.py takes trailing `key.path=value` positionals, not --flags.
+    assert "trainer.max_iter=10" in argv
+    assert "--trainer.max-iter" not in argv
 
 
-def test_train_argv_bool_true_is_bare_flag(
+def test_train_argv_bool_true_is_key_true(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _repo_with_recipe(tmp_path)
     monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
     task = _task(config={"config_name": "action_policy_libero_nano", "wandb": True})
     argv = build_cosmos3_train_argv(task=task)
-    assert "--wandb" in argv
-    assert "True" not in argv
+    assert "wandb=true" in argv
+    assert "--wandb" not in argv
 
 
-def test_train_argv_bool_false_is_no_flag(
+def test_train_argv_bool_false_is_key_false(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     repo = _repo_with_recipe(tmp_path)
     monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
     task = _task(config={"config_name": "action_policy_libero_nano", "wandb": False})
     argv = build_cosmos3_train_argv(task=task)
-    assert "--no-wandb" in argv
+    assert "wandb=false" in argv
+    assert "--no-wandb" not in argv
 
 
 def test_train_argv_excludes_control_keys(
@@ -171,20 +173,23 @@ def test_train_argv_excludes_control_keys(
         }
     )
     argv = build_cosmos3_train_argv(task=task)
+    # Control keys are consumed by the runner — never forwarded as dotlist
+    # positionals (nor as the old --flag form).
+    joined = " ".join(argv)
     for control in (
-        "--runner",
-        "--base-model",
-        "--convert-dcp",
-        "--no-convert-dcp",
-        "--export",
-        "--no-export",
-        "--nproc-per-node",
-        "--wan-vae-path",
-        "--filter-dir",
-        "--dataset-path",
-        "--config-name",
+        "runner=",
+        "base_model=",
+        "convert_dcp=",
+        "export=",
+        "nproc_per_node=",
+        "wan_vae_path=",
+        "filter_dir=",
+        "dataset_path=",
+        "config_name=",
     ):
-        assert control not in argv
+        assert control not in joined
+    for old_flag in ("--runner", "--base-model", "--config-name", "--no-convert-dcp"):
+        assert old_flag not in argv
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cosmos3_train.py
+++ b/tests/unit/test_cosmos3_train.py
@@ -1,0 +1,405 @@
+"""Tests for the Cosmos 3 (cosmos-framework) SFT training runner's argv builders,
+recipe resolution, env overlays, checkpoint resolution and stdout parser.
+
+We don't invoke the real ``cosmos_framework.scripts.*`` entry points — those need
+the cosmos-framework package, torch with CUDA, multi-GPU and a registered SFT
+recipe TOML. The testable pieces are the pure functions that shape the three
+subprocess argvs from a ``TrainingTask`` spec, the dataset/path env overlays, the
+run-dir + checkpoint locators, and the parser that turns cosmos stdout into
+progress events.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from odyssey.runners import Cosmos3Runner, RunnerRegistry
+from odyssey.runners.models.cosmos3_train import (
+    _dataset_env,
+    _path_env,
+    _resolve_base_model,
+    _resolve_cosmos_recipe,
+    _resolve_run_dir,
+    _resolve_trained_checkpoint,
+    build_cosmos3_dcp_argv,
+    build_cosmos3_export_argv,
+    build_cosmos3_train_argv,
+    parse_cosmos3_train_line,
+)
+from odyssey.spec import DatasetRef, DatasetSource, TrainingTask, TrainingType
+
+
+def _task(**overrides: Any) -> TrainingTask:
+    fields: dict[str, Any] = {
+        "name": "finetune-cosmos3",
+        "training_type": TrainingType.DEMONSTRATION,
+        "agent_id": "pilot",
+    }
+    fields.update(overrides)
+    return TrainingTask(**fields)
+
+
+def _repo_with_recipe(tmp_path: Path, name: str = "action_policy_libero_nano") -> Path:
+    """Materialize a fake cosmos-framework checkout holding one recipe TOML."""
+    recipe_dir = tmp_path / "examples" / "toml" / "sft_config"
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / f"{name}.toml").write_text("# recipe\n")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# recipe resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_recipe_against_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    resolved = _resolve_cosmos_recipe("action_policy_libero_nano")
+    assert resolved == str(
+        repo / "examples" / "toml" / "sft_config" / "action_policy_libero_nano.toml"
+    )
+
+
+def test_resolve_recipe_accepts_toml_suffix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    # Passing the name already suffixed must not double the extension.
+    resolved = _resolve_cosmos_recipe("action_policy_libero_nano.toml")
+    assert resolved.endswith("action_policy_libero_nano.toml")
+    assert not resolved.endswith(".toml.toml")
+
+
+def test_resolve_recipe_accepts_absolute_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recipe = tmp_path / "custom.toml"
+    recipe.write_text("# recipe\n")
+    # An absolute path bypasses the repo-relative lookup entirely.
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", "/nonexistent")
+    assert _resolve_cosmos_recipe(str(recipe)) == str(recipe)
+
+
+def test_resolve_recipe_missing_raises_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(tmp_path))
+    with pytest.raises(RuntimeError, match="COSMOS_FRAMEWORK_REPO_PATH"):
+        _resolve_cosmos_recipe("action_policy_libero_nano")
+
+
+# ---------------------------------------------------------------------------
+# train argv builder
+# ---------------------------------------------------------------------------
+
+def test_train_argv_requires_config_name() -> None:
+    with pytest.raises(RuntimeError, match="config_name"):
+        build_cosmos3_train_argv(task=_task())
+
+
+def test_train_argv_sft_toml_first(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    task = _task(config={"config_name": "action_policy_libero_nano"})
+    argv = build_cosmos3_train_argv(task=task)
+    assert argv[0].startswith("--sft-toml=")
+    assert argv[0].endswith("action_policy_libero_nano.toml")
+
+
+def test_train_argv_passthrough_is_kebab_case(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    task = _task(
+        config={
+            "config_name": "action_policy_libero_nano",
+            "trainer": {"max_iter": 10},
+        }
+    )
+    argv = build_cosmos3_train_argv(task=task)
+    idx = argv.index("--trainer.max-iter")
+    assert argv[idx + 1] == "10"
+
+
+def test_train_argv_bool_true_is_bare_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    task = _task(config={"config_name": "action_policy_libero_nano", "wandb": True})
+    argv = build_cosmos3_train_argv(task=task)
+    assert "--wandb" in argv
+    assert "True" not in argv
+
+
+def test_train_argv_bool_false_is_no_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    task = _task(config={"config_name": "action_policy_libero_nano", "wandb": False})
+    argv = build_cosmos3_train_argv(task=task)
+    assert "--no-wandb" in argv
+
+
+def test_train_argv_excludes_control_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _repo_with_recipe(tmp_path)
+    monkeypatch.setenv("COSMOS_FRAMEWORK_REPO_PATH", str(repo))
+    task = _task(
+        config={
+            "config_name": "action_policy_libero_nano",
+            "runner": "cosmos3",
+            "base_model": "Cosmos3-Nano",
+            "convert_dcp": False,
+            "export": False,
+            "nproc_per_node": 8,
+            "wan_vae_path": "/x/vae.pth",
+            "filter_dir": "/x/filters",
+            "dataset_path": "/x/data",
+        }
+    )
+    argv = build_cosmos3_train_argv(task=task)
+    for control in (
+        "--runner",
+        "--base-model",
+        "--convert-dcp",
+        "--no-convert-dcp",
+        "--export",
+        "--no-export",
+        "--nproc-per-node",
+        "--wan-vae-path",
+        "--filter-dir",
+        "--dataset-path",
+        "--config-name",
+    ):
+        assert control not in argv
+
+
+# ---------------------------------------------------------------------------
+# dcp + export argv builders
+# ---------------------------------------------------------------------------
+
+def test_dcp_argv_shape() -> None:
+    argv = build_cosmos3_dcp_argv(
+        base_model="Cosmos3-Nano", base_checkpoint_path="/out/dcp"
+    )
+    assert argv == ["--checkpoint-path", "Cosmos3-Nano", "-o", "/out/dcp"]
+
+
+def test_export_argv_shape() -> None:
+    argv = build_cosmos3_export_argv(
+        checkpoint_path="/run/checkpoints/iter_1000",
+        config_file="/run/config.yaml",
+        out_dir="/run/model",
+    )
+    assert argv == [
+        "--checkpoint-path",
+        "/run/checkpoints/iter_1000",
+        "--config-file",
+        "/run/config.yaml",
+        "-o",
+        "/run/model",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# base model resolution
+# ---------------------------------------------------------------------------
+
+def test_base_model_config_wins() -> None:
+    task = _task(config={"config_name": "c", "base_model": "Cosmos3-Edge"})
+    assert _resolve_base_model(task, "Cosmos3-Nano") == "Cosmos3-Edge"
+
+
+def test_base_model_falls_back_to_agent_base() -> None:
+    task = _task(config={"config_name": "c"})
+    assert _resolve_base_model(task, "nvidia/Cosmos3-Nano") == "nvidia/Cosmos3-Nano"
+
+
+def test_base_model_defaults_when_unknown() -> None:
+    assert _resolve_base_model(_task(config={"config_name": "c"}), None) == "Cosmos3-Nano"
+
+
+# ---------------------------------------------------------------------------
+# dataset env overlay (the LeRobot footgun)
+# ---------------------------------------------------------------------------
+
+def test_dataset_env_maps_absolute_local_verbatim() -> None:
+    # DATASET_PATH points at the PARENT of success/ — i.e. the named dataset dir
+    # itself, NOT success/. The loader infers schema from this dir NAME, so it is
+    # passed through unchanged (contrast pi05, which strips to the parent).
+    task = _task(
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL,
+            ref="/data/droid_plus_lerobot_640x360_20260412",
+        )
+    )
+    env = _dataset_env(task)
+    assert env["DATASET_PATH"] == "/data/droid_plus_lerobot_640x360_20260412"
+
+
+def test_dataset_env_explicit_config_wins() -> None:
+    task = _task(
+        config={"config_name": "c", "dataset_path": "/override/data"},
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/ignored"),
+    )
+    assert _dataset_env(task)["DATASET_PATH"] == "/override/data"
+
+
+def test_dataset_env_empty_for_hf_ref() -> None:
+    task = _task(dataset=DatasetRef(source=DatasetSource.HUGGINGFACE, ref="nvidia/Cosmos3-DROID"))
+    assert _dataset_env(task) == {}
+
+
+def test_dataset_env_empty_when_no_dataset() -> None:
+    assert _dataset_env(_task()) == {}
+
+
+# ---------------------------------------------------------------------------
+# path env bridging
+# ---------------------------------------------------------------------------
+
+def test_path_env_sets_required_and_output_root(tmp_path: Path) -> None:
+    env = _path_env(_task(config={"config_name": "c"}), tmp_path, "/out/dcp")
+    assert env["BASE_CHECKPOINT_PATH"] == "/out/dcp"
+    assert env["IMAGINAIRE_OUTPUT_ROOT"] == str(tmp_path)
+    assert env["NPROC_PER_NODE"] == "8"  # default
+
+
+def test_path_env_optional_paths_only_when_configured(tmp_path: Path) -> None:
+    # WAN_VAE_PATH / FILTER_DIR are the operator's to provide via shell unless the
+    # mission pins them — never emitted empty.
+    env = _path_env(_task(config={"config_name": "c"}), tmp_path, "/out/dcp")
+    assert "WAN_VAE_PATH" not in env
+    assert "FILTER_DIR" not in env
+
+    task = _task(
+        config={
+            "config_name": "c",
+            "nproc_per_node": 16,
+            "wan_vae_path": "/x/Wan2.2_VAE.pth",
+            "filter_dir": "/x/droid_filters",
+        }
+    )
+    env2 = _path_env(task, tmp_path, "/out/dcp")
+    assert env2["NPROC_PER_NODE"] == "16"
+    assert env2["WAN_VAE_PATH"] == "/x/Wan2.2_VAE.pth"
+    assert env2["FILTER_DIR"] == "/x/droid_filters"
+
+
+# ---------------------------------------------------------------------------
+# run-dir + trained-checkpoint resolution
+# ---------------------------------------------------------------------------
+
+def test_resolve_run_dir_picks_newest_config_yaml(tmp_path: Path) -> None:
+    old = tmp_path / "run_old"
+    new = tmp_path / "run_new"
+    old.mkdir()
+    new.mkdir()
+    (old / "config.yaml").write_text("a: 1\n")
+    (new / "config.yaml").write_text("a: 2\n")
+    # Make `new` unambiguously newer regardless of write ordering.
+    os.utime(old / "config.yaml", (1_000, 1_000))
+    os.utime(new / "config.yaml", (2_000, 2_000))
+    assert _resolve_run_dir(tmp_path) == new
+
+
+def test_resolve_run_dir_none_when_empty(tmp_path: Path) -> None:
+    assert _resolve_run_dir(tmp_path) is None
+
+
+def test_resolve_trained_checkpoint_picks_highest_iter(tmp_path: Path) -> None:
+    ckpt = tmp_path / "checkpoints"
+    for step in ("iter_000001000", "iter_000005000", "iter_000002000"):
+        (ckpt / step).mkdir(parents=True)
+    resolved = _resolve_trained_checkpoint(tmp_path)
+    assert resolved is not None
+    assert resolved.name == "iter_000005000"
+
+
+def test_resolve_trained_checkpoint_falls_back_to_root(tmp_path: Path) -> None:
+    # A checkpoints dir with no numbered subdir still resolves to the root, not None.
+    ckpt = tmp_path / "checkpoints"
+    ckpt.mkdir()
+    assert _resolve_trained_checkpoint(tmp_path) == ckpt
+
+
+def test_resolve_trained_checkpoint_none_when_missing(tmp_path: Path) -> None:
+    assert _resolve_trained_checkpoint(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# registry dispatch
+# ---------------------------------------------------------------------------
+
+def test_runner_selected_by_config_override() -> None:
+    registry = RunnerRegistry()
+    registry.register(Cosmos3Runner())
+    task = _task(config={"runner": "cosmos3", "config_name": "action_policy_libero_nano"})
+    # The engine forwards config['runner'] as the select override.
+    assert isinstance(registry.select(task, override="cosmos3"), Cosmos3Runner)
+
+
+def test_runner_name_and_kind() -> None:
+    runner = Cosmos3Runner()
+    assert runner.name == "cosmos3"
+    from odyssey.spec.tasks import TaskKind
+
+    assert runner.supported_kinds == {TaskKind.TRAINING}
+
+
+# ---------------------------------------------------------------------------
+# stdout parser
+# ---------------------------------------------------------------------------
+
+def test_parse_loss_and_iter_line() -> None:
+    event = parse_cosmos3_train_line("iter=1000 loss=0.234 grad_norm=1.2")
+    assert event is not None
+    assert event["stage"] == "executing"
+    assert event["step"] == "training_step"
+    assert event["step_index"] == 1000
+    assert "loss=0.234" in event["step_label"]
+
+
+def test_parse_tqdm_progress_line() -> None:
+    event = parse_cosmos3_train_line(" 10%|█  | 100/1000 [00:42<06:18,  2.38it/s]")
+    assert event is not None
+    assert event["step_index"] == 100
+    assert event["step_total"] == 1000
+
+
+def test_parse_checkpoint_save_line() -> None:
+    event = parse_cosmos3_train_line(
+        "Saving checkpoint to outputs/train/exp/checkpoints/iter_000001000"
+    )
+    assert event is not None
+    assert event["stage"] == "checkpoint_saving"
+
+
+def test_parse_dcp_line() -> None:
+    event = parse_cosmos3_train_line("Converting model to DCP format ...")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+    assert event["step"] == "convert_dcp"
+
+
+def test_parse_dataset_loading_line() -> None:
+    event = parse_cosmos3_train_line("Loading LeRobot dataset droid_plus_lerobot_640x360")
+    assert event is not None
+    assert event["stage"] == "dataset_loading"
+
+
+def test_parse_unrelated_line_returns_none() -> None:
+    assert parse_cosmos3_train_line("nothing interesting here") is None

--- a/tests/unit/test_cosmos3_train.py
+++ b/tests/unit/test_cosmos3_train.py
@@ -250,6 +250,28 @@ def test_dataset_env_maps_absolute_local_verbatim() -> None:
     assert env["DATASET_PATH"] == "/data/droid_plus_lerobot_640x360_20260412"
 
 
+def test_dataset_env_name_is_recipe_specific() -> None:
+    # LIBERO recipe reads LIBERO_ROOT, not DATASET_PATH (verified on
+    # cosmos-framework). dataset_env overrides the env VAR NAME; value unchanged.
+    task = _task(
+        config={"config_name": "action_policy_libero_10_nano", "dataset_env": "LIBERO_ROOT"},
+        dataset=DatasetRef(
+            source=DatasetSource.LOCAL, ref="/data/LIBERO_LeRobot_v3/libero_10"
+        ),
+    )
+    env = _dataset_env(task)
+    assert env == {"LIBERO_ROOT": "/data/LIBERO_LeRobot_v3/libero_10"}
+    assert "DATASET_PATH" not in env
+
+
+def test_dataset_env_defaults_to_dataset_path() -> None:
+    # No dataset_env -> DROID default DATASET_PATH.
+    task = _task(
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref="/data/droid_lerobot")
+    )
+    assert _dataset_env(task) == {"DATASET_PATH": "/data/droid_lerobot"}
+
+
 def test_dataset_env_explicit_config_wins() -> None:
     task = _task(
         config={"config_name": "c", "dataset_path": "/override/data"},

--- a/tests/unit/test_eval_openloop_gt_cosmos3.py
+++ b/tests/unit/test_eval_openloop_gt_cosmos3.py
@@ -1,0 +1,137 @@
+"""Unit tests for the pure metric/transform helpers of the Cosmos3 open-loop eval.
+
+The script lives beside its mission (examples/drugsort-cosmos3-train/) rather than
+on the package path, so it is loaded by file path. Only the numpy-only helpers are
+exercised here — the CLI's server/FK/dataset IO is integration-tested on the box.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "examples"
+    / "drugsort-cosmos3-train"
+    / "eval_openloop_gt_cosmos3.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("eval_openloop_gt_cosmos3", _SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+mod = _load_module()
+
+
+def test_rot6d_to_matrix_identity_is_orthonormal():
+    # rot6d for identity: first two columns of I3.
+    r = mod.rot6d_to_matrix([1, 0, 0, 0, 1, 0])
+    assert np.allclose(r, np.eye(3), atol=1e-6)
+    # columns orthonormal, det +1
+    assert np.allclose(r.T @ r, np.eye(3), atol=1e-6)
+    assert np.isclose(np.linalg.det(r), 1.0, atol=1e-6)
+
+
+def test_rot6d_to_matrix_gram_schmidt_orthogonalises():
+    # non-orthogonal input still yields an orthonormal matrix
+    r = mod.rot6d_to_matrix([2, 0, 0, 1, 1, 0])
+    assert np.allclose(r.T @ r, np.eye(3), atol=1e-6)
+
+
+def test_geodesic_deg_mat_zero_for_equal():
+    r = mod.rot6d_to_matrix([1, 0, 0, 0, 1, 0])
+    assert mod.geodesic_deg_mat(r, r) == pytest.approx(0.0, abs=1e-2)
+
+
+def test_geodesic_deg_mat_ninety_degrees():
+    # identity vs 90deg about z: R = [[0,-1,0],[1,0,0],[0,0,1]] -> cols [0,1,0],[-1,0,0]
+    ident = mod.rot6d_to_matrix([1, 0, 0, 0, 1, 0])
+    rot_z90 = mod.rot6d_to_matrix([0, 1, 0, -1, 0, 0])
+    assert mod.geodesic_deg_mat(ident, rot_z90) == pytest.approx(90.0, abs=1e-3)
+
+
+def test_axis_angle_to_matrix_zero_is_identity():
+    assert np.allclose(mod.axis_angle_to_matrix([0, 0, 0]), np.eye(3), atol=1e-9)
+
+
+def test_axis_angle_to_matrix_ninety_about_z():
+    import math
+    r = mod.axis_angle_to_matrix([0, 0, math.pi / 2])
+    assert np.allclose(r, [[0, -1, 0], [1, 0, 0], [0, 0, 1]], atol=1e-6)
+
+
+def test_axis_angle_and_rot6d_agree():
+    # a rot6d identity and an axis-angle zero rotation are the same R -> 0 geodesic
+    import math
+    r_rot6d = mod.rot6d_to_matrix([0, 1, 0, -1, 0, 0])           # 90deg about z
+    r_aa = mod.axis_angle_to_matrix([0, 0, math.pi / 2])          # 90deg about z
+    assert mod.geodesic_deg_mat(r_rot6d, r_aa) == pytest.approx(0.0, abs=1e-2)
+
+
+def test_cartesian_metrics_mixed_widths():
+    # pred is the 7-D server row [dpos(3), axis-angle(3), gripper(1)];
+    # gt is the 10-D FK'd row [dpos(3), rot6d(6), gripper(1)] — same pose -> ~0 error.
+    pred = np.array([[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]])       # identity rot, closed
+    gt = np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0]])  # identity rot6d, closed
+    tm, rm, gm = mod.cartesian_chunk_metrics(pred, gt)
+    assert tm == pytest.approx(0.0)
+    assert rm == pytest.approx(0.0, abs=1e-2)
+    assert gm == pytest.approx(1.0)
+
+
+def test_cartesian_chunk_metrics_zero_when_equal():
+    chunk = np.zeros((4, 10), dtype=np.float64)
+    chunk[:, 3:9] = [1, 0, 0, 0, 1, 0]  # identity rot6d
+    chunk[:, 9] = 1.0
+    tm, rm, gm = mod.cartesian_chunk_metrics(chunk, chunk)
+    assert tm == pytest.approx(0.0)
+    assert rm == pytest.approx(0.0, abs=1e-2)
+    assert gm == pytest.approx(1.0)
+
+
+def test_cartesian_chunk_metrics_translation_and_gripper():
+    gt = np.zeros((3, 10))
+    gt[:, 3:9] = [1, 0, 0, 0, 1, 0]
+    gt[:, 9] = 1.0  # closed
+    pred = gt.copy()
+    pred[:, 0] = 0.1  # 0.1 m off in x each step
+    pred[:, 9] = 0.0  # gripper disagrees on all steps
+    tm, _rm, gm = mod.cartesian_chunk_metrics(pred, gt)
+    assert tm == pytest.approx(0.1 / 3, abs=1e-6)  # mean over dpos block (x=0.1, y=z=0)
+    assert gm == pytest.approx(0.0)
+
+
+def test_cartesian_chunk_metrics_overlap_horizon():
+    gt = np.zeros((2, 10))
+    gt[:, 3:9] = [1, 0, 0, 0, 1, 0]
+    pred = np.zeros((5, 10))
+    pred[:, 3:9] = [1, 0, 0, 0, 1, 0]
+    tm, _rm, _gm = mod.cartesian_chunk_metrics(pred, gt)  # min horizon = 2
+    assert not np.isnan(tm)
+
+
+def test_cartesian_chunk_metrics_empty_is_nan():
+    tm, rm, gm = mod.cartesian_chunk_metrics(np.empty((0, 10)), np.empty((0, 10)))
+    assert np.isnan(tm) and np.isnan(rm) and np.isnan(gm)
+
+
+def test_aggregate_nan_safe():
+    out = mod.aggregate([0.1, float("nan"), 0.3], [1.0, 2.0, float("nan")], [1.0, 0.0, 1.0])
+    assert out["n_ticks"] == 3
+    assert out["trans_mae_m"] == pytest.approx(0.2)  # nanmean(0.1,0.3)
+    assert out["gripper_agreement"] == pytest.approx(2 / 3)
+
+
+def test_aggregate_empty():
+    out = mod.aggregate([], [], [])
+    assert out["n_ticks"] == 0
+    assert np.isnan(out["trans_mae_m"])


### PR DESCRIPTION
## What

Adds **`Cosmos3Runner`** — fine-tune an NVIDIA Cosmos 3 (WAM) action policy from a mission `kind: training` task, reached via `config: {runner: cosmos3}` (same wildcard mechanism as `gr00t` / `pi05`). Thin wrapper over **cosmos-framework**'s own SFT entry points — no training code reimplemented.

This is the **Phase 2** training counterpart to the Phase 1 eval integration (`pilot: cosmos3`, merged to develop via #95). With both landed, the `quickstart-cosmos3-train` example does the full round-trip: **train → export → `pilot: cosmos3` eval** (no longer DROID-OOD).

## How

Three subprocesses via `TrainingProcessSpec` (all `python -m cosmos_framework.*`):

| # | entry | torchrun | skip |
|---|-------|----------|------|
| 1 | `convert_model_to_dcp` | no | DCP dir exists / `convert_dcp: false` |
| 2 | `train --sft-toml=<recipe>` | **yes** (`nproc_per_node`) | never |
| 3 | `export_model` | no | `export: false` |

- **Dataset = LeRobot v3.0**, native to cosmos-framework — **no Odyssey-side conversion** (the cheap case, verified against upstream `docs/training.md` + `docs/action_policy_droid_posttrain.md`).
- Config-name-driven (like π0.5): `config_name` names an SFT recipe TOML resolved against `$COSMOS_FRAMEWORK_REPO_PATH/examples/toml/sft_config/`; other `config:` keys → dotted CLI overrides.
- Paths reach the recipe via OmegaConf `${oc.env:...}`, so the runner bridges `DATASET_PATH` / `BASE_CHECKPOINT_PATH` / `IMAGINAIRE_OUTPUT_ROOT` / `NPROC_PER_NODE` / `WAN_VAE_PATH` / `FILTER_DIR`.

## Design decisions

- **Strict-mypy clean** — a clean runner like `pi05_train.py`, **not** added to the `ignore_errors` SDK-mirror list (only the numpy glue is).
- **Venv = option A**: run `odyssey` from *inside* the cosmos-framework venv; `run_training_subprocess` launches via `sys.executable`, so torchrun workers inherit the right interpreter — **zero core change**.
- **`models/` split follows the newest convention**: `cosmos3.py` (pilot, Phase 1) + `cosmos3_train.py` (training, this PR) — same as `pi05.py` / `pi05_train.py`. (`openvla.py` bundling both, and `gr00t.py` being training-only with its pilot under `evals/`, are pre-existing artifacts — a future cleanup PR may harmonize them.)

## Footgun documented + tested

`DATASET_PATH` must point at the **PARENT of `success/`** (the named dataset dir itself), and the loader **infers schema from the dir NAME** (e.g. `droid_plus_lerobot_640x360_20260412`) — so the local ref passes through verbatim (contrast pi05) and the vendor naming must be kept.

## Tests

- `tests/unit/test_cosmos3_train.py` — **34 tests** (argv builders, recipe resolution, dataset/path env, base-model resolution, run-dir + `iter_<N>` checkpoint locators, registry dispatch, stdout parser).
- Full suite: **652 passed, 5 skipped**; ruff clean; mypy strict clean (86 files).
- `examples/quickstart-cosmos3-train/mission.yaml` validates OK and runs green through `--use-mock-runner`.

## Pending (out of scope — documented)

**GPU smoke**: confirm the three entry-point flag names, the run-dir / `iter_<N>` checkpoint layout (the resolvers are heuristics), and `FILTER_DIR` on a real DROID run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)