### PR TITLE
feat(agents): deterministic multi-agent brain (dispatch → compose → converge)

### DIFF
--- a/examples/multiagent-openvla-gemma/mission.yaml
+++ b/examples/multiagent-openvla-gemma/mission.yaml
@@ -98,6 +98,11 @@ tasks:
     benchmark_name: Lift
     num_episodes: 10
     config:
+      # Deterministic multi-agent brain (dispatch -> compose -> converge, no
+      # ADK): the SPECIALIST is engaged by deterministic dispatch and its
+      # advisory composes into a single convergent pilot inference per step.
+      # Omit or set to "planned" for the legacy plan-then-execute runtime.
+      brain: deterministic
       unnorm_key: bridge_orig
       capture_video: true   # one MP4 per episode (README: "Recording rollout videos")
       # video_camera: frontview   # record from a dedicated camera instead of the

--- a/src/odyssey/runners/agents/__init__.py
+++ b/src/odyssey/runners/agents/__init__.py
@@ -15,6 +15,14 @@ Model loading (``VLARuntime``, ``GemmaVLMGenerator``) lives in
 ``runners/models/``.
 """
 
+from odyssey.runners.agents.brain import (
+    Advisory,
+    BrainContext,
+    DeterministicBrain,
+    SafetyBoundary,
+    SpecialistTurn,
+    select_specialists,
+)
 from odyssey.runners.agents.openai_judge import OpenAICompatCompletionJudge
 from odyssey.runners.agents.planned import (
     PhaseConfig,
@@ -26,6 +34,9 @@ from odyssey.runners.agents.remote_planner import RemotePlanner
 from odyssey.runners.agents.runtime import PilotRuntime, PlannerRuntime, TextGenerator
 
 __all__ = [
+    "Advisory",
+    "BrainContext",
+    "DeterministicBrain",
     "LLMPlanner",
     "OpenAICompatCompletionJudge",
     "PhaseConfig",
@@ -34,5 +45,8 @@ __all__ = [
     "PlannedEvalRuntime",
     "PlannerRuntime",
     "RemotePlanner",
+    "SafetyBoundary",
+    "SpecialistTurn",
     "TextGenerator",
+    "select_specialists",
 ]

--- a/src/odyssey/runners/agents/brain/__init__.py
+++ b/src/odyssey/runners/agents/brain/__init__.py
@@ -1,0 +1,38 @@
+"""Deterministic multi-agent brain — dispatch -> compose -> converge.
+
+A framework-agnostic (no Google ADK) control plane that replaces the
+plan-then-execute planner (``agents/planned.py``). The brain owns *who acts*
+(deterministic dispatch), *how outputs compose* (advisories), and *convergence*
+(a single Pilot inference over the composed context). It calls only odyssey's
+existing model-layer ports — ``TextGenerator`` (specialist turn) and
+``PilotRuntime`` (action turn) — so it needs no agent framework.
+
+The pieces:
+  * ``BrainContext`` / ``Advisory``  — the compose seam (``context.py``).
+  * ``select_specialists`` + concept lexicon — deterministic dispatch,
+    no LLM decision (``dispatch.py``).
+  * ``SpecialistTurn``               — one advisory-producing cognitive turn
+    over any ``TextGenerator`` (``specialist.py``).
+  * ``DeterministicBrain``           — the orchestrator that satisfies the eval
+    runtime surface (``runtime.py``).
+  * ``SafetyBoundary``               — monitor-only action checks (``safety.py``).
+"""
+
+from __future__ import annotations
+
+from odyssey.runners.agents.brain.context import Advisory, BrainContext
+from odyssey.runners.agents.brain.dispatch import Decision, select_specialists
+from odyssey.runners.agents.brain.runtime import DeterministicBrain
+from odyssey.runners.agents.brain.safety import SafetyBoundary, SafetyFinding
+from odyssey.runners.agents.brain.specialist import SpecialistTurn
+
+__all__ = [
+    "Advisory",
+    "BrainContext",
+    "Decision",
+    "DeterministicBrain",
+    "SafetyBoundary",
+    "SafetyFinding",
+    "SpecialistTurn",
+    "select_specialists",
+]

--- a/src/odyssey/runners/agents/brain/context.py
+++ b/src/odyssey/runners/agents/brain/context.py
@@ -1,0 +1,58 @@
+"""BrainContext — the compose seam.
+
+Framework-agnostic (no ADK, no torch at import) types that carry a single
+Pilot turn's input: the request, the robot identity, and the advisories
+composed from specialists. ``render_instruction`` is the COMPOSE step (of
+dispatch -> compose -> converge) expressed as plain string composition the
+model host cannot silently reshape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Advisory:
+    """One specialist's structured output block, composed into the Pilot turn.
+
+    ``kind`` distinguishes the source class (e.g. ``"specialist"``); ``source``
+    is the human-readable origin (the specialist's name), surfaced in the
+    rendered instruction and in logs/telemetry.
+    """
+
+    source: str
+    kind: str
+    text: str
+
+
+@dataclass
+class BrainContext:
+    """Input to one convergent Pilot turn.
+
+    Assembled by the orchestrator from the request (``instruction``), the
+    robot ``identity``, and ``advisories`` gathered from engaged specialists.
+    """
+
+    instruction: str
+    identity: str | None = None
+    advisories: list[Advisory] = field(default_factory=list)
+
+    def render_instruction(self) -> str:
+        """Compose identity + advisory blocks + the request into one string.
+
+        This is the compose step (dispatch -> **compose** -> converge) as plain
+        string concatenation: the Pilot sees every advisory before it acts.
+        When there is nothing to compose, the bare instruction is returned so a
+        no-specialist turn is byte-identical to a single-agent one.
+        """
+        sections: list[str] = []
+        if self.identity:
+            sections.append(f"[ROBOT IDENTITY]\n{self.identity}")
+        for adv in self.advisories:
+            if adv.text:
+                sections.append(f"[ADVISORY — {adv.source}]\n{adv.text}")
+        if not sections:
+            return self.instruction
+        sections.append(f"[TASK]\n{self.instruction}")
+        return "\n\n".join(sections)

