### PR TITLE
refactor(runners/models): harmonize pilot/training file split

### DIFF
--- a/src/odyssey/runners/__init__.py
+++ b/src/odyssey/runners/__init__.py
@@ -25,8 +25,16 @@ from odyssey.runners.base import WILDCARD_TYPE, Runner, TaskContext
 from odyssey.runners.cpu_mock import CPUMockRunner
 from odyssey.runners.evals.isaac_lab import IsaacLabRunner
 from odyssey.runners.evals.robosuite import RobosuiteRunner
-from odyssey.runners.models.gr00t import GR00TRunner, build_gr00t_argv, parse_gr00t_line
-from odyssey.runners.models.openvla import OpenVLARunner, build_openvla_argv, parse_openvla_line
+from odyssey.runners.models.gr00t_train import (
+    GR00TRunner,
+    build_gr00t_argv,
+    parse_gr00t_line,
+)
+from odyssey.runners.models.openvla_train import (
+    OpenVLARunner,
+    build_openvla_argv,
+    parse_openvla_line,
+)
 from odyssey.runners.models.pi05_train import (
     Pi05Runner,
     build_pi05_train_argv,

--- a/src/odyssey/runners/models/__init__.py
+++ b/src/odyssey/runners/models/__init__.py
@@ -1,18 +1,28 @@
 """Model loaders — training runners and inference models."""
 
+from odyssey.runners.models.gr00t_train import (
+    GR00TRunner,
+    build_gr00t_argv,
+    parse_gr00t_line,
+)
 from odyssey.runners.models.openvla import (
+    make_openvla_policy,
+)
+from odyssey.runners.models.openvla_train import (
     OpenVLARunner,
     build_openvla_argv,
-    make_openvla_policy,
     parse_openvla_line,
 )
 
 __all__ = [
+    "GR00TRunner",
     "GemmaVLMGenerator",
     "OpenVLARunner",
     "VLARuntime",
+    "build_gr00t_argv",
     "build_openvla_argv",
     "make_openvla_policy",
+    "parse_gr00t_line",
     "parse_openvla_line",
 ]
 

--- a/src/odyssey/runners/models/gr00t_train.py
+++ b/src/odyssey/runners/models/gr00t_train.py
@@ -38,7 +38,10 @@ from odyssey.runners.base import (
 
 # Shared with the OpenVLA runner; extract to a common module when a
 # third runner needs them.
-from odyssey.runners.models.openvla import _flatten_config, _resolve_and_fetch_hf_model
+from odyssey.runners.models.openvla_train import (
+    _flatten_config,
+    _resolve_and_fetch_hf_model,
+)
 from odyssey.runners.subprocess import (
     TrainingProcessSpec,
     output_path,
@@ -129,7 +132,7 @@ def _resolve_dataset_path(task: TrainingTask) -> str | None:
     ref = task.dataset.ref
     if task.dataset.source == DatasetSource.LOCAL and not os.path.isabs(ref):
         repo_path = os.getenv("ISAAC_GR00T_REPO_PATH", _DEFAULT_REPO_PATH)
-        return os.path.join(repo_path, ref)
+        return (Path(repo_path) / ref).as_posix()
     return ref
 
 
@@ -180,7 +183,7 @@ def build_gr00t_argv(
         # *requires* a modality config file, so this lets a mission point at a
         # repo-relative config (e.g. examples/SO100/so100_config.py) portably.
         if key == "modality_config_path" and isinstance(value, str) and not os.path.isabs(value):
-            value = os.path.join(repo_path, value)
+            value = (Path(repo_path) / value).as_posix()
         argv += [f"--{key.replace('_', '-')}", str(value)]
     return argv
 

--- a/src/odyssey/runners/models/openvla.py
+++ b/src/odyssey/runners/models/openvla.py
@@ -1,29 +1,4 @@
-"""OpenVLA training runner and inference policy.
-
-Training
---------
-Adapted from ``lai-inference/.../jobs/training/openvla_runner.py``.
-OpenVLA uses draccus for config parsing — flags are flat
-(``--vla_path``, ``--data_root_dir``, ``--batch_size``, etc.). LoRA is
-the default fine-tuning mode (``--use_lora True``), producing a
-HuggingFace-format adapter directory under ``run_root_dir``.
-
-What's different from the lai-inference version:
-
-  * Drops ``_stage_for_lai_trainer`` — OSS leaves the checkpoint in the
-    task's output_dir for the user to consume. Lovell's hosted runner
-    can re-add the staging step.
-  * Uses ``odyssey.runners.subprocess`` instead of
-    ``..jobs.training.subprocess_runner``.
-  * Reads identifiers off ``ctx.task.spec`` instead of ``ctx``: the
-    OSS TaskContext is spec-centric.
-
-Scope B (v0.1.0-alpha) caveat: the runner expects the OpenVLA repo to be
-on disk and either pointed at via ``$OPENVLA_REPO_PATH`` or located at
-``/srv/openvla``. The first-class HF resolve+fetch flow lands in Batch 3
-once the HF provider exists; for now ``vla_path`` is read from
-``task.config["vla_path"]`` (or the env var pattern below) without
-re-resolving against the model spec.
+"""OpenVLA inference policy and runtime.
 
 Inference policy
 ----------------
@@ -40,343 +15,11 @@ from __future__ import annotations
 
 import json
 import logging
-import os
-import re
 from pathlib import Path
 from typing import Any
 
-from odyssey.providers.base import ResolvedModel
-from odyssey.runners.base import (
-    WILDCARD_TYPE,
-    Runner,
-    TaskContext,
-)
-from odyssey.runners.subprocess import (
-    TrainingProcessSpec,
-    output_path,
-    run_training_subprocess,
-)
-from odyssey.spec.refs import HFModelRef
-from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
-
 logger = logging.getLogger(__name__)
 
-
-# OpenVLA logs step progress like:
-#   "step: 1234 | loss: 0.234 | grad_norm: 1.23 | lr: 5e-5"
-_OPENVLA_STEP_RE = re.compile(
-    r"\bstep:\s*(\d+)\s*\|\s*loss:\s*([\d.eE+-]+)", re.IGNORECASE
-)
-_OPENVLA_LOAD_RE = re.compile(
-    r"(loading|Loading).*?(VLA|processor|tokenizer|checkpoint)"
-)
-_OPENVLA_DATASET_RE = re.compile(
-    r"(building|Building|loading).*?(RLDS|dataset)", re.IGNORECASE
-)
-_OPENVLA_SAVE_RE = re.compile(
-    r"(saving|Saved).*?(adapter|checkpoint|model)", re.IGNORECASE
-)
-
-
-_DEFAULT_REPO_PATH = "/srv/openvla"
-_FINETUNE_SCRIPT_REL = "vla-scripts/finetune.py"
-
-
-def parse_openvla_line(line: str) -> dict[str, Any] | None:
-    """Extract a progress-event dict from an OpenVLA finetune stdout line.
-
-    Public for tests and for users who want to embed OpenVLA stdout
-    parsing in a custom runner.
-    """
-    m = _OPENVLA_STEP_RE.search(line)
-    if m:
-        return {
-            "stage": "executing",
-            "step": "training_step",
-            "step_index": int(m.group(1)),
-            "step_label": f"loss={m.group(2)}",
-        }
-    if _OPENVLA_LOAD_RE.search(line):
-        return {"stage": "model_loading", "step": "load_artifacts"}
-    if _OPENVLA_DATASET_RE.search(line):
-        return {"stage": "dataset_loading"}
-    if _OPENVLA_SAVE_RE.search(line):
-        return {"stage": "checkpoint_saving"}
-    return None
-
-
-def _flatten_config(d: dict[str, Any], prefix: str = "") -> list[tuple[str, Any]]:
-    out: list[tuple[str, Any]] = []
-    for k, v in d.items():
-        flat_key = f"{prefix}.{k}" if prefix else k
-        if isinstance(v, dict):
-            out.extend(_flatten_config(v, flat_key))
-        else:
-            out.append((flat_key, v))
-    return out
-
-
-def _path_env_for_hf_id(hf_id: str) -> str | None:
-    """Convention: ``openvla/openvla-7b`` → ``OPENVLA_OPENVLA_7B_PATH``."""
-    slug = hf_id.replace("/", "_").replace("-", "_").upper()
-    return os.getenv(f"{slug}_PATH")
-
-
-def build_openvla_argv(
-    *,
-    task: TrainingTask,
-    agent_model_base: str | None,
-    output_dir: Path,
-    run_id: str,
-) -> list[str]:
-    """Build the OpenVLA draccus CLI argv.
-
-    Resolution order for ``vla_path``:
-      1. ``task.config["vla_path"]`` (operator override, also where the
-         runner injects a starting-checkpoint path or a fetched HF dir)
-      2. ``<HF_ID>_PATH`` env var derived from the agent's HF base id
-      3. ``agent_model_base`` itself (treated as an HF hub id; first
-         call triggers a download)
-
-    ``agent_model_base`` is the HF base id pulled off the agent's model
-    ref (``AgentSpec.model.base`` for an HFModelRef). ``None`` when the
-    agent's model isn't an HF ref — in which case ``vla_path`` must
-    have been pre-filled by the runner via the config override.
-    """
-    config = task.config or {}
-    vla_path = (
-        config.get("vla_path")
-        or (_path_env_for_hf_id(agent_model_base) if agent_model_base else None)
-        or agent_model_base
-    )
-    if not vla_path:
-        raise RuntimeError(
-            "OpenVLA runner: cannot resolve vla_path. The agent's model "
-            "must be a HuggingFace ref, or the runner must pre-fill "
-            "task.config['vla_path'] from a starting checkpoint."
-        )
-
-    dataset_id = config.get("data_root_dir")
-    if dataset_id is None and task.dataset is not None:
-        dataset_id = task.dataset.ref
-
-    # OXE dataset name: prefer dataset.ref (the OXE registry key) over
-    # config fallback, so users declare the key in the dataset spec
-    # rather than burying it in hyperparameter config.
-    dataset_name = (
-        task.dataset.ref if task.dataset else config.get("dataset_name", task.name)
-    )
-
-    argv: list[str] = ["--vla_path", str(vla_path)]
-    if dataset_id:
-        argv += ["--data_root_dir", str(dataset_id)]
-    argv += ["--dataset_name", str(dataset_name)]
-    argv += ["--run_root_dir", str(output_dir)]
-    argv += ["--adapter_tmp_dir", str(output_dir / "adapter_tmp")]
-    argv += ["--run_id", run_id]
-    if "use_lora" not in config:
-        argv += ["--use_lora", "True"]
-
-    # Pass through any remaining flat overrides (skip the keys we
-    # already injected). `use_lora` is intentionally NOT in `handled` —
-    # the dedicated branch above only fires when it's missing from
-    # config, so when the operator sets it the override loop here is
-    # what propagates their value.
-    # Keys consumed by Odyssey's mission spec but not accepted by the
-    # upstream finetune.py draccus config.
-    handled = {
-        "vla_path",
-        "data_root_dir",
-        "dataset_name",
-        "method",
-        "lora_alpha",
-        "epochs",
-    }
-    for key, value in _flatten_config(config):
-        if key in handled:
-            continue
-        argv += [f"--{key}", str(value)]
-    return argv
-
-
-async def _resolve_and_fetch_hf_model(
-    context: TaskContext, ref: HFModelRef, dest: Path
-) -> Path:
-    """Resolve + fetch an HF model via the engine's ProviderRegistry."""
-    assert context.providers is not None  # checked by caller
-    provider = context.providers.for_model_ref(ref)
-    await context.emit_progress(
-        "model_loading",
-        step="resolve_hf",
-        step_label=f"{ref.base}@{ref.revision or 'HEAD'}",
-    )
-    resolved: ResolvedModel = await provider.resolve(ref)
-    await context.emit_progress(
-        "model_loading",
-        step="fetch_hf",
-        step_label=f"{resolved.identifier}@{resolved.revision[:8]}",
-    )
-    return await provider.fetch(resolved, dest)
-
-
-def _resolve_finetune_script() -> str:
-    repo_path = os.getenv("OPENVLA_REPO_PATH", _DEFAULT_REPO_PATH)
-    script_path = os.path.join(repo_path, _FINETUNE_SCRIPT_REL)
-    if not os.path.isfile(script_path):
-        raise RuntimeError(
-            f"openvla finetune script not found at {script_path!r}; "
-            "clone https://github.com/openvla/openvla and set OPENVLA_REPO_PATH."
-        )
-    return script_path
-
-
-def _resolve_run_subdir(output_dir: Path, run_id: str) -> Path | None:
-    """OpenVLA writes to ``{run_root_dir}/<vla_name>+<run_id>+<suffix>/``.
-
-    Pick whichever subdir contains an adapter (LoRA) or full-finetune
-    config and includes ``run_id`` in its name.  Then look inside for
-    the latest ``checkpoint-NNN/`` subdir with an ``adapter_config.json``
-    — that's the actual LoRA checkpoint the eval needs.
-    """
-    if not output_dir.is_dir():
-        return None
-    candidates: list[Path] = []
-    for entry in output_dir.iterdir():
-        if not entry.is_dir() or entry.name == "adapter_tmp":
-            continue
-        has_config = any(
-            (entry / fname).is_file()
-            for fname in ("adapter_config.json", "config.json")
-        )
-        if has_config and run_id in entry.name:
-            candidates.append(entry)
-    if not candidates:
-        return None
-    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
-    run_dir = candidates[0]
-
-    # Look for the latest checkpoint-NNN/ subdir with adapter_config.json
-    checkpoint = _resolve_latest_checkpoint(run_dir)
-    return checkpoint if checkpoint is not None else run_dir
-
-
-def _resolve_latest_checkpoint(run_dir: Path) -> Path | None:
-    """Find the latest ``checkpoint-NNN/`` subdir containing a LoRA adapter."""
-    checkpoints: list[tuple[int, Path]] = []
-    for entry in run_dir.iterdir():
-        if not entry.is_dir() or not entry.name.startswith("checkpoint-"):
-            continue
-        if (entry / "adapter_config.json").is_file():
-            # Extract step number for sorting
-            try:
-                step_num = int(entry.name.split("-", 1)[1])
-            except (ValueError, IndexError):
-                step_num = 0
-            checkpoints.append((step_num, entry))
-    if not checkpoints:
-        return None
-    checkpoints.sort(reverse=True)
-    return checkpoints[0][1]
-
-
-class OpenVLARunner(Runner):
-    """Fine-tune an OpenVLA model via LoRA. Subprocess-based — actual
-    training happens in the upstream ``finetune.py`` script."""
-
-    @property
-    def name(self) -> str:
-        return "openvla"
-
-    @property
-    def supported_kinds(self) -> set[TaskKind]:
-        return {TaskKind.TRAINING}
-
-    @property
-    def supported_types(self) -> set[str]:
-        # Any training_type pairs with OpenVLA — the framework decides
-        # based on dataset shape, not the type enum.
-        return {WILDCARD_TYPE}
-
-    async def run(self, context: TaskContext) -> dict[str, Any]:
-        spec = context.task.spec
-        if not isinstance(spec, TrainingTask):
-            raise TypeError(
-                f"OpenVLARunner expects TrainingTask, got {type(spec).__name__}"
-            )
-        if context.agent is None:
-            raise RuntimeError(
-                "OpenVLARunner: TaskContext.agent is None — training tasks "
-                "must be invoked through the engine, which resolves the "
-                "agent from spec.robot.agents[task.agent_id]."
-            )
-
-        output_dir = output_path(context)
-        script_path = _resolve_finetune_script()
-
-        # Decide what vla_path the subprocess should start from:
-        #   1. A prior training task on this agent already produced a
-        #      checkpoint → start from that local path.
-        #   2. The agent's base model is an HF ref and we have a
-        #      provider registry → fetch it locally first.
-        #   3. Otherwise fall through to build_openvla_argv's env-var
-        #      / HF-id resolution against the agent's base model.
-        config = dict(spec.config)
-        agent_model_base: str | None = None
-        if context.starting_checkpoint is not None:
-            config.setdefault("vla_path", context.starting_checkpoint)
-        elif (
-            context.providers is not None
-            and isinstance(context.agent.model, HFModelRef)
-        ):
-            resolved_path = await _resolve_and_fetch_hf_model(
-                context, context.agent.model, output_dir / "model"
-            )
-            config.setdefault("vla_path", str(resolved_path))
-
-        if isinstance(context.agent.model, HFModelRef):
-            agent_model_base = context.agent.model.base
-
-        process_spec = TrainingProcessSpec(
-            timeout_seconds=getattr(spec, "timeout_seconds", None),
-            script_path=script_path,
-            use_torchrun=True,
-            argv_extra=build_openvla_argv(
-                task=spec.model_copy(update={"config": config}),
-                agent_model_base=agent_model_base,
-                output_dir=output_dir,
-                run_id=context.task.id,
-            ),
-            line_parser=parse_openvla_line,
-        )
-
-        rc = await run_training_subprocess(context, process_spec)
-        if context.cancelled():
-            logger.info("OpenVLA task %s cancelled by user", context.task.id)
-            return {"cancelled": True}
-        if rc != 0:
-            raise RuntimeError(f"openvla finetune exited with code {rc}")
-
-        run_subdir = _resolve_run_subdir(output_dir, context.task.id)
-        if run_subdir is None:
-            raise RuntimeError(
-                f"openvla finetune finished but no run subdir found under "
-                f"{output_dir!r}"
-            )
-        return {
-            "checkpoint_path": str(run_subdir),
-            "agent_id": context.agent.id,
-            "training_config": spec.config,
-            "training_type": (
-                spec.training_type.value
-                if isinstance(spec.training_type, TrainingType)
-                else spec.training_type
-            ),
-        }
-
-
-# ---------------------------------------------------------------------------
-# Inference policy
-# ---------------------------------------------------------------------------
 
 # Default natural-language instructions per Robosuite benchmark.
 _DEFAULT_INSTRUCTIONS: dict[str, str] = {
@@ -416,7 +59,6 @@ def _find_image_key(obs: dict[str, Any], preferred: str) -> str:
     """Find a camera image key in the observation dict."""
     if preferred in obs:
         return preferred
-    # Fall back to any key ending with "_image"
     for key in obs:
         if key.endswith("_image"):
             return key
@@ -433,14 +75,7 @@ def _is_lora_checkpoint(checkpoint_path: Path) -> bool:
 
 
 def _center_crop_image(image: Any, crop_scale: float = 0.9) -> Any:
-    """Center-crop to ``crop_scale`` of the frame, then resize back to the original size.
-
-    OpenVLA checkpoints fine-tuned with image augmentation (``image_aug=True`` — e.g. the
-    published ``openvla-7b-finetuned-libero-*``) were trained on a RandomResizedCrop, so
-    inference must apply the matching deterministic center crop (mirrors ``crop_and_resize``
-    in OpenVLA's ``run_libero_eval.py``). Skipping it widens the input FOV vs. training and
-    degrades spatial precision — the arm approaches the target but misses the grasp.
-    """
+    """Center-crop to ``crop_scale`` of the frame, then resize back to the original size."""
     import math
 
     from PIL import Image
@@ -484,8 +119,6 @@ def make_openvla_policy(
     )
     image_key = cfg.get("image_key", "agentview_image")
     device = cfg.get("device", "cuda" if torch.cuda.is_available() else "cpu")
-    # OpenVLA checkpoints trained with image_aug expect a matching center crop at eval
-    # (e.g. the finetuned-libero-* checkpoints). Default on; disable via config.
     center_crop = bool(cfg.get("center_crop", True))
     crop_scale = float(cfg.get("crop_scale", 0.9))
 
@@ -509,8 +142,6 @@ def make_openvla_policy(
         logger.info("Applying LoRA adapter from: %s", checkpoint_path)
         model = PeftModel.from_pretrained(model, str(checkpoint_path))
 
-        # merge_and_unload() for faster inference — but only if the merged
-        # model retains the custom predict_action method.
         if hasattr(model, "merge_and_unload"):
             merged = model.merge_and_unload()
             if hasattr(merged, "predict_action"):
@@ -547,15 +178,12 @@ def make_openvla_policy(
         key = _find_image_key(obs, image_key)
         img_array = obs[key]
 
-        # Convert numpy HWC uint8 → PIL Image
         if not isinstance(img_array, Image.Image):
             img_array = Image.fromarray(img_array.astype("uint8"), "RGB")
 
         if center_crop:
             img_array = _center_crop_image(img_array, crop_scale)
 
-        # The HF-hosted OpenVLAForActionPrediction.predict_action() expects
-        # pre-tokenized input_ids, not raw image+instruction.
         inputs = processor(task_instruction, img_array).to(device, dtype=torch.bfloat16)
         action = model.predict_action(
             inputs["input_ids"],
@@ -568,24 +196,7 @@ def make_openvla_policy(
 
 
 class VLARuntime:
-    """OpenVLA pilot runtime with per-call instruction.
-
-    Unlike ``make_openvla_policy()`` which bakes ``task_instruction`` at
-    creation time, ``VLARuntime.act()`` accepts the instruction on every
-    call. This lets ``PlannedEvalRuntime`` feed different sub-instructions
-    per phase without reloading the model.
-
-    Satisfies ``PilotRuntime`` protocol.
-
-    Parameters
-    ----------
-    checkpoint_path:
-        Path to a LoRA adapter dir or full merged model dir.
-    unnorm_key:
-        Unnormalization key passed to ``predict_action``.
-    device:
-        Torch device string. Defaults to CUDA if available.
-    """
+    """OpenVLA pilot runtime with per-call instruction."""
 
     def __init__(
         self,
@@ -665,7 +276,6 @@ class VLARuntime:
         if self._center_crop:
             image = _center_crop_image(image, self._crop_scale)
 
-        # Pre-tokenize with processor, then pass input_ids to predict_action
         inputs = self._processor(instruction, image).to(
             self._device, dtype=torch.bfloat16
         )

--- a/src/odyssey/runners/models/openvla.py
+++ b/src/odyssey/runners/models/openvla.py
@@ -75,7 +75,14 @@ def _is_lora_checkpoint(checkpoint_path: Path) -> bool:
 
 
 def _center_crop_image(image: Any, crop_scale: float = 0.9) -> Any:
-    """Center-crop to ``crop_scale`` of the frame, then resize back to the original size."""
+    """Center-crop to ``crop_scale`` of the frame, then resize back to the original size.
+
+    OpenVLA checkpoints fine-tuned with image augmentation (``image_aug=True`` — e.g. the
+    published ``openvla-7b-finetuned-libero-*``) were trained on a RandomResizedCrop, so
+    inference must apply the matching deterministic center crop (mirrors ``crop_and_resize``
+    in OpenVLA's ``run_libero_eval.py``). Skipping it widens the input FOV vs. training and
+    degrades spatial precision — the arm approaches the target but misses the grasp.
+    """
     import math
 
     from PIL import Image
@@ -119,6 +126,8 @@ def make_openvla_policy(
     )
     image_key = cfg.get("image_key", "agentview_image")
     device = cfg.get("device", "cuda" if torch.cuda.is_available() else "cpu")
+    # OpenVLA checkpoints trained with image_aug expect a matching center crop at eval
+    # (e.g. the finetuned-libero-* checkpoints). Default on; disable via config.
     center_crop = bool(cfg.get("center_crop", True))
     crop_scale = float(cfg.get("crop_scale", 0.9))
 
@@ -196,7 +205,24 @@ def make_openvla_policy(
 
 
 class VLARuntime:
-    """OpenVLA pilot runtime with per-call instruction."""
+    """OpenVLA pilot runtime with per-call instruction.
+
+    Unlike ``make_openvla_policy()`` which bakes ``task_instruction`` at
+    creation time, ``VLARuntime.act()`` accepts the instruction on every
+    call. This lets ``PlannedEvalRuntime`` feed different sub-instructions
+    per phase without reloading the model.
+
+    Satisfies ``PilotRuntime`` protocol.
+
+    Parameters
+    ----------
+    checkpoint_path:
+        Path to a LoRA adapter dir or full merged model dir.
+    unnorm_key:
+        Unnormalization key passed to ``predict_action``.
+    device:
+        Torch device string. Defaults to CUDA if available.
+    """
 
     def __init__(
         self,

--- a/src/odyssey/runners/models/openvla_train.py
+++ b/src/odyssey/runners/models/openvla_train.py
@@ -1,0 +1,334 @@
+"""OpenVLA training runner.
+
+Adapted from ``lai-inference/.../jobs/training/openvla_runner.py``.
+OpenVLA uses draccus for config parsing — flags are flat
+(``--vla_path``, ``--data_root_dir``, ``--batch_size``, etc.). LoRA is
+the default fine-tuning mode (``--use_lora True``), producing a
+HuggingFace-format adapter directory under ``run_root_dir``.
+
+What's different from the lai-inference version:
+
+  * Drops ``_stage_for_lai_trainer`` — OSS leaves the checkpoint in the
+    task's output_dir for the user to consume. Lovell's hosted runner
+    can re-add the staging step.
+  * Uses ``odyssey.runners.subprocess`` instead of
+    ``..jobs.training.subprocess_runner``.
+  * Reads identifiers off ``ctx.task.spec`` instead of ``ctx``: the
+    OSS TaskContext is spec-centric.
+
+Scope B (v0.1.0-alpha) caveat: the runner expects the OpenVLA repo to be
+on disk and either pointed at via ``$OPENVLA_REPO_PATH`` or located at
+``/srv/openvla``. The first-class HF resolve+fetch flow lands in Batch 3
+once the HF provider exists; for now ``vla_path`` is read from
+``task.config["vla_path"]`` (or the env var pattern below) without
+re-resolving against the model spec.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+from odyssey.providers.base import ResolvedModel
+from odyssey.runners.base import (
+    WILDCARD_TYPE,
+    Runner,
+    TaskContext,
+)
+from odyssey.runners.subprocess import (
+    TrainingProcessSpec,
+    output_path,
+    run_training_subprocess,
+)
+from odyssey.spec.refs import HFModelRef
+from odyssey.spec.tasks import TaskKind, TrainingTask, TrainingType
+
+logger = logging.getLogger(__name__)
+
+
+# OpenVLA logs step progress like:
+#   "step: 1234 | loss: 0.234 | grad_norm: 1.23 | lr: 5e-5"
+_OPENVLA_STEP_RE = re.compile(
+    r"\bstep:\s*(\d+)\s*\|\s*loss:\s*([\d.eE+-]+)", re.IGNORECASE
+)
+_OPENVLA_LOAD_RE = re.compile(
+    r"(loading|Loading).*?(VLA|processor|tokenizer|checkpoint)"
+)
+_OPENVLA_DATASET_RE = re.compile(
+    r"(building|Building|loading).*?(RLDS|dataset)", re.IGNORECASE
+)
+_OPENVLA_SAVE_RE = re.compile(
+    r"(saving|Saved).*?(adapter|checkpoint|model)", re.IGNORECASE
+)
+
+
+_DEFAULT_REPO_PATH = "/srv/openvla"
+_FINETUNE_SCRIPT_REL = "vla-scripts/finetune.py"
+
+
+def parse_openvla_line(line: str) -> dict[str, Any] | None:
+    """Extract a progress-event dict from an OpenVLA finetune stdout line.
+
+    Public for tests and for users who want to embed OpenVLA stdout
+    parsing in a custom runner.
+    """
+    m = _OPENVLA_STEP_RE.search(line)
+    if m:
+        return {
+            "stage": "executing",
+            "step": "training_step",
+            "step_index": int(m.group(1)),
+            "step_label": f"loss={m.group(2)}",
+        }
+    if _OPENVLA_LOAD_RE.search(line):
+        return {"stage": "model_loading", "step": "load_artifacts"}
+    if _OPENVLA_DATASET_RE.search(line):
+        return {"stage": "dataset_loading"}
+    if _OPENVLA_SAVE_RE.search(line):
+        return {"stage": "checkpoint_saving"}
+    return None
+
+
+def _flatten_config(d: dict[str, Any], prefix: str = "") -> list[tuple[str, Any]]:
+    out: list[tuple[str, Any]] = []
+    for k, v in d.items():
+        flat_key = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            out.extend(_flatten_config(v, flat_key))
+        else:
+            out.append((flat_key, v))
+    return out
+
+
+def _path_env_for_hf_id(hf_id: str) -> str | None:
+    """Convention: ``openvla/openvla-7b`` → ``OPENVLA_OPENVLA_7B_PATH``."""
+    slug = hf_id.replace("/", "_").replace("-", "_").upper()
+    return os.getenv(f"{slug}_PATH")
+
+
+def build_openvla_argv(
+    *,
+    task: TrainingTask,
+    agent_model_base: str | None,
+    output_dir: Path,
+    run_id: str,
+) -> list[str]:
+    """Build the OpenVLA draccus CLI argv.
+
+    Resolution order for ``vla_path``:
+      1. ``task.config["vla_path"]`` (operator override, also where the
+         runner injects a starting-checkpoint path or a fetched HF dir)
+      2. ``<HF_ID>_PATH`` env var derived from the agent's HF base id
+      3. ``agent_model_base`` itself (treated as an HF hub id; first
+         call triggers a download)
+
+    ``agent_model_base`` is the HF base id pulled off the agent's model
+    ref (``AgentSpec.model.base`` for an HFModelRef). ``None`` when the
+    agent's model isn't an HF ref — in which case ``vla_path`` must
+    have been pre-filled by the runner via the config override.
+    """
+    config = task.config or {}
+    vla_path = (
+        config.get("vla_path")
+        or (_path_env_for_hf_id(agent_model_base) if agent_model_base else None)
+        or agent_model_base
+    )
+    if not vla_path:
+        raise RuntimeError(
+            "OpenVLA runner: cannot resolve vla_path. The agent's model "
+            "must be a HuggingFace ref, or the runner must pre-fill "
+            "task.config['vla_path'] from a starting checkpoint."
+        )
+
+    dataset_id = config.get("data_root_dir")
+    if dataset_id is None and task.dataset is not None:
+        dataset_id = task.dataset.ref
+
+    dataset_name = (
+        task.dataset.ref if task.dataset else config.get("dataset_name", task.name)
+    )
+
+    argv: list[str] = ["--vla_path", str(vla_path)]
+    if dataset_id:
+        argv += ["--data_root_dir", str(dataset_id)]
+    argv += ["--dataset_name", str(dataset_name)]
+    argv += ["--run_root_dir", str(output_dir)]
+    argv += ["--adapter_tmp_dir", str(output_dir / "adapter_tmp")]
+    argv += ["--run_id", run_id]
+    if "use_lora" not in config:
+        argv += ["--use_lora", "True"]
+
+    handled = {
+        "vla_path",
+        "data_root_dir",
+        "dataset_name",
+        "method",
+        "lora_alpha",
+        "epochs",
+    }
+    for key, value in _flatten_config(config):
+        if key in handled:
+            continue
+        argv += [f"--{key}", str(value)]
+    return argv
+
+
+async def _resolve_and_fetch_hf_model(
+    context: TaskContext, ref: HFModelRef, dest: Path
+) -> Path:
+    """Resolve + fetch an HF model via the engine's ProviderRegistry."""
+    assert context.providers is not None  # checked by caller
+    provider = context.providers.for_model_ref(ref)
+    await context.emit_progress(
+        "model_loading",
+        step="resolve_hf",
+        step_label=f"{ref.base}@{ref.revision or 'HEAD'}",
+    )
+    resolved: ResolvedModel = await provider.resolve(ref)
+    await context.emit_progress(
+        "model_loading",
+        step="fetch_hf",
+        step_label=f"{resolved.identifier}@{resolved.revision[:8]}",
+    )
+    return await provider.fetch(resolved, dest)
+
+
+def _resolve_finetune_script() -> str:
+    repo_path = os.getenv("OPENVLA_REPO_PATH", _DEFAULT_REPO_PATH)
+    script_path = os.path.join(repo_path, _FINETUNE_SCRIPT_REL)
+    if not os.path.isfile(script_path):
+        raise RuntimeError(
+            f"openvla finetune script not found at {script_path!r}; "
+            "clone https://github.com/openvla/openvla and set OPENVLA_REPO_PATH."
+        )
+    return script_path
+
+
+def _resolve_run_subdir(output_dir: Path, run_id: str) -> Path | None:
+    """OpenVLA writes to ``{run_root_dir}/<vla_name>+<run_id>+<suffix>/``."""
+    if not output_dir.is_dir():
+        return None
+    candidates: list[Path] = []
+    for entry in output_dir.iterdir():
+        if not entry.is_dir() or entry.name == "adapter_tmp":
+            continue
+        has_config = any(
+            (entry / fname).is_file()
+            for fname in ("adapter_config.json", "config.json")
+        )
+        if has_config and run_id in entry.name:
+            candidates.append(entry)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    run_dir = candidates[0]
+
+    checkpoint = _resolve_latest_checkpoint(run_dir)
+    return checkpoint if checkpoint is not None else run_dir
+
+
+def _resolve_latest_checkpoint(run_dir: Path) -> Path | None:
+    """Find the latest ``checkpoint-NNN/`` subdir containing a LoRA adapter."""
+    checkpoints: list[tuple[int, Path]] = []
+    for entry in run_dir.iterdir():
+        if not entry.is_dir() or not entry.name.startswith("checkpoint-"):
+            continue
+        if (entry / "adapter_config.json").is_file():
+            try:
+                step_num = int(entry.name.split("-", 1)[1])
+            except (ValueError, IndexError):
+                step_num = 0
+            checkpoints.append((step_num, entry))
+    if not checkpoints:
+        return None
+    checkpoints.sort(reverse=True)
+    return checkpoints[0][1]
+
+
+class OpenVLARunner(Runner):
+    """Fine-tune an OpenVLA model via LoRA. Subprocess-based — actual
+    training happens in the upstream ``finetune.py`` script."""
+
+    @property
+    def name(self) -> str:
+        return "openvla"
+
+    @property
+    def supported_kinds(self) -> set[TaskKind]:
+        return {TaskKind.TRAINING}
+
+    @property
+    def supported_types(self) -> set[str]:
+        return {WILDCARD_TYPE}
+
+    async def run(self, context: TaskContext) -> dict[str, Any]:
+        spec = context.task.spec
+        if not isinstance(spec, TrainingTask):
+            raise TypeError(
+                f"OpenVLARunner expects TrainingTask, got {type(spec).__name__}"
+            )
+        if context.agent is None:
+            raise RuntimeError(
+                "OpenVLARunner: TaskContext.agent is None — training tasks "
+                "must be invoked through the engine, which resolves the "
+                "agent from spec.robot.agents[task.agent_id]."
+            )
+
+        output_dir = output_path(context)
+        script_path = _resolve_finetune_script()
+
+        config = dict(spec.config)
+        agent_model_base: str | None = None
+        if context.starting_checkpoint is not None:
+            config.setdefault("vla_path", context.starting_checkpoint)
+        elif (
+            context.providers is not None
+            and isinstance(context.agent.model, HFModelRef)
+        ):
+            resolved_path = await _resolve_and_fetch_hf_model(
+                context, context.agent.model, output_dir / "model"
+            )
+            config.setdefault("vla_path", str(resolved_path))
+
+        if isinstance(context.agent.model, HFModelRef):
+            agent_model_base = context.agent.model.base
+
+        process_spec = TrainingProcessSpec(
+            timeout_seconds=getattr(spec, "timeout_seconds", None),
+            script_path=script_path,
+            use_torchrun=True,
+            argv_extra=build_openvla_argv(
+                task=spec.model_copy(update={"config": config}),
+                agent_model_base=agent_model_base,
+                output_dir=output_dir,
+                run_id=context.task.id,
+            ),
+            line_parser=parse_openvla_line,
+        )
+
+        rc = await run_training_subprocess(context, process_spec)
+        if context.cancelled():
+            logger.info("OpenVLA task %s cancelled by user", context.task.id)
+            return {"cancelled": True}
+        if rc != 0:
+            raise RuntimeError(f"openvla finetune exited with code {rc}")
+
+        run_subdir = _resolve_run_subdir(output_dir, context.task.id)
+        if run_subdir is None:
+            raise RuntimeError(
+                f"openvla finetune finished but no run subdir found under "
+                f"{output_dir!r}"
+            )
+        return {
+            "checkpoint_path": str(run_subdir),
+            "agent_id": context.agent.id,
+            "training_config": spec.config,
+            "training_type": (
+                spec.training_type.value
+                if isinstance(spec.training_type, TrainingType)
+                else spec.training_type
+            ),
+        }

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -63,7 +63,7 @@ from odyssey.runners.base import (
 )
 
 # Shared flatten helper (dotted keys for nested dicts).
-from odyssey.runners.models.openvla import _flatten_config
+from odyssey.runners.models.openvla_train import _flatten_config
 from odyssey.runners.subprocess import (
     TrainingProcessSpec,
     output_path,
@@ -231,11 +231,8 @@ def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
     if task.dataset is None:
         return {}
     ref = task.dataset.ref
-    if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
-        parent = os.path.dirname(os.path.normpath(ref))
-        # Only HF_LEROBOT_HOME — do NOT also set the legacy LEROBOT_HOME. Recent
-        # lerobot HARD-FAILS at import (raises ValueError) if the deprecated
-        # LEROBOT_HOME var is present, which killed compute_norm_stats.
+    if task.dataset.source == DatasetSource.LOCAL and (os.path.isabs(ref) or ref.startswith("/")):
+        parent = Path(ref).parent.as_posix()
         return {"HF_LEROBOT_HOME": parent}
     return {}
 

--- a/src/odyssey/runners/models/pi05_train.py
+++ b/src/odyssey/runners/models/pi05_train.py
@@ -231,8 +231,11 @@ def _lerobot_env_for_dataset(task: TrainingTask) -> dict[str, str]:
     if task.dataset is None:
         return {}
     ref = task.dataset.ref
-    if task.dataset.source == DatasetSource.LOCAL and (os.path.isabs(ref) or ref.startswith("/")):
-        parent = Path(ref).parent.as_posix()
+    if task.dataset.source == DatasetSource.LOCAL and os.path.isabs(ref):
+        parent = os.path.dirname(os.path.normpath(ref))
+        # Only HF_LEROBOT_HOME — do NOT also set the legacy LEROBOT_HOME. Recent
+        # lerobot HARD-FAILS at import (raises ValueError) if the deprecated
+        # LEROBOT_HOME var is present, which killed compute_norm_stats.
         return {"HF_LEROBOT_HOME": parent}
     return {}
 

--- a/tests/conformance/test_gr00t_upstream.py
+++ b/tests/conformance/test_gr00t_upstream.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import pytest
 
-from odyssey.runners.models.gr00t import _ENTRY_MODULE, build_gr00t_argv
+from odyssey.runners.models.gr00t_train import _ENTRY_MODULE, build_gr00t_argv
 from odyssey.spec import TrainingTask
 from odyssey.spec.loader import load_mission
 

--- a/tests/unit/test_gr00t_train.py
+++ b/tests/unit/test_gr00t_train.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from odyssey.runners.models.gr00t import build_gr00t_argv, parse_gr00t_line
+from odyssey.runners.models.gr00t_train import build_gr00t_argv, parse_gr00t_line
 from odyssey.spec import DatasetRef, DatasetSource, TrainingTask, TrainingType
 
 

--- a/tests/unit/test_imports.py
+++ b/tests/unit/test_imports.py
@@ -20,9 +20,9 @@ import pytest
 
 ENTRY_MODULES = [
     "odyssey.runners.base",
-    "odyssey.runners.models.gr00t",
+    "odyssey.runners.models.gr00t_train",
     "odyssey.runners.evals.isaac_lab",
-    "odyssey.runners.models.openvla",
+    "odyssey.runners.models.openvla_train",
     "odyssey.runners.evals.robosuite",
     "odyssey.engine",
     "odyssey.spec",

--- a/tests/unit/test_openvla_train.py
+++ b/tests/unit/test_openvla_train.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import pytest
 
-from odyssey.runners.models.openvla import build_openvla_argv, parse_openvla_line
+from odyssey.runners.models.openvla_train import build_openvla_argv, parse_openvla_line
 from odyssey.spec import TrainingTask, TrainingType
 
 

--- a/tests/unit/test_pi05_train.py
+++ b/tests/unit/test_pi05_train.py
@@ -283,6 +283,17 @@ def test_dataset_repo_id_empty_when_unknown() -> None:
     assert _dataset_repo_id(_task(config={"config_name": _CFG})) == ""
 
 
+def test_lerobot_env_exports_only_hf_lerobot_home(tmp_path: Path) -> None:
+    abs_ref = str(tmp_path / "ur10e_v0")
+    task = _task(
+        dataset=DatasetRef(source=DatasetSource.LOCAL, ref=abs_ref)
+    )
+    env = _lerobot_env_for_dataset(task)
+    assert "HF_LEROBOT_HOME" in env
+    assert "LEROBOT_HOME" not in env
+    assert env["HF_LEROBOT_HOME"] == str(tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # stdout parser
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_provider_threading.py
+++ b/tests/unit/test_provider_threading.py
@@ -170,7 +170,7 @@ async def test_openvla_runner_substitutes_provider_fetched_path(
     """When ctx.providers is set and model is HFModelRef, the runner
     should call provider.resolve + provider.fetch and use the resulting
     path as vla_path — overriding env-var fallbacks."""
-    from odyssey.runners.models.openvla import _resolve_and_fetch_hf_model
+    from odyssey.runners.models.openvla_train import _resolve_and_fetch_hf_model
 
     fetched_path = tmp_path / "fetched-model"
     fetched_path.mkdir()
@@ -211,7 +211,7 @@ async def test_openvla_runner_works_without_providers(
     """Back-compat: when providers is None, the runner relies on
     build_openvla_argv's existing env/config/HF-id fallback against
     the agent's model base."""
-    from odyssey.runners.models.openvla import build_openvla_argv
+    from odyssey.runners.models.openvla_train import build_openvla_argv
 
     monkeypatch.delenv("OPENVLA_OPENVLA_7B_PATH", raising=False)
     task = TrainingTask(


### PR DESCRIPTION
### Summary of Changes
Harmonized the pilot/training file split across `runners/models`:
- Split `openvla.py` into `openvla.py` (inference) + `openvla_train.py` (training).
- Renamed `gr00t.py` to `gr00t_train.py` (training-only; pilot lives in `evals/`).
- Updated re-exports in `runners/models/__init__.py` and `runners/__init__.py`.

Closes #98