--- a/src/odyssey/runners/agents/brain/dispatch.py
+++ b/src/odyssey/runners/agents/brain/dispatch.py
@@ -1,0 +1,226 @@
+"""Deterministic dispatch — decide which specialists to engage, no LLM.
+
+The DISPATCH stage of dispatch -> compose -> converge. Engagement is decided
+from explicit, auditable signals: semantic term overlap between the request and
+each specialist's vocabulary (both sides expanded through a small concept
+lexicon + a crude stemmer so synonyms/paraphrases match), with a fuzzy fallback
+for typos/morphology, and an image-present + vision-capable rule.
+
+Module philosophy: *a readable rule table beats an opaque score.* Extend
+``_CONCEPT_LEXICON`` rather than reaching for an embedding model — matching
+stays deterministic, local, and testable without any model dependency
+(stdlib ``re`` + ``difflib`` only).
+"""
+
+from __future__ import annotations
+
+import difflib
+import os
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+_DISPATCH_STOPWORDS = {
+    "the", "and", "for", "with", "that", "this", "from", "into", "onto",
+    "your", "you", "are", "was", "will", "would", "should", "could", "have",
+    "has", "had", "then", "than", "them", "they", "there", "here", "what",
+    "when", "where", "which", "while", "about", "over", "under", "please",
+}
+
+
+def _dispatch_terms(text: str) -> set[str]:
+    """Significant lowercase tokens for dispatch matching (len>=4, non-stopword)."""
+    return {
+        t
+        for t in re.split(r"[^a-z0-9]+", (text or "").lower())
+        if len(t) >= 4 and t not in _DISPATCH_STOPWORDS
+    }
+
+
+# Small, transparent concept lexicon so engagement matches on MEANING, not just
+# identical tokens. Each canonical concept lists surface forms that resolve to
+# it; both the request and each specialist's vocabulary are expanded through
+# this map before overlap is computed. EXTEND this table rather than reaching
+# for an embedding model.
+_CONCEPT_LEXICON: dict[str, set[str]] = {
+    "inspect": {"inspect", "inspection", "examine", "check", "monitor", "survey",
+                "audit", "assess", "evaluate", "review", "scan", "look"},
+    "equipment": {"equipment", "machinery", "machine", "device", "asset",
+                  "hardware", "apparatus", "unit", "component", "gear",
+                  "instrument", "motor", "pump", "valve", "pipe", "panel"},
+    "anomaly": {"anomaly", "anomalies", "abnormal", "irregular", "fault",
+                "defect", "malfunction", "issue", "problem", "fail", "failure"},
+    "overheat": {"overheat", "overheating", "hotspot", "hot", "heat", "thermal",
+                 "temperature", "warm", "burning"},
+    "leak": {"leak", "leaking", "leakage", "spill", "drip", "seepage", "seep"},
+    "damage": {"damage", "crack", "cracked", "broken", "break", "dent", "wear",
+               "corrosion", "rust", "worn", "degraded"},
+    "patrol": {"patrol", "route", "rounds", "tour", "sweep", "stop", "waypoint"},
+    "navigate": {"navigate", "navigation", "drive", "move", "travel", "path",
+                 "traverse", "roam", "wander"},
+    "grasp": {"grasp", "grip", "pick", "place", "manipulate", "handle", "grab",
+              "lift", "assemble", "assembly"},
+    "obstacle": {"obstacle", "collision", "avoid", "avoidance", "clearance",
+                 "blocked", "hazard"},
+    "inventory": {"inventory", "stock", "count", "counting", "barcode", "shelf",
+                  "warehouse"},
+    "safety": {"safety", "hazard", "danger", "risk", "unsafe", "emergency"},
+    "quality": {"quality", "flaw", "tolerance", "conformance", "reject",
+                "grade", "finish"},
+    "report": {"report", "reporting", "findings", "record", "document",
+               "alert", "notify", "flag"},
+    "measure": {"measure", "measurement", "gauge", "reading", "sensor",
+                "sensing", "telemetry"},
+    "scene": {"scene", "object", "objects", "color", "colour", "shape",
+              "identify", "detect", "locate", "recognize", "recognise",
+              "describe", "vision", "visual", "see"},
+}
+
+
+def _stem(token: str) -> str:
+    """Very small suffix-stripping stemmer — deterministic, no dependencies.
+
+    Collapses common inflections so ``inspecting``/``inspected``/``inspects``
+    all map to the same base as ``inspect``. Intentionally crude; it only needs
+    to normalize morphology enough for concept-lexicon and fuzzy matching.
+    """
+    for suf in ("ings", "ing", "ies", "ied", "ers", "er", "ed", "es", "s"):
+        if token.endswith(suf) and len(token) - len(suf) >= 3:
+            base = token[: -len(suf)]
+            if suf == "ies":
+                base += "y"
+            return base
+    return token
+
+
+# Reverse index: stemmed surface form -> concept tags. Built once at import.
+_SURFACE_TO_CONCEPTS: dict[str, set[str]] = {}
+for _concept, _surfaces in _CONCEPT_LEXICON.items():
+    for _surface in _surfaces:
+        _SURFACE_TO_CONCEPTS.setdefault(_stem(_surface), set()).add(_concept)
+
+
+def _concept_tags(term: str) -> set[str]:
+    """Concept tags a term resolves to (namespaced so they never collide with a
+    literal stemmed token)."""
+    return {f"concept:{c}" for c in _SURFACE_TO_CONCEPTS.get(_stem(term), set())}
+
+
+def _expand_terms(terms: set[str]) -> set[str]:
+    """Expand raw tokens into stems + concept tags for semantic overlap.
+
+    Literal exact matches are preserved (the stem of an unchanged token is the
+    token itself), so this is strictly a superset of plain token overlap.
+    """
+    expanded: set[str] = set()
+    for t in terms:
+        expanded.add(_stem(t))
+        expanded |= _concept_tags(t)
+    return expanded
+
+
+def _humanize_concepts(overlap: set[str]) -> set[str]:
+    """Strip the ``concept:`` namespace prefix for readable audit reasons."""
+    return {
+        t.split("concept:", 1)[1] if t.startswith("concept:") else t
+        for t in overlap
+    }
+
+
+def _fuzzy_overlap(
+    a_terms: set[str], b_terms: set[str], threshold: float = 0.86
+) -> set[tuple[str, str]]:
+    """Near-identical token pairs across two sets (typos / morphology the
+    stemmer and concept map miss). Deterministic; term sets are small."""
+    hits: set[tuple[str, str]] = set()
+    for a in a_terms:
+        for b in b_terms:
+            if a == b:
+                continue
+            if difflib.SequenceMatcher(None, a, b).ratio() >= threshold:
+                hits.add((a, b))
+    return hits
+
+
+@runtime_checkable
+class DispatchCandidate(Protocol):
+    """The dispatch surface a specialist must expose (structural).
+
+    ``vocab`` is the specialist's authored routing vocabulary (tokens from its
+    name/id, and any configured keywords); ``is_vision`` marks a multimodal
+    specialist that can consume the camera image.
+    """
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def vocab(self) -> set[str]: ...
+
+    @property
+    def is_vision(self) -> bool: ...
+
+
+@dataclass
+class Decision:
+    """One dispatch decision — auditable per candidate, engaged or skipped."""
+
+    specialist: DispatchCandidate
+    engaged: bool
+    reason: str
+    is_vision: bool
+
+
+def select_specialists(
+    instruction: str,
+    specialists: Sequence[DispatchCandidate],
+    has_image: bool,
+) -> list[Decision]:
+    """Decide which specialists to engage for a request — deterministically.
+
+    Cascade: engage-all mode -> concept overlap -> fuzzy overlap ->
+    image-present + vision-capable -> skip.
+
+    Modes (env ``ODYSSEY_DISPATCH``):
+      * ``selective`` (default): engage only matching specialists; a request
+        with no signal engages NONE (pure Pilot).
+      * ``all``: engage every specialist (escape hatch).
+
+    Returns one ``Decision`` per candidate so the full table is auditable.
+    """
+    if not specialists:
+        return []
+
+    mode = os.getenv("ODYSSEY_DISPATCH", "selective").lower()
+    msg_terms = _dispatch_terms(instruction)
+    msg_expanded = _expand_terms(msg_terms)
+
+    decisions: list[Decision] = []
+    for sd in specialists:
+        vocab = sd.vocab
+        concept_overlap = msg_expanded & _expand_terms(vocab)
+        is_vision = sd.is_vision
+
+        fuzzy: set[tuple[str, str]] = set()
+        if not concept_overlap and mode != "all":
+            fuzzy = _fuzzy_overlap(msg_terms, vocab)
+
+        if mode == "all":
+            engaged, reason = True, "engage-all dispatch (ODYSSEY_DISPATCH=all)"
+        elif concept_overlap:
+            matched = sorted(_humanize_concepts(concept_overlap))[:4]
+            engaged, reason = True, f"request matches {matched}"
+        elif fuzzy:
+            pairs = sorted({f"{a}~{b}" for a, b in fuzzy})[:3]
+            engaged, reason = True, f"request fuzzy-matches {pairs}"
+        elif has_image and is_vision:
+            engaged, reason = True, "image present + vision-capable specialist"
+        else:
+            engaged, reason = False, "no signal match"
+
+        decisions.append(
+            Decision(specialist=sd, engaged=engaged, reason=reason, is_vision=is_vision)
+        )
+
+    return decisions

--- a/src/odyssey/runners/agents/brain/runtime.py
+++ b/src/odyssey/runners/agents/brain/runtime.py
@@ -1,0 +1,141 @@
+"""DeterministicBrain — the orchestrator: dispatch -> compose -> converge.
+
+Replaces the plan-then-execute ``PlannedEvalRuntime``. Instead of decomposing
+the task into a script the pilot replays, it engages specialists by meaning
+(deterministic dispatch, no LLM), composes their advisories into the pilot's
+instruction, and runs a single convergent pilot inference per step over that
+composed instruction. No agent framework — it calls only the ``PilotRuntime``
+and ``TextGenerator`` ports.
+
+It presents the exact surface the eval loop already drives
+(``begin_episode`` / ``get_action`` / ``close``), so it is a drop-in for
+``PlannedEvalRuntime`` behind the ``brain: deterministic`` flag.
+
+v1 cadence is ``"episode"``: dispatch + compose run ONCE at episode start and
+the composed instruction is reused for every step. ``cadence`` is the extension
+point for a future per-tick recompose (e.g. gated on a completion detector).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from odyssey.runners.agents.brain.context import Advisory, BrainContext
+from odyssey.runners.agents.brain.dispatch import select_specialists
+from odyssey.runners.agents.brain.safety import SafetyBoundary
+from odyssey.runners.agents.brain.specialist import SpecialistTurn
+from odyssey.runners.agents.runtime import PilotRuntime
+
+logger = logging.getLogger(__name__)
+
+
+class DeterministicBrain:
+    """Dispatch -> compose -> converge orchestrator (drop-in for the eval loop).
+
+    Parameters
+    ----------
+    pilot:
+        The convergent action agent (a ``PilotRuntime`` such as ``VLARuntime``).
+    specialists:
+        Advisory-only cognitive turns. Engaged per-request by deterministic
+        dispatch; their outputs compose into the pilot's instruction.
+    identity:
+        Optional robot identity prepended to the composed instruction.
+    safety:
+        Optional monitor-only ``SafetyBoundary`` the action traverses.
+    cadence:
+        ``"episode"`` (v1): compose once per episode. Reserved for future
+        higher-cadence strategies.
+    """
+
+    def __init__(
+        self,
+        pilot: PilotRuntime,
+        specialists: list[SpecialistTurn],
+        *,
+        identity: str | None = None,
+        safety: SafetyBoundary | None = None,
+        cadence: str = "episode",
+    ) -> None:
+        self._pilot = pilot
+        self._specialists = specialists
+        self._identity = identity
+        self._safety = safety
+        if cadence != "episode":
+            logger.warning(
+                "DeterministicBrain: cadence %r not implemented; using 'episode'", cadence
+            )
+        self._cadence = "episode"
+        self._instruction = ""
+        self._composed = ""
+
+    @property
+    def current_instruction(self) -> str:
+        return self._composed
+
+    def begin_episode(
+        self, task_instruction: str, image: Any | None = None
+    ) -> list[str]:
+        """Dispatch + compose once for the episode; cache the composed instruction.
+
+        Returns a single-element "plan" (the task) so the eval loop's plan
+        telemetry stays meaningful — this brain converges on one instruction
+        rather than a multi-phase script.
+        """
+        self._instruction = task_instruction
+        has_image = image is not None
+        decisions = select_specialists(task_instruction, self._specialists, has_image)
+        engaged = [d for d in decisions if d.engaged]
+        logger.info(
+            "brain dispatch: engaging %d/%d specialist(s)",
+            len(engaged),
+            len(self._specialists),
+        )
+        for d in decisions:
+            logger.info(
+                "brain   %s: %s (%s)",
+                d.specialist.name,
+                "ENGAGE" if d.engaged else "skip",
+                d.reason,
+            )
+
+        advisories: list[Advisory] = []
+        for d in engaged:
+            spec = d.specialist
+            assert isinstance(spec, SpecialistTurn)
+            text = spec.run(task_instruction, image if d.is_vision else None)
+            if text:
+                advisories.append(Advisory(source=spec.name, kind="specialist", text=text))
+                logger.info("brain advisory [%s]: %s", spec.name, text[:160])
+
+        ctx = BrainContext(
+            instruction=task_instruction,
+            identity=self._identity,
+            advisories=advisories,
+        )
+        self._composed = ctx.render_instruction()
+        logger.info(
+            "brain composed instruction for the pilot (%d advisory block(s))",
+            len(advisories),
+        )
+        return [task_instruction]
+
+    def get_action(self, image: Any) -> NDArray[np.floating[Any]]:
+        """Converge: one pilot inference over the composed instruction, then safety."""
+        instruction = self._composed or self._instruction
+        action: NDArray[np.floating[Any]] = self._pilot.act(image, instruction)
+        if self._safety is not None:
+            action = self._safety.check(action)
+        return action
+
+    def close(self) -> None:
+        """Tear down specialists (out-of-process subprocesses). Idempotent."""
+        for spec in self._specialists:
+            try:
+                spec.close()
+            except Exception as e:
+                logger.warning("brain: specialist %r close failed: %s", spec.name, e)

--- a/src/odyssey/runners/agents/brain/safety.py
+++ b/src/odyssey/runners/agents/brain/safety.py
@@ -1,0 +1,125 @@
+"""SafetyBoundary — deterministic, monitor-only action checks.
+
+A small brain-side gate the action traverses before it leaves the runtime.
+MONITOR-only by default: it reports (and can expose a clamped copy of) the
+action, but does NOT mutate the action stream — enforcement is a later,
+separate concern at the actuator boundary. It is plain runtime code (numpy
+only), never inside a framework.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SafetyFinding:
+    """One check result: ``severity`` in {"violation", "warning"}."""
+
+    check: str
+    severity: str
+    detail: str
+
+
+@dataclass
+class SafetyResult:
+    """Outcome of one safety pass over an action vector."""
+
+    ok: bool
+    mode: str
+    findings: list[SafetyFinding]
+    clamped: NDArray[np.floating[Any]]
+
+    @property
+    def violation_count(self) -> int:
+        return sum(1 for f in self.findings if f.severity == "violation")
+
+
+class SafetyBoundary:
+    """Structural action checks (finite / shape / range), monitor-only.
+
+    Parameters
+    ----------
+    expected_dim:
+        Expected action dimensionality (e.g. 7 for a 7-DoF end-effector delta).
+        ``None`` skips the shape check.
+    abs_limit:
+        Symmetric magnitude bound each component is checked (and clamped, in the
+        returned copy) against. The clamp is reported, NOT applied to the stream
+        while ``mode == "monitor"``.
+    mode:
+        ``"monitor"`` (default) reports only; ``"enforce"`` returns the clamped
+        action. Enforce is provided for completeness but off by default.
+    """
+
+    def __init__(
+        self,
+        *,
+        expected_dim: int | None = 7,
+        abs_limit: float = 1.0,
+        mode: str = "monitor",
+    ) -> None:
+        self._expected_dim = expected_dim
+        self._abs_limit = abs_limit
+        self._mode = mode
+
+    def evaluate(self, action: NDArray[np.floating[Any]]) -> SafetyResult:
+        """Run the checks and return a structured result (does not log)."""
+        findings: list[SafetyFinding] = []
+        arr = np.asarray(action, dtype=np.float64)
+
+        if not np.all(np.isfinite(arr)):
+            findings.append(
+                SafetyFinding("finite", "violation", "action contains NaN/Inf")
+            )
+            arr = np.nan_to_num(arr, nan=0.0, posinf=self._abs_limit, neginf=-self._abs_limit)
+
+        if self._expected_dim is not None and arr.shape[-1] != self._expected_dim:
+            findings.append(
+                SafetyFinding(
+                    "shape",
+                    "warning",
+                    f"expected dim {self._expected_dim}, got {arr.shape[-1]}",
+                )
+            )
+
+        out_of_range = int(np.count_nonzero(np.abs(arr) > self._abs_limit))
+        clamped = np.clip(arr, -self._abs_limit, self._abs_limit)
+        if out_of_range:
+            findings.append(
+                SafetyFinding(
+                    "range",
+                    "warning",
+                    f"{out_of_range} component(s) exceed |{self._abs_limit}| (clamped copy exposed)",
+                )
+            )
+
+        ok = not any(f.severity == "violation" for f in findings)
+        return SafetyResult(ok=ok, mode=self._mode, findings=findings, clamped=clamped)
+
+    def check(self, action: NDArray[np.floating[Any]]) -> NDArray[np.floating[Any]]:
+        """Evaluate + log; return the action (monitor) or the clamped one (enforce).
+
+        MONITOR-only by default: the original action is returned unchanged so the
+        boundary never silently alters behavior; findings surface as log lines.
+        """
+        result = self.evaluate(action)
+        if result.findings:
+            logger.warning(
+                "safety [%s]: %d finding(s) (action %s)",
+                self._mode,
+                len(result.findings),
+                "clamped" if self._mode == "enforce" else "NOT modified",
+            )
+            for f in result.findings:
+                logger.warning("safety   %s: %s — %s", f.severity, f.check, f.detail)
+        if self._mode == "enforce":
+            return result.clamped
+        return np.asarray(action, dtype=np.float64)

--- a/src/odyssey/runners/agents/brain/specialist.py
+++ b/src/odyssey/runners/agents/brain/specialist.py
@@ -1,0 +1,121 @@
+"""SpecialistTurn — one advisory-producing cognitive turn.
+
+Wraps *any* ``TextGenerator`` (in-process ``GemmaVLMGenerator`` or the
+out-of-process ``RemoteGenerator`` — both satisfy the same
+``runtime.py:TextGenerator`` protocol) and turns ``(instruction, image)`` into
+a single grounded **advisory** string.
+
+The advisory prompt lives HERE, in the brain — never in the model host. The
+host just runs the model on whatever messages it is handed; deciding what to
+ask (a grounded advisory, not a numbered plan) is a control-plane concern.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+from typing import Any, Protocol, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Advisory system prompt. Reuses the vision-grounding guardrails of the old
+# planner (``agents/planner.py:_SYSTEM_PROMPT_VISION``) but asks for ONE grounded
+# advisory the Pilot can act on — not a numbered decomposition.
+_ADVISORY_SYSTEM = (
+    "You are a robot task SPECIALIST. You advise the pilot; you do not act. "
+    "Given the task instruction, produce a single short advisory (1-3 sentences) "
+    "that helps the pilot execute the task. Be concrete and actionable. Output "
+    "ONLY the advisory text, no preamble, no numbered list."
+)
+
+_ADVISORY_SYSTEM_VISION = (
+    "You are a robot task SPECIALIST with vision. You advise the pilot; you do "
+    "not act. You are given the current scene image and the task instruction. "
+    "Ground your advisory STRICTLY in what you actually see — name concrete "
+    "objects, colors, and spatial relationships relevant to the task. Do NOT "
+    "invent objects or details that are not visible. Produce a single short "
+    "advisory (1-3 sentences) that helps the pilot execute the task. Output ONLY "
+    "the advisory text, no preamble, no numbered list."
+)
+
+_WS = re.compile(r"\s+")
+
+
+@runtime_checkable
+class TextGenerator(Protocol):
+    """The model-layer port a specialist runs on (mirrors ``runtime.py``)."""
+
+    def generate(self, messages: list[dict[str, Any]]) -> str: ...
+
+
+class SpecialistTurn:
+    """An advisory-only specialist over a ``TextGenerator``.
+
+    Parameters
+    ----------
+    name:
+        Human-readable specialist name (used for advisory attribution + dispatch).
+    generator:
+        Any ``TextGenerator`` (in-process or out-of-process). A multimodal one
+        (``generate`` accepts an ``image`` kwarg) is fed the scene image.
+    is_vision:
+        Whether this specialist can consume the camera image (multimodal model).
+    keywords:
+        Optional extra routing vocabulary, merged with tokens from ``name``.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        generator: TextGenerator,
+        *,
+        is_vision: bool,
+        keywords: set[str] | None = None,
+    ) -> None:
+        self._name = name
+        self._generator = generator
+        self._is_vision = is_vision
+        self._accepts_image = "image" in inspect.signature(generator.generate).parameters
+        toks = {t for t in re.split(r"[^a-z0-9]+", name.lower()) if len(t) >= 3}
+        self._vocab = toks | (keywords or set())
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def vocab(self) -> set[str]:
+        return self._vocab
+
+    @property
+    def is_vision(self) -> bool:
+        return self._is_vision
+
+    def run(self, instruction: str, image: Any | None = None) -> str:
+        """Produce one advisory string for the task. Empty string on failure.
+
+        The image is forwarded only when this specialist is vision-capable AND
+        its generator accepts an ``image`` argument.
+        """
+        use_vision = image is not None and self._is_vision and self._accepts_image
+        system = _ADVISORY_SYSTEM_VISION if use_vision else _ADVISORY_SYSTEM
+        messages = [
+            {"role": "user", "content": f"{system}\n\nTask: {instruction}"},
+        ]
+        try:
+            if use_vision:
+                text = self._generator.generate(messages, image=image)  # type: ignore[call-arg]
+            else:
+                text = self._generator.generate(messages)
+        except Exception as e:
+            logger.warning("SpecialistTurn %r failed (%s) — empty advisory", self._name, e)
+            return ""
+        return _WS.sub(" ", text).strip()
+
+    def close(self) -> None:
+        """Release the generator if it owns out-of-process resources. Safe to
+        call multiple times; no-op for in-process generators."""
+        closer = getattr(self._generator, "close", None)
+        if callable(closer):
+            closer()

--- a/src/odyssey/runners/evals/libero.py
+++ b/src/odyssey/runners/evals/libero.py
@@ -283,9 +283,25 @@ class LiberoRunner(Runner):
         instruction = _resolve_libero_instruction(task, cfg)
         logger.info("LIBERO task %d instruction: %r", task_id, instruction)
 
-        # Single-agent (OpenVLA policy) vs multi-agent (PlannedEvalRuntime + Gemma).
-        use_planned = _has_specialist(context)
-        if use_planned:
+        # Single-agent (OpenVLA policy) vs multi-agent. The deterministic brain
+        # (dispatch -> compose -> converge, no ADK) is opt-in via
+        # ``config.brain: deterministic`` / ``ODYSSEY_DETERMINISTIC_BRAIN=1``;
+        # otherwise the legacy PlannedEvalRuntime stays the default.
+        _multi = _has_specialist(context)
+        use_deterministic = _multi and (
+            cfg.get("brain") == "deterministic"
+            or os.getenv("ODYSSEY_DETERMINISTIC_BRAIN") == "1"
+        )
+        use_planned = _multi and not use_deterministic
+        if use_deterministic:
+            runtime = _build_deterministic_runtime(context, checkpoint, cfg)
+            await context.emit_progress(
+                "model_loading",
+                step="load_specialist",
+                step_label="DeterministicBrain (PILOT + SPECIALIST)",
+            )
+            policy = None
+        elif use_planned:
             runtime = _build_planned_runtime(context, checkpoint, cfg, instruction)
             await context.emit_progress(
                 "model_loading",
@@ -717,4 +733,63 @@ def _build_planned_runtime(
         planner=planner,
         phase_config=phase_config,
         fallback_instruction=instruction,
+    )
+
+
+def _build_deterministic_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    cfg: dict[str, Any],
+) -> Any:
+    """Compose PILOT (OpenVLA) + out-of-process SPECIALIST(s) as a DeterministicBrain.
+
+    dispatch -> compose -> converge, no agent framework. Same out-of-process
+    ``ODYSSEY_SPECIALIST_PYTHON`` requirement as the planned path.
+    """
+    from odyssey.runners.agents.brain import (
+        DeterministicBrain,
+        SafetyBoundary,
+        SpecialistTurn,
+    )
+    from odyssey.runners.models.openvla import VLARuntime
+    from odyssey.runners.models.remote_generator import RemoteGenerator
+    from odyssey.spec.agents import AgentRole
+    from odyssey.spec.refs import HFModelRef
+
+    unnorm_key = cfg.get("unnorm_key", "bridge_orig")
+    pilot = VLARuntime(checkpoint, unnorm_key=unnorm_key)
+
+    specialist_python = os.getenv("ODYSSEY_SPECIALIST_PYTHON")
+    if not specialist_python:
+        raise RuntimeError(
+            "The deterministic brain requires the out-of-process SPECIALIST: set "
+            "ODYSSEY_SPECIALIST_PYTHON to the specialist venv's python (the multimodal "
+            "Gemma 4 specialist cannot load in the OpenVLA-pinned env)."
+        )
+
+    specialists: list[SpecialistTurn] = []
+    for agent in context.agents or context.mission.spec.robot.agents:
+        if agent.role != AgentRole.SPECIALIST:
+            continue
+        model = agent.model
+        if not isinstance(model, HFModelRef):
+            raise ValueError(
+                f"SPECIALIST agent {agent.id!r} uses a non-HuggingFace model. "
+                "Only HuggingFace models are supported for SPECIALIST inference."
+            )
+        generator = RemoteGenerator(
+            model.base, model.quantization, python_path=specialist_python
+        )
+        is_vision = model.modality == "multimodal"
+        logger.info(
+            "SPECIALIST out-of-process: id=%s model=%s vision=%s via %s",
+            agent.id,
+            model.base,
+            is_vision,
+            specialist_python,
+        )
+        specialists.append(SpecialistTurn(agent.id, generator, is_vision=is_vision))
+
+    return DeterministicBrain(
+        pilot, specialists, safety=SafetyBoundary(), cadence="episode"
     )

--- a/src/odyssey/runners/evals/robosuite.py
+++ b/src/odyssey/runners/evals/robosuite.py
@@ -260,12 +260,26 @@ class RobosuiteRunner(Runner):
             capture_video = False
         elif capture_video:
             video_dir = context.output_dir / "videos"  # type: ignore[operator]
-        use_planned = (
-            self._policy_factory is _default_policy_factory
-            and _has_specialist(context)
+        # Multi-agent brain selection. The deterministic brain (dispatch ->
+        # compose -> converge, no ADK) is opt-in via ``config.brain:
+        # deterministic`` or ``ODYSSEY_DETERMINISTIC_BRAIN=1``; otherwise the
+        # legacy plan-then-execute PlannedEvalRuntime stays the default.
+        _multi = self._policy_factory is _default_policy_factory and _has_specialist(context)
+        use_deterministic = _multi and (
+            (spec.config or {}).get("brain") == "deterministic"
+            or os.getenv("ODYSSEY_DETERMINISTIC_BRAIN") == "1"
         )
+        use_planned = _multi and not use_deterministic
 
-        if use_planned:
+        if use_deterministic:
+            runtime = _build_deterministic_runtime(context, checkpoint, spec)
+            await context.emit_progress(
+                "model_loading",
+                step="load_specialist",
+                step_label="DeterministicBrain (PILOT + SPECIALIST)",
+            )
+            policy = None
+        elif use_planned:
             runtime = _build_planned_runtime(context, checkpoint, spec)
             await context.emit_progress(
                 "model_loading",
@@ -576,4 +590,75 @@ def _build_planned_runtime(
         planner=planner,
         phase_config=phase_config,
         fallback_instruction=task_instruction,
+    )
+
+
+def _build_deterministic_runtime(
+    context: TaskContext,
+    checkpoint: Path,
+    spec: EvaluationTask,
+) -> Any:
+    """Build a ``DeterministicBrain`` from the mission's PILOT + SPECIALIST(s).
+
+    dispatch -> compose -> converge, no agent framework. The PILOT is a
+    ``VLARuntime``; each SPECIALIST is a ``SpecialistTurn`` over an
+    out-of-process ``RemoteGenerator`` (Gemma 4 needs a modern transformers,
+    incompatible with OpenVLA's pin, so it must run in the specialist venv —
+    same ``ODYSSEY_SPECIALIST_PYTHON`` requirement as the planned path). The
+    composed advisory conditions a single convergent pilot inference per step.
+    """
+    from odyssey.runners.agents.brain import (
+        DeterministicBrain,
+        SafetyBoundary,
+        SpecialistTurn,
+    )
+    from odyssey.runners.models.openvla import VLARuntime
+    from odyssey.runners.models.remote_generator import RemoteGenerator
+    from odyssey.spec.agents import AgentRole
+    from odyssey.spec.refs import HFModelRef
+
+    cfg = spec.config or {}
+    unnorm_key = cfg.get("unnorm_key", "bridge_orig")
+    pilot = VLARuntime(checkpoint, unnorm_key=unnorm_key)
+
+    specialist_python = os.getenv("ODYSSEY_SPECIALIST_PYTHON")
+    if not specialist_python:
+        raise RuntimeError(
+            "The deterministic brain requires the out-of-process SPECIALIST: set "
+            "ODYSSEY_SPECIALIST_PYTHON to the specialist venv's python (see the "
+            "README 'Multi-agent evaluation' section). The multimodal Gemma 4 "
+            "specialist cannot load in this venv, which pins transformers==4.40.1 "
+            "for OpenVLA."
+        )
+
+    specialists: list[SpecialistTurn] = []
+    for agent in context.agents or context.mission.spec.robot.agents:
+        if agent.role != AgentRole.SPECIALIST:
+            continue
+        model = agent.model
+        if not isinstance(model, HFModelRef):
+            raise ValueError(
+                f"SPECIALIST agent {agent.id!r} uses a non-HuggingFace model. "
+                "Only HuggingFace models are supported for SPECIALIST inference."
+            )
+        generator = RemoteGenerator(
+            model.base,
+            model.quantization,
+            python_path=specialist_python,
+        )
+        is_vision = model.modality == "multimodal"
+        logger.info(
+            "SPECIALIST out-of-process: id=%s model=%s vision=%s via %s",
+            agent.id,
+            model.base,
+            is_vision,
+            specialist_python,
+        )
+        specialists.append(SpecialistTurn(agent.id, generator, is_vision=is_vision))
+
+    return DeterministicBrain(
+        pilot,
+        specialists,
+        safety=SafetyBoundary(),
+        cadence="episode",
     )

--- a/src/odyssey/runners/models/generator_server.py
+++ b/src/odyssey/runners/models/generator_server.py
@@ -1,0 +1,125 @@
+"""Out-of-process, prompt-agnostic text-generation server.
+
+Runs in the *specialist* venv — a modern ``transformers`` + ``torchvision`` that
+can host the multimodal Gemma 4 generator, free of the OpenVLA-pinned
+``transformers==4.40.1`` that constrains the main venv. This is INFRASTRUCTURE,
+not brain: it hosts a ``TextGenerator`` and knows nothing about tasks, plans, or
+advisories — the caller sends fully-composed messages, the server returns text.
+
+JSON-lines stdin/stdout protocol:
+
+    <- {"ready": true}                              (once, after the model loads)
+    -> {"messages": [...], "image": "<base64 PNG>"} (one request per line)
+    <- {"text": "<generated text>"}                 (one response per line)
+    <- {"error": "..."}                             (on failure; client falls back)
+    -> {"shutdown": true}                           (client asks the server to exit)
+
+**stdout carries ONLY protocol JSON.** Model-loading / log noise is forced to
+stderr. Heavy imports are deferred into ``main()`` so this module imports
+cheaply for unit-testing ``serve()`` with ``io.StringIO`` and a fake generator.
+
+Usage (normally launched by ``RemoteGenerator``, not by hand):
+    python -m odyssey.runners.models.generator_server \
+        --model google/gemma-4-E2B-it --quantization int4
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import TYPE_CHECKING, Any, TextIO
+
+if TYPE_CHECKING:
+    from odyssey.runners.agents.runtime import TextGenerator
+
+
+def _emit(stream: TextIO, obj: dict[str, Any]) -> None:
+    """Write one protocol JSON line and flush."""
+    stream.write(json.dumps(obj) + "\n")
+    stream.flush()
+
+
+def _decode_image(data: str) -> Any:
+    """Decode a base64 PNG string into a PIL Image (deferred PIL import)."""
+    import base64
+    import io
+
+    from PIL import Image
+
+    return Image.open(io.BytesIO(base64.b64decode(data))).convert("RGB")
+
+
+def serve(
+    generator: TextGenerator,
+    instream: TextIO,
+    outstream: TextIO,
+) -> None:
+    """Emit ``{"ready": true}``, then answer one request per stdin line.
+
+    Pure I/O loop over the streams — no model loading here — so it can be
+    unit-tested with ``io.StringIO`` and a fake generator.
+    """
+    _emit(outstream, {"ready": True})
+    for raw in instream:
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            _emit(outstream, {"error": "invalid JSON request"})
+            continue
+        if not isinstance(req, dict):
+            _emit(outstream, {"error": "request must be a JSON object"})
+            continue
+        if req.get("shutdown"):
+            break
+        messages = req.get("messages")
+        if not isinstance(messages, list):
+            _emit(outstream, {"error": "missing 'messages' list"})
+            continue
+        try:
+            raw_image = req.get("image")
+            if isinstance(raw_image, str):
+                text = generator.generate(messages, image=_decode_image(raw_image))  # type: ignore[call-arg]
+            else:
+                text = generator.generate(messages)
+            _emit(outstream, {"text": str(text)})
+        except BaseException as e:
+            _emit(outstream, {"error": f"generate failed: {type(e).__name__}: {e}"})
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Odyssey out-of-process text-generation server"
+    )
+    parser.add_argument("--model", required=True, help="HF id of the SPECIALIST model")
+    parser.add_argument("--quantization", default=None, help="e.g. int4 (or omit)")
+    parser.add_argument("--max-new-tokens", type=int, default=256)
+    args = parser.parse_args()
+
+    # Keep stdout clean for the protocol: route any model-loading prints to
+    # stderr while we import + load the model, then restore.
+    real_stdout = sys.stdout
+    sys.stdout = sys.stderr
+    try:
+        from odyssey.runners.models.gemma_vlm import GemmaVLMGenerator
+
+        generator: TextGenerator = GemmaVLMGenerator(
+            args.model,
+            quantization=args.quantization,
+            max_new_tokens=args.max_new_tokens,
+        )
+    except BaseException as e:
+        sys.stdout = real_stdout
+        _emit(sys.stdout, {"error": f"generator load failed: {type(e).__name__}: {e}"})
+        return
+    finally:
+        sys.stdout = real_stdout
+
+    serve(generator, sys.stdin, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/odyssey/runners/models/remote_generator.py
+++ b/src/odyssey/runners/models/remote_generator.py
@@ -1,0 +1,217 @@
+"""RemoteGenerator — drives an out-of-process ``TextGenerator``.
+
+Implements the ``TextGenerator`` protocol but, instead of loading Gemma in this
+process, launches ``generator_server`` in a *separate* venv/process. That frees
+the specialist from OpenVLA's pinned ``transformers==4.40.1`` (which lives in
+the main venv) so it can host the multimodal Gemma 4 generator (which needs a
+modern ``transformers`` + ``torchvision``).
+
+This is a generic, prompt-agnostic transport: it sends fully-composed
+``messages`` (+ optional image) and returns generated ``text``. It carries no
+brain logic — prompting/composition is the caller's (the brain's) job.
+
+Communicates over the JSON-lines stdin/stdout protocol documented in
+``generator_server``. The subprocess (and the model) starts lazily on the first
+``generate`` call and is reused across calls. Robust by design: non-JSON stdout
+lines are skipped, and any failure returns ``""`` so an advisory turn degrades
+gracefully rather than crashing the rollout.
+"""
+
+from __future__ import annotations
+
+import atexit
+import base64
+import contextlib
+import io
+import json
+import logging
+import os
+import queue
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Sequence
+from typing import IO, Any
+
+logger = logging.getLogger(__name__)
+
+_SERVER_MODULE = "odyssey.runners.models.generator_server"
+_SIGKILL = getattr(signal, "SIGKILL", signal.SIGTERM)
+
+
+def _popen_creation_kwargs() -> dict[str, Any]:
+    if sys.platform == "win32":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _terminate_process(proc: subprocess.Popen[str], sig: int) -> None:
+    killpg = getattr(os, "killpg", None)
+    getpgid = getattr(os, "getpgid", None)
+    if killpg is not None and getpgid is not None:
+        killpg(getpgid(proc.pid), sig)
+    elif sig == signal.SIGTERM:
+        proc.terminate()
+    else:
+        proc.kill()
+
+
+def _encode_image(image: Any) -> str:
+    """Encode a PIL Image or HWC uint8 ndarray as a base64 PNG string."""
+    from PIL import Image
+
+    pil = image if isinstance(image, Image.Image) else Image.fromarray(image)
+    buf = io.BytesIO()
+    pil.convert("RGB").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+class RemoteGenerator:
+    """Out-of-process ``TextGenerator``. Satisfies the ``TextGenerator`` protocol.
+
+    Parameters
+    ----------
+    model_base:
+        HF id of the SPECIALIST model (e.g. ``google/gemma-4-E2B-it``).
+    quantization:
+        Quantization string passed through to the server (e.g. ``int4``) or None.
+    python_path:
+        Path to the *specialist* venv's python interpreter (from
+        ``ODYSSEY_SPECIALIST_PYTHON``).
+    startup_timeout:
+        Seconds to wait for ``{"ready": true}`` — the first run downloads the
+        model, so this is generous.
+    request_timeout:
+        Seconds to wait for a single generate response.
+    launch_args:
+        Argv (after ``python_path``) that starts the server. Defaults to
+        ``("-m", generator_server)``; overridable for tests.
+    """
+
+    def __init__(
+        self,
+        model_base: str,
+        quantization: str | None = None,
+        *,
+        python_path: str,
+        startup_timeout: float = 600.0,
+        request_timeout: float = 120.0,
+        launch_args: Sequence[str] = ("-m", _SERVER_MODULE),
+    ) -> None:
+        self._model_base = model_base
+        self._quantization = quantization
+        self._python_path = python_path
+        self._startup_timeout = startup_timeout
+        self._request_timeout = request_timeout
+        self._launch_args = list(launch_args)
+        self._proc: subprocess.Popen[str] | None = None
+        self._lines: queue.Queue[str | None] = queue.Queue()
+        self._reader: threading.Thread | None = None
+        atexit.register(self.close)
+
+    def _ensure_started(self) -> None:
+        if self._proc is not None:
+            return
+        argv = [self._python_path, *self._launch_args, "--model", self._model_base]
+        if self._quantization:
+            argv += ["--quantization", self._quantization]
+        logger.info("RemoteGenerator: launching specialist server: %s", " ".join(argv))
+        self._proc = subprocess.Popen(
+            argv,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            **_popen_creation_kwargs(),
+        )
+        assert self._proc.stdout is not None
+        self._reader = threading.Thread(
+            target=self._drain_stdout, args=(self._proc.stdout,), daemon=True
+        )
+        self._reader.start()
+        msg = self._read_message(self._startup_timeout)
+        if not msg or not msg.get("ready"):
+            err = (msg or {}).get("error", "no ready signal / server exited")
+            self.close()
+            raise RuntimeError(f"specialist generator failed to start: {err}")
+
+    def _drain_stdout(self, stdout: IO[str]) -> None:
+        """Reader thread: push each stdout line onto the queue; None on EOF."""
+        try:
+            for line in stdout:
+                self._lines.put(line)
+        finally:
+            self._lines.put(None)
+
+    def _read_message(self, timeout: float) -> dict[str, Any] | None:
+        """Return the next protocol JSON object, skipping noise. None on timeout/EOF."""
+        deadline = time.monotonic() + timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                logger.warning("RemoteGenerator: timed out waiting for server response")
+                return None
+            try:
+                line = self._lines.get(timeout=remaining)
+            except queue.Empty:
+                logger.warning("RemoteGenerator: timed out waiting for server response")
+                return None
+            if line is None:
+                logger.warning("RemoteGenerator: server stdout closed (process exited?)")
+                return None
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                logger.debug("RemoteGenerator: skipping non-JSON stdout line: %s", line[:200])
+                continue
+            if isinstance(obj, dict):
+                return obj
+
+    def generate(self, messages: list[dict[str, Any]], image: Any | None = None) -> str:
+        """Generate text from chat messages via the out-of-process server.
+
+        When ``image`` is given it is sent as a base64 PNG alongside the
+        messages. Returns ``""`` on any error (the caller degrades gracefully).
+        """
+        try:
+            self._ensure_started()
+            proc = self._proc
+            assert proc is not None and proc.stdin is not None
+            request: dict[str, Any] = {"messages": messages}
+            if image is not None:
+                request["image"] = _encode_image(image)
+            proc.stdin.write(json.dumps(request) + "\n")
+            proc.stdin.flush()
+            msg = self._read_message(self._request_timeout)
+            text = (msg or {}).get("text")
+            if isinstance(text, str):
+                return text
+            logger.warning("RemoteGenerator: bad/empty response %r — empty text", msg)
+        except Exception as e:
+            logger.warning("RemoteGenerator.generate failed (%s) — empty text", e)
+        return ""
+
+    def close(self) -> None:
+        """Shut down the server process. Idempotent; also runs at exit."""
+        proc = self._proc
+        if proc is None:
+            return
+        self._proc = None
+        if proc.stdin is not None and not proc.stdin.closed:
+            with contextlib.suppress(BrokenPipeError, ValueError, OSError):
+                proc.stdin.write(json.dumps({"shutdown": True}) + "\n")
+                proc.stdin.flush()
+            with contextlib.suppress(BrokenPipeError, ValueError, OSError):
+                proc.stdin.close()
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            if proc.poll() is None:
+                _terminate_process(proc, signal.SIGTERM)
+                try:
+                    proc.wait(timeout=10)
+                except subprocess.TimeoutExpired:
+                    _terminate_process(proc, _SIGKILL)

--- a/tests/unit/test_deterministic_brain.py
+++ b/tests/unit/test_deterministic_brain.py
@@ -1,0 +1,100 @@
+"""Unit tests for DeterministicBrain (dispatch -> compose -> converge)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Import engine first to avoid circular import (same pattern as test_engine.py).
+import odyssey.engine  # noqa: F401
+from odyssey.runners.agents.brain.runtime import DeterministicBrain
+from odyssey.runners.agents.brain.safety import SafetyBoundary
+from odyssey.runners.agents.brain.specialist import SpecialistTurn
+from odyssey.runners.agents.runtime import PilotRuntime
+
+
+class FakePilot:
+    """Records every (image, instruction) call and returns a fixed action."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, str]] = []
+
+    def act(self, image: Any, instruction: str) -> NDArray[np.floating[Any]]:
+        self.calls.append((image, instruction))
+        return np.zeros(7, dtype=np.float64)
+
+
+class FakeTextGenerator:
+    """Returns canned advisory text; records how many times it ran."""
+
+    def __init__(self, response: str) -> None:
+        self._response = response
+        self.call_count = 0
+
+    def generate(self, messages: list[dict[str, Any]]) -> str:
+        self.call_count += 1
+        return self._response
+
+
+def _image() -> NDArray[np.uint8]:
+    return np.zeros((8, 8, 3), dtype=np.uint8)
+
+
+def test_fake_pilot_satisfies_protocol() -> None:
+    assert isinstance(FakePilot(), PilotRuntime)
+
+
+def test_engaged_specialist_advisory_composes_into_pilot_instruction() -> None:
+    pilot = FakePilot()
+    gen = FakeTextGenerator("a red cube is on the left")
+    spec = SpecialistTurn("scene-describer", gen, is_vision=True)
+    brain = DeterministicBrain(pilot, [spec], safety=SafetyBoundary())
+
+    plan = brain.begin_episode("describe the scene", _image())
+    assert plan == ["describe the scene"]  # single convergent "phase"
+
+    # Specialist ran exactly once (compose-once-per-episode).
+    assert gen.call_count == 1
+    composed = brain.current_instruction
+    assert "[ADVISORY — scene-describer]" in composed
+    assert "a red cube is on the left" in composed
+    assert composed.rstrip().endswith("describe the scene")
+
+    action = brain.get_action(_image())
+    assert action.shape == (7,)
+    # Pilot converged over the composed instruction, not the raw task.
+    assert pilot.calls[-1][1] == composed
+
+
+def test_compose_once_then_reused_across_steps() -> None:
+    pilot = FakePilot()
+    gen = FakeTextGenerator("advice")
+    brain = DeterministicBrain(pilot, [SpecialistTurn("scene", gen, is_vision=True)])
+
+    brain.begin_episode("do the thing", _image())
+    for _ in range(5):
+        brain.get_action(_image())
+
+    assert gen.call_count == 1          # composed once for the whole episode
+    assert len(pilot.calls) == 5        # pilot ran every step
+
+
+def test_no_engagement_yields_bare_instruction() -> None:
+    pilot = FakePilot()
+    gen = FakeTextGenerator("unused")
+    # No text signal, no image -> selective dispatch engages nobody.
+    brain = DeterministicBrain(pilot, [SpecialistTurn("mapper", gen, is_vision=False)])
+
+    brain.begin_episode("say hello", image=None)
+    assert gen.call_count == 0
+    assert brain.current_instruction == "say hello"
+
+    brain.get_action(_image())
+    assert pilot.calls[-1][1] == "say hello"
+
+
+def test_close_is_safe() -> None:
+    brain = DeterministicBrain(FakePilot(), [SpecialistTurn("s", FakeTextGenerator("x"), is_vision=False)])
+    brain.close()  # no out-of-process resources -> no-op, must not raise

--- a/tests/unit/test_deterministic_context.py
+++ b/tests/unit/test_deterministic_context.py
@@ -1,0 +1,35 @@
+"""Unit tests for BrainContext composition (the compose seam)."""
+
+from __future__ import annotations
+
+from odyssey.runners.agents.brain.context import Advisory, BrainContext
+
+
+def test_bare_instruction_when_nothing_to_compose() -> None:
+    ctx = BrainContext(instruction="pick up the cube")
+    # No identity, no advisories -> byte-identical to a single-agent instruction.
+    assert ctx.render_instruction() == "pick up the cube"
+
+
+def test_advisories_and_identity_compose_in_order() -> None:
+    ctx = BrainContext(
+        instruction="pick up the cube",
+        identity="I am arm-1",
+        advisories=[
+            Advisory(source="scene", kind="specialist", text="a red cube is left"),
+        ],
+    )
+    out = ctx.render_instruction()
+    assert out.index("[ROBOT IDENTITY]") < out.index("[ADVISORY — scene]")
+    assert out.index("[ADVISORY — scene]") < out.index("[TASK]")
+    assert "a red cube is left" in out
+    assert out.rstrip().endswith("pick up the cube")
+
+
+def test_empty_advisory_text_is_skipped() -> None:
+    ctx = BrainContext(
+        instruction="go",
+        advisories=[Advisory(source="s", kind="specialist", text="")],
+    )
+    # The only advisory is empty -> nothing to compose -> bare instruction.
+    assert ctx.render_instruction() == "go"

--- a/tests/unit/test_deterministic_dispatch.py
+++ b/tests/unit/test_deterministic_dispatch.py
@@ -1,0 +1,82 @@
+"""Unit tests for the deterministic dispatch (concept lexicon, no LLM)."""
+
+from __future__ import annotations
+
+import pytest
+
+from odyssey.runners.agents.brain.dispatch import DispatchCandidate, select_specialists
+
+
+class FakeCandidate:
+    """Minimal dispatch candidate: name + routing vocab + vision capability."""
+
+    def __init__(self, name: str, vocab: set[str], *, is_vision: bool = False) -> None:
+        self._name = name
+        self._vocab = set(vocab)
+        self._is_vision = is_vision
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def vocab(self) -> set[str]:
+        return self._vocab
+
+    @property
+    def is_vision(self) -> bool:
+        return self._is_vision
+
+
+def test_fake_candidate_satisfies_protocol() -> None:
+    assert isinstance(FakeCandidate("x", set()), DispatchCandidate)
+
+
+def test_exact_token_overlap_engages() -> None:
+    sd = FakeCandidate("inspector", {"inspection"})
+    [d] = select_specialists("inspect the equipment", [sd], has_image=False)
+    assert d.engaged and "matches" in d.reason
+
+
+def test_synonym_via_concept_lexicon_engages() -> None:
+    # "examine"->inspect, "machinery"->equipment: concept overlap, not token overlap.
+    sd = FakeCandidate("auditor", {"equipment", "inspect"})
+    [d] = select_specialists("examine the machinery", [sd], has_image=False)
+    assert d.engaged
+
+
+def test_fuzzy_fallback_engages_on_typo() -> None:
+    # "cartograpy" (typo) is outside the concept lexicon, so only the fuzzy
+    # fallback can match it to the specialist's "cartography" vocab.
+    sd = FakeCandidate("mapper", {"cartography"})
+    [d] = select_specialists("do a cartograpy", [sd], has_image=False)
+    assert d.engaged and "fuzzy" in d.reason
+
+
+def test_no_signal_no_image_skips_in_selective_mode() -> None:
+    sd = FakeCandidate("mapper", {"cartography"})
+    [d] = select_specialists("say hello", [sd], has_image=False)
+    assert not d.engaged and d.reason == "no signal match"
+
+
+def test_image_plus_vision_engages_without_text_signal() -> None:
+    sd = FakeCandidate("scene", {"cartography"}, is_vision=True)
+    [d] = select_specialists("say hello", [sd], has_image=True)
+    assert d.engaged and "image present" in d.reason
+
+
+def test_image_without_vision_does_not_engage() -> None:
+    sd = FakeCandidate("mapper", {"cartography"}, is_vision=False)
+    [d] = select_specialists("say hello", [sd], has_image=True)
+    assert not d.engaged
+
+
+def test_engage_all_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ODYSSEY_DISPATCH", "all")
+    sds = [FakeCandidate("a", set()), FakeCandidate("b", set())]
+    decisions = select_specialists("anything", sds, has_image=False)
+    assert all(d.engaged for d in decisions)
+
+
+def test_empty_specialists_returns_empty() -> None:
+    assert select_specialists("inspect", [], has_image=True) == []

--- a/tests/unit/test_deterministic_safety.py
+++ b/tests/unit/test_deterministic_safety.py
@@ -1,0 +1,46 @@
+"""Unit tests for the monitor-only SafetyBoundary."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from odyssey.runners.agents.brain.safety import SafetyBoundary
+
+
+def test_clean_action_passes() -> None:
+    sb = SafetyBoundary(expected_dim=7)
+    result = sb.evaluate(np.zeros(7))
+    assert result.ok and result.findings == []
+
+
+def test_non_finite_is_a_violation() -> None:
+    sb = SafetyBoundary(expected_dim=7)
+    result = sb.evaluate(np.array([np.nan, 0, 0, 0, 0, 0, 0]))
+    assert not result.ok
+    assert any(f.check == "finite" and f.severity == "violation" for f in result.findings)
+
+
+def test_wrong_shape_is_a_warning() -> None:
+    sb = SafetyBoundary(expected_dim=7)
+    result = sb.evaluate(np.zeros(4))
+    assert any(f.check == "shape" for f in result.findings)
+
+
+def test_out_of_range_is_reported_and_clamped_copy_exposed() -> None:
+    sb = SafetyBoundary(expected_dim=7, abs_limit=1.0)
+    result = sb.evaluate(np.array([5.0, 0, 0, 0, 0, 0, 0]))
+    assert any(f.check == "range" for f in result.findings)
+    assert float(result.clamped[0]) == 1.0
+
+
+def test_monitor_mode_returns_action_unchanged() -> None:
+    sb = SafetyBoundary(expected_dim=7, abs_limit=1.0, mode="monitor")
+    action = np.array([5.0, 0, 0, 0, 0, 0, 0])
+    out = sb.check(action)
+    assert float(out[0]) == 5.0  # NOT clamped in monitor mode
+
+
+def test_enforce_mode_returns_clamped_action() -> None:
+    sb = SafetyBoundary(expected_dim=7, abs_limit=1.0, mode="enforce")
+    out = sb.check(np.array([5.0, 0, 0, 0, 0, 0, 0]))
+    assert float(out[0]) == 1.0

--- a/tests/unit/test_deterministic_smoke.py
+++ b/tests/unit/test_deterministic_smoke.py
@@ -1,0 +1,93 @@
+"""End-to-end smoke test for the deterministic brain — no GPU, all fakes.
+
+Simulates the eval loop's contract (``begin_episode`` then repeated
+``get_action``) against a fake env, asserting the full dispatch -> compose ->
+converge -> safety path runs and produces actions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+# Import engine first to avoid circular import (same pattern as test_engine.py).
+import odyssey.engine  # noqa: F401
+from odyssey.runners.agents.brain.runtime import DeterministicBrain
+from odyssey.runners.agents.brain.safety import SafetyBoundary
+from odyssey.runners.agents.brain.specialist import SpecialistTurn
+
+
+class _FakeEnv:
+    """Yields a fresh RGB frame each step; ends after ``horizon`` steps."""
+
+    def __init__(self, horizon: int) -> None:
+        self._horizon = horizon
+        self._t = 0
+
+    def reset(self) -> NDArray[np.uint8]:
+        self._t = 0
+        return self._frame()
+
+    def step(self) -> tuple[NDArray[np.uint8], bool]:
+        self._t += 1
+        return self._frame(), self._t >= self._horizon
+
+    def _frame(self) -> NDArray[np.uint8]:
+        return np.full((16, 16, 3), self._t % 255, dtype=np.uint8)
+
+
+class _VisionGenerator:
+    """A multimodal fake TextGenerator (accepts an ``image`` kwarg)."""
+
+    def __init__(self) -> None:
+        self.saw_image = False
+
+    def generate(self, messages: list[dict[str, Any]], image: Any | None = None) -> str:
+        self.saw_image = image is not None
+        return "the target object is centered; approach slowly"
+
+
+class _FakePilot:
+    def __init__(self) -> None:
+        self.instructions: list[str] = []
+
+    def act(self, image: Any, instruction: str) -> NDArray[np.floating[Any]]:
+        self.instructions.append(instruction)
+        # Deliberately return an out-of-range component to exercise the safety monitor.
+        return np.array([2.0, 0, 0, 0, 0, 0, 0], dtype=np.float64)
+
+
+def test_smoke_dispatch_compose_converge_safety() -> None:
+    env = _FakeEnv(horizon=6)
+    gen = _VisionGenerator()
+    pilot = _FakePilot()
+    brain = DeterministicBrain(
+        pilot,
+        [SpecialistTurn("scene-inspector", gen, is_vision=True)],
+        safety=SafetyBoundary(expected_dim=7, mode="monitor"),
+    )
+
+    image = env.reset()
+    plan = brain.begin_episode("inspect the object and lift it", image)
+    assert len(plan) == 1
+
+    # Dispatch engaged the vision specialist and forwarded the image to it.
+    assert gen.saw_image is True
+    assert "the target object is centered" in brain.current_instruction
+
+    done = False
+    steps = 0
+    while not done:
+        action = brain.get_action(image)
+        assert action.shape == (7,)
+        # Monitor-only: the out-of-range action is reported but NOT clamped.
+        assert float(action[0]) == 2.0
+        image, done = env.step()
+        steps += 1
+
+    assert steps == 6
+    # Every step converged over the same composed instruction.
+    assert all(instr == brain.current_instruction for instr in pilot.instructions)
+    brain.close()

--- a/tests/unit/test_remote_generator.py
+++ b/tests/unit/test_remote_generator.py
@@ -1,0 +1,193 @@
+"""Tests for the generic out-of-process TextGenerator.
+
+No GPU / no real model: ``serve()`` is driven with a fake generator over
+in-memory streams, and ``RemoteGenerator`` is driven against a tiny fake server
+script run as a real subprocess (exercises the real Popen + JSON protocol +
+lifecycle). Mirrors ``test_remote_planner.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import odyssey.engine  # noqa: F401 — import engine first to break the runners<->engine cycle
+from odyssey.runners.models.generator_server import serve
+from odyssey.runners.models.remote_generator import RemoteGenerator
+
+
+class _FakeGen:
+    """TextGenerator stub: returns fixed text; records the image it was handed."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self.last_image: object = "unset"
+
+    def generate(self, messages: list[dict[str, Any]], image: object = None) -> str:
+        self.last_image = image
+        return self._text
+
+
+def _tiny_png_b64() -> str:
+    import base64
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (2, 2), (10, 20, 30)).save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# serve() — the server-side request/response loop
+# --------------------------------------------------------------------------- #
+
+
+def _run_serve(gen: _FakeGen, requests: list[dict[str, object]]) -> list[dict[str, Any]]:
+    instream = io.StringIO("".join(json.dumps(r) + "\n" for r in requests))
+    outstream = io.StringIO()
+    serve(gen, instream, outstream)
+    return [json.loads(line) for line in outstream.getvalue().splitlines() if line.strip()]
+
+
+def test_serve_emits_ready_then_text() -> None:
+    out = _run_serve(
+        _FakeGen("the cube is centered"),
+        [{"messages": [{"role": "user", "content": "hi"}]}, {"shutdown": True}],
+    )
+    assert out[0] == {"ready": True}
+    assert out[1] == {"text": "the cube is centered"}
+
+
+def test_serve_rejects_invalid_json() -> None:
+    instream = io.StringIO('not-json\n{"shutdown": true}\n')
+    outstream = io.StringIO()
+    serve(_FakeGen("x"), instream, outstream)
+    msgs = [json.loads(x) for x in outstream.getvalue().splitlines() if x.strip()]
+    assert msgs[0] == {"ready": True}
+    assert any("error" in m for m in msgs)
+
+
+def test_serve_missing_messages() -> None:
+    out = _run_serve(_FakeGen("x"), [{"foo": "bar"}, {"shutdown": True}])
+    assert any("error" in m for m in out)
+
+
+def test_serve_decodes_image_and_passes_to_generator() -> None:
+    from PIL import Image
+
+    gen = _FakeGen("ok")
+    out = _run_serve(
+        gen,
+        [{"messages": [{"role": "user", "content": "x"}], "image": _tiny_png_b64()},
+         {"shutdown": True}],
+    )
+    assert out[1] == {"text": "ok"}
+    assert isinstance(gen.last_image, Image.Image)
+    assert gen.last_image.size == (2, 2)
+
+
+# --------------------------------------------------------------------------- #
+# RemoteGenerator — the client, against a fake server subprocess
+# --------------------------------------------------------------------------- #
+
+# Emits stderr + non-JSON stdout noise (client must skip), then the protocol.
+_FAKE_SERVER_OK = """
+import argparse, json, sys
+p = argparse.ArgumentParser()
+p.add_argument("--model"); p.add_argument("--quantization"); p.add_argument("--max-new-tokens")
+p.parse_args()
+sys.stderr.write("specialist: loading model noise\\n"); sys.stderr.flush()
+print("non-json noise on stdout that the client must skip")
+sys.stdout.write(json.dumps({"ready": True}) + "\\n"); sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    if req.get("shutdown"):
+        break
+    has_img = isinstance(req.get("image"), str) and len(req["image"]) > 0
+    n = len(req.get("messages", []))
+    sys.stdout.write(json.dumps({"text": "msgs=%d image=%s" % (n, has_img)}) + "\\n")
+    sys.stdout.flush()
+"""
+
+# Never prints {"ready": true} — exits immediately.
+_FAKE_SERVER_DIES = "import sys; sys.exit(1)\n"
+
+# Ready, but returns a non-string text -> client should fall back to "".
+_FAKE_SERVER_BAD = """
+import json, sys
+sys.stdout.write(json.dumps({"ready": True}) + "\\n"); sys.stdout.flush()
+for line in sys.stdin:
+    if line.strip():
+        sys.stdout.write(json.dumps({"text": None}) + "\\n"); sys.stdout.flush()
+"""
+
+
+def _generator_for(script_body: str, tmp_path: Path) -> RemoteGenerator:
+    script = tmp_path / "fake_server.py"
+    script.write_text(script_body)
+    return RemoteGenerator(
+        "fake/model",
+        "int4",
+        python_path=sys.executable,
+        launch_args=(str(script),),
+        startup_timeout=30.0,
+        request_timeout=30.0,
+    )
+
+
+def test_remote_generator_roundtrip(tmp_path: Path) -> None:
+    gen = _generator_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        msgs = [{"role": "user", "content": "advise me"}]
+        assert gen.generate(msgs) == "msgs=1 image=False"
+        # Persistent: a second call reuses the same process.
+        assert gen.generate(msgs) == "msgs=1 image=False"
+    finally:
+        gen.close()
+        gen.close()  # idempotent
+
+
+def test_remote_generator_encodes_image_into_request(tmp_path: Path) -> None:
+    import numpy as np
+
+    gen = _generator_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        msgs = [{"role": "user", "content": "x"}]
+        assert gen.generate(msgs) == "msgs=1 image=False"
+        img = np.zeros((4, 4, 3), dtype=np.uint8)
+        assert gen.generate(msgs, image=img) == "msgs=1 image=True"
+    finally:
+        gen.close()
+
+
+def test_remote_generator_falls_back_when_server_dies(tmp_path: Path) -> None:
+    gen = _generator_for(_FAKE_SERVER_DIES, tmp_path)
+    try:
+        assert gen.generate([{"role": "user", "content": "x"}]) == ""
+    finally:
+        gen.close()
+
+
+def test_remote_generator_falls_back_on_bad_response(tmp_path: Path) -> None:
+    gen = _generator_for(_FAKE_SERVER_BAD, tmp_path)
+    try:
+        assert gen.generate([{"role": "user", "content": "x"}]) == ""
+    finally:
+        gen.close()
+
+
+def test_remote_generator_satisfies_textgenerator_protocol(tmp_path: Path) -> None:
+    from odyssey.runners.agents.runtime import TextGenerator
+
+    gen = _generator_for(_FAKE_SERVER_OK, tmp_path)
+    try:
+        assert isinstance(gen, TextGenerator)
+    finally:
+        gen.close()


### PR DESCRIPTION
## What

A framework-agnostic multi-agent runtime for evals, **opt-in behind a flag**. It replaces the plan-then-execute planner with a **dispatch → compose → converge** pipeline whose invariant is: the only path to a robot action is a single, convergent pilot inference.

- **Dispatch** — deterministic, no LLM. A concept-lexicon term-overlap rule table (plus an image-present + vision rule) picks which specialists to engage. Auditable per candidate (`{engaged, reason}`).
- **Compose** — engaged specialists produce text **advisories** that are composed into the pilot's instruction (composition, not handoff).
- **Converge** — one pilot inference per step over the composed instruction, then a monitor-only safety check on the action.

It builds only on the existing `TextGenerator` / `PilotRuntime` ports.

## How it's wired

- `runners/agents/brain/` — `context` (BrainContext/Advisory), `dispatch` (concept lexicon + `select_specialists`), `specialist` (`SpecialistTurn`, which owns the advisory prompt), `runtime` (`DeterministicBrain`), `safety` (monitor-only `SafetyBoundary`).
- `runners/models/{generator_server,remote_generator}` — a generic, **prompt-agnostic** out-of-process `TextGenerator` (the specialist model needs a modern `transformers` incompatible with the pilot venv, so it runs in a separate process). The host knows nothing about tasks/advisories; all prompting lives in the brain.
- Opt-in via `config.brain: deterministic` (or `ODYSSEY_DETERMINISTIC_BRAIN=1`) in the robosuite/libero eval; the existing planner path stays the **default** and is untouched.
- The OpenVLA + Gemma example mission is flipped to the new brain.

## Cadence (v1)

Compose **once per episode** (matches the current per-episode planner cadence; cheapest bridge). Per-tick recompose is a documented extension point.

## Checks

`ruff check src tests` clean · `mypy src/odyssey` clean · new unit + smoke tests (plain fakes, no GPU) + existing agent/eval suites green.

## Draft — why not ready

- The real OpenVLA + Gemma **GPU eval has not been run yet** (needs the out-of-process specialist venv). Acceptance = ≥1 successful lift on the existing mission.
- The legacy planner path is intentionally **kept** (behind the flag) until that eval is green — removing it is a follow-up, so the working path is never deleted before the replacement is proven.